### PR TITLE
Trigger onCheck/onUncheck event handler after calling method check/uncheck

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1533,6 +1533,7 @@
         this.$selectItem.filter(sprintf('[data-index="%s"]', index)).prop('checked', checked);
         this.data[index][this.header.stateField] = checked;
         this.updateSelected();
+        this.trigger(checked ? 'check' : 'uncheck', this.data[index]);
     };
 
     BootstrapTable.prototype.destroy = function () {


### PR DESCRIPTION
This fixes issue https://github.com/wenzhixin/bootstrap-table/issues/510. Method check_ triggers appropriate event handlers with requested row obejct as a parameter.