### PR TITLE
Fix pageList smartDisplay

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -844,7 +844,7 @@
             if (this.totalPages <= 1) {
                 this.$pagination.find('div.pagination').hide();
             }
-            if (this.options.pageList.length < 2 || this.options.totalRows <= this.options.pageList[1]) {
+            if (this.options.pageList.length < 2 || this.options.totalRows <= this.options.pageList[0]) {
                 this.$pagination.find('span.page-list').hide();
             }
 


### PR DESCRIPTION
With pageList = [25,50,100], totalRows=45 et pageSize=25
The span.page-list is hidden, because totalRows <= pageList[1]
