### PR TITLE
Updated ellipsis to html-safe string

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -198,7 +198,7 @@
 
     BootstrapTable.LOCALES['en-US'] = {
         formatLoadingMessage: function () {
-            return 'Loading, please wait…';
+            return 'Loading, please wait&#8230';
         },
         formatRecordsPerPage: function (pageNumber) {
             return sprintf('%s records per page', pageNumber);


### PR DESCRIPTION
This ellipsis poses a potential issue if the file isn't handled with the proper encoding. Updated it to be the corresponding html-safe string. Reference: http://www.ascii.cl/htmlcodes.htm
