### PR TITLE
Added cache option for AJAX calls to Documentation

### DIFF
--- a/docs/docs.js
+++ b/docs/docs.js
@@ -169,6 +169,15 @@ $(function () {
                     example: 'basic-table'
                 },
                 {
+                    name: 'cache',
+                    attribute: 'data-cache',
+                    type: 'Boolean',
+                    description: 'False to disable caching of AJAX requests.',
+                    description_zh: '',
+                    'default': 'true',
+                    example: 'basic-table'
+                },
+                {
                     name: 'contentType',
                     attribute: 'data-content-type',
                     type: 'String',


### PR DESCRIPTION
Please see the other proposed changes... This is the corresponding documentation change for this.
