### PR TITLE
Fix for headers where data is split to html and js

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -200,7 +200,7 @@
 
             columns.push(column);
         });
-        this.options.columns = $.extend(columns, this.options.columns);
+        this.options.columns = $.extend(true, columns, this.options.columns);
         $.each(this.options.columns, function(i, column) {
             that.options.columns[i] = $.extend({}, BootstrapTable.COLUMN_DEFAULTS, column);
         });


### PR DESCRIPTION
Tables with headers defined in markup (<th>Label<th>) and extra data (like visiblity) in JS would get existing Labels overwritten unless deep-extend is performed.
