### PR TITLE
Bug fix in rowStyle passing css classes

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -937,7 +937,7 @@
             html.push('<tr',
                 sprintf(' %s', htmlAttributes.join(' ')),
                 sprintf(' id="%s"', $.isArray(item) ? undefined : item._id),
-                sprintf(' class="%s"', style.classes || $.isArray(item) ? undefined : item._class),
+                sprintf(' class="%s"', style.classes || ($.isArray(item) ? undefined : item._class)),
                 sprintf(' data-index="%s"', i),
                 '>'
             );


### PR DESCRIPTION
Added round brackets to line 940 where the classes are set to the DOM object. Without the round brackets, it didn't take the classes from classes || something although it was valid. Now everything works as expected.
