### PR TITLE
Enhancement/fix for #81

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -174,7 +174,8 @@
         formatter: undefined,
         events: undefined,
         sorter: undefined,
-        clickToSelect: true
+        clickToSelect: true,
+        chkBoxStyled: false //false keeps current behavior
     };
 
     BootstrapTable.EVENTS = {
@@ -306,11 +307,19 @@
             style += sprintf('width: %spx; ', column.checkbox || column.radio ? 36 : column.width);
             style += that.options.sortable && column.sortable ? 'cursor: pointer; ' : '';
 
-            html.push('<th',
-                column.checkbox || column.radio ? ' class="bs-checkbox"' :
-                sprintf(' class="%s"', column['class']),
-                sprintf(' style="%s"', style),
-                '>');
+            if(that.options.columns[i].chkBoxStyled){
+                html.push('<th',
+                    column.checkbox || column.radio ? ' class="bs-checkbox '+column['class']+'"' : '',
+                    sprintf(' style="%s"', style),
+                    '>');
+            }else{
+                html.push('<th',
+                    column.checkbox || column.radio ? ' class="bs-checkbox"':
+                    sprintf(' class="%s"', column['class']),
+                    sprintf(' style="%s"', style),
+                    '>');
+            }
+
             html.push('<div class="th-inner">');
 
             text = column.title;


### PR DESCRIPTION
This will allow the class specified on a column to be applied to the `<th>` row even if that column is of type checkbox or radio.  The default is opt-in, so as to remain backwards-compatible.  The modifications will eliminate the errant behavior noted in the screenshot on the original issue report.

Example:

``` javascript
            }, {
                field: 'COMPLETE',
                title: 'Complete',
                align: 'center',
                valign: 'middle',
                sortable: true,
                checkbox: true,
                checkboxEnabled: false,
                chkBoxStyled: true,
                class: 'info'
            }, {
```
