### PR TITLE
修复bs-table预设数据字段，不能支持对象的问题

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -109,6 +109,17 @@
         return text;
     };
 
+    //读取item字段，将字段分解为对象
+    var getDataItemFildValue = function (item, field) {
+        var res = item;
+        field = field && String(field).split('.');
+        while (field.length) {
+            if ((res = res[field.shift()]) == null)
+                return '';
+        }
+        return res;
+    }
+    
     // BOOTSTRAP TABLE CLASS DEFINITION
     // ======================
 
@@ -1005,7 +1016,7 @@
 
             $.each(this.header.fields, function (j, field) {
                 var text = '',
-                    value = item[field],
+                    value = getDataItemFildValue(item, field),//支持对象的读取，例如"linkFly.github"
                     type = '',
                     cellStyle = {},
                     id_ = '',


### PR DESCRIPTION
添加getDataItemFildValue(item,field)方法：
===

bootstrap-table使用服务器分页的时候，th标签使用data-field属性标志数据字段，但标志的值并不支持对象，例如：
```javascript
[ "rows":{ "User":{ "name":"linkFly" }   } ]
```

设置为下面的th并不能读取到正确的数据：

```html
<th data-field="User.name">UserName</th>
```

此次更改解决该问题，但仅在现代浏览器中经过**少量测试**，希望作者调整代码解决这个问题。