### PR TITLE
fix bug, if events is defined with namespace,修复使用命名空间定义的对象无法被调用的问题

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -952,8 +952,9 @@
             if (!events) {
                 return;
             }
+            // fix bug, if events is defined with namespace
             if (typeof events === 'string') {
-                events = window[events];
+                events = window[events] || eval(events);;
             }
             for (var key in events) {
                 that.$body.find('tr').each(function () {


### PR DESCRIPTION
fix bug, if events is defined with namespace,修复使用命名空间定义的对象无法被调用的问题
