### PR TITLE
Show upper number in pageList display.

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -780,7 +780,7 @@
         }
 
         $.each(pageList, function (i, page) {
-            if (!that.options.smartDisplay || that.options.totalRows >= page || i === 0) {
+            if (!that.options.smartDisplay || i === 0 || pageList[i-1] <= that.options.totalRows) {
                 var active = page === that.options.pageSize ? ' class="active"' : '';
                 pageNumber.push(sprintf('<li%s><a href="javascript:void(0)">%s</a></li>', active, page));
             }


### PR DESCRIPTION
If totalRows is 45 and pageList is [25,50,100], we should be able to display the 45 rows.
Instead of that, we only can display 25 max, because 45 is not >= 50.