### PR TITLE
Added cache option for AJAX calls to Examples

### DIFF
--- a/docs/examples.html
+++ b/docs/examples.html
@@ -122,7 +122,7 @@
                 </div>
                 <p data-zh="不通过JavaScript的方式启动Bootstrap Table。">Activate bootstrap table without writing JavaScript.</p>
                 <div class="bs-example">
-                    <table data-toggle="table" data-url="data1.json" data-height="299">
+                    <table data-toggle="table" data-url="data1.json" data-cache="false" data-height="299">
                         <thead>
                             <tr>
                                 <th data-field="id">Item ID</th>
@@ -143,7 +143,7 @@
                                 <h4 class="modal-title" id="myModalLabel" data-zh="基本表格">Basic Table</h4>
                             </div>
                             <div class="modal-body">
-                                <table data-toggle="table" data-url="data1.json" data-height="299">
+                                <table data-toggle="table" data-url="data1.json" data-cache="false" data-height="299">
                                     <thead>
                                     <tr>
                                         <th data-field="id">Item ID</th>
@@ -976,6 +976,7 @@
                                 $('#table-javascript').bootstrapTable({
                                     method: 'get',
                                     url: 'data2.json',
+                                    cache: false,
                                     height: 400,
                                     striped: true,
                                     pagination: true,


### PR DESCRIPTION
See my other proposed change (this is the documentation change for the examples file)... In the via JavaScript section as well as in the Basic Table section (probably should go somewhere else but I'm not sure where it is most appropriate).
