### PR TITLE
Fix for issue #493 'Wrong parsing in data-page-list'

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -813,7 +813,7 @@
             pageList = this.options.pageList;
 
         if (typeof this.options.pageList === 'string') {
-            var list = this.options.pageList.slice(1, -1).replace(/ /g, '').split(',');
+            var list = this.options.pageList.replace('[', '').replace(']', '').replace(/ /g, '').split(',');
 
             pageList = [];
             $.each(list, function (i, value) {


### PR DESCRIPTION
Now, its possible to define data-page-list without [ and ].
Issue https://github.com/wenzhixin/bootstrap-table/issues/493
