### PR TITLE
Support for data-field with dot notation.

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -113,6 +113,10 @@
     };
 
     var getItemField = function (item, field) {
+        if (typeof text != 'string') {
+            return item[field];
+        }
+
         var arr = field.split(".");
         while(arr.length && (item = item[arr.shift()]));
         return item;


### PR DESCRIPTION
Useful when you need fields that are inside an object.

First commit had a bug, for non-string fields and it was fixed.
