### PR TITLE
Allow use of disabled property of HTML checkboxes

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -144,6 +144,7 @@
     BootstrapTable.COLUMN_DEFAULTS = {
         radio: false,
         checkbox: false,
+        checkboxEnabled: true,
         field: undefined,
         title: undefined,
         'class': undefined,
@@ -774,7 +775,9 @@
                             sprintf(' name="%s"', that.options.selectItemName) +
                             sprintf(' type="%s"', type) +
                             sprintf(' value="%s"', item[that.options.idField]) +
-                            sprintf(' checked="%s"', value ? 'checked' : undefined) + ' />',
+                            sprintf(' checked="%s"', value ? 'checked' : undefined) +
+                            sprintf(' %s', that.options.columns[j].checkboxEnabled ? undefined : 'disabled') +
+                            ' />',
                         '</td>'].join('');
                 } else {
                     value = typeof value === 'undefined' ? that.options.undefinedText : value;


### PR DESCRIPTION
I needed this capability in the project for which I'm using this plugin, but I figured why should it be limited to just me.  The property is defined on the column level, so:
...

``` javascript
            }, {
                field: 'COMPLETE',
                title: 'Complete',
                align: 'center',
                valign: 'middle',
                sortable: true,
                checkbox: true,
                class: 'info',
                checkboxEnabled: false
            }, {
```

etc.

I'd also like to apologize that I apparently also tried to merge in every other merge done recently...I'm still learning how to keep my own fork up to date with its parent repo on GitHub.
