### PR TITLE
Added cache option for AJAX calls

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -100,6 +100,7 @@
         data: [],
         method: 'get',
         url: undefined,
+        cache: true,
         contentType: 'application/json',
         queryParams: function (params) {return {};},
         queryParamsType: undefined,
@@ -946,6 +947,7 @@
             type: this.options.method,
             url: this.options.url,
             data: data,
+            cache: this.options.cache,
             contentType: this.options.contentType,
             dataType: 'json',
             success: function (res) {


### PR DESCRIPTION
Setting cache to 'false' sets the corresponding 'cache' setting in the jQuery.ajax call (as described here... http://api.jquery.com/jquery.ajax/ ).  

Setting the cache to 'false' is typically only useful for GET and HEAD methods (jQuery appends a timestamp to the URL to avoid browser caching of the resource) so I also added the default value as 'true' in BootstrapTable.DEFAULTS.  This is equivalent to what already existed in Bootstrap Table (so shouldn't affect anyone's existing scripts) as 'true' is the default for the cache setting in jQuery and does not append the timestamp to the URL.
