### PR TITLE
add function escapeHTML for preventing add custom row attribute with dou...

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -108,9 +108,8 @@
                 .replace(/>/g, "&gt;")
                 .replace(/"/g, "&quot;")
                 .replace(/'/g, "&#039;");
-        }else {
-            return text;
         }
+        return text;
     };
 
     // BOOTSTRAP TABLE CLASS DEFINITION


### PR DESCRIPTION
add function escapeHTML for preventing adding custom row attribute that contain double quote.

Eg. add custom attribute that value is string [{"id":1,"name":"Test 1"}]
it will be like this ![](http://i.imgur.com/vXjoROR.png)
