### PR TITLE
New methods to select rows by value

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1542,6 +1542,27 @@
         this.updateSelected();
         this.trigger(checked ? 'check' : 'uncheck', this.data[index]);
     };
+    
+    BootstrapTable.prototype.checkBy = function (obj) {
+        this.checkBy_(true, obj);
+    };
+
+    BootstrapTable.prototype.uncheckBy = function (obj) {
+        this.checkBy_(false, obj);
+    };
+    
+    BootstrapTable.prototype.checkBy_ = function (checked, obj) {
+        var that = this;
+        var is_array = $.isArray(obj.value);
+        $.each(this.data, function (index, row) {
+            if(is_array ? $.inArray(row[obj.field], obj.value) != -1 : row[obj.field] == obj.value) {
+                that.$selectItem.filter(sprintf('[data-index="%s"]', index)).prop('checked', checked);
+                row[that.header.stateField] = checked;
+                that.trigger(checked ? 'check' : 'uncheck', row);  
+            }
+        });
+        this.updateSelected();
+    };
 
     BootstrapTable.prototype.destroy = function () {
         this.$el.insertBefore(this.$container);
@@ -1643,6 +1664,7 @@
         'mergeCells',
         'checkAll', 'uncheckAll',
         'check', 'uncheck',
+        'checkBy', 'uncheckBy',
         'refresh',
         'resetView',
         'destroy',

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1515,10 +1515,17 @@
     };
 
     BootstrapTable.prototype.checkAll_ = function (checked) {
+        var rows;
+        if(!checked) {
+            rows = this.getSelections();
+        }
         this.$selectItem.filter(':enabled').prop('checked', checked);
         this.updateRows(checked);
         this.updateSelected();
-        this.trigger(checked ? 'check-all' : 'uncheck-all');
+        if(checked) {
+            rows = this.getSelections();
+        }
+        this.trigger(checked ? 'check-all' : 'uncheck-all', rows);
     };
 
     BootstrapTable.prototype.check = function (index) {


### PR DESCRIPTION
Hi Wenzhixin,

I'd like to introduce new methods: checkBy and uncheckBy to select rows by value or array of values.

You can call
$("#table").bootstrapTable("checkBy", {field:"field_name", value:"value1"}) 
to check/uncheck rows by a single value
or
$("#table").bootstrapTable("checkBy", {field:"field_name", value:["value1","value2","value3"]})
to check/uncheck rows by multiple values.

In addition, onCheckAll/onUncheckAll event handlers return an array of newly/previously selected row objects.

This two commits can help in the future with https://github.com/wenzhixin/bootstrap-table/issues/372

What do you think?