### PR TITLE
Support for data-field with dot notation

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -113,7 +113,7 @@
     };
 
     var getItemField = function (item, field) {
-        if (typeof text != 'string') {
+        if (typeof field != 'string') {
             return item[field];
         }
 

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -112,6 +112,12 @@
         return text;
     };
 
+    var getItemField = function (item, field) {
+        var arr = field.split(".");
+        while(arr.length && (item = item[arr.shift()]));
+        return item;
+    };
+
     // BOOTSTRAP TABLE CLASS DEFINITION
     // ======================
 
@@ -965,7 +971,7 @@
 
             $.each(this.header.fields, function (j, field) {
                 var text = '',
-                    value = item[field],
+                    value = getItemField(item, field),
                     type = '',
                     cellStyle = {},
                     id_ = '',

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -113,6 +113,10 @@
     };
 
     var getItemField = function (item, field) {
+        if (typeof text != 'string') {
+            return item[field];
+        }
+
         var arr = field.split(".");
         while(arr.length && (item = item[arr.shift()]));
         return item;


### PR DESCRIPTION
Useful when you need fields that are inside an object.

First commit had a bug, for non-string fields and it was fixed.