### PR TITLE
Add data-value to editable table. Remove data in anchor.

### DIFF
--- a/src/extensions/editable/bootstrap-table-editable.js
+++ b/src/extensions/editable/bootstrap-table-editable.js
@@ -42,7 +42,8 @@
                 return ['<a href="javascript:void(0)"',
                     ' data-name="' + column.field + '"',
                     ' data-pk="' + row[that.options.idField] + '"',
-                    '>' + result + '</a>'
+                    ' data-vlaue="' + result + '"',
+                    '>' + '</a>'
                 ].join('');
             };
         });


### PR DESCRIPTION
Change to editable-table to insert the data using data-value parameter of the editable item instead of placing the result between the anchor open and close statements.
This forces the formatting of the data value as it is inserted into the table. In most cases this will not make a big difference. But when using the select editable type this enables a lookup to be made from the value against the text representations of the value in the select.