### PR TITLE
Fixed sorting bug when one value is numeric and the other is not.

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -502,12 +502,8 @@
                     return order * value;
                 }
 
-                // Convert numerical values form string to float.
-                if ($.isNumeric(aa)) {
-                    aa = parseFloat(aa);
-                }
-                if ($.isNumeric(bb)) {
-                    bb = parseFloat(bb);
+                if (value !== undefined) {
+                    return order * value;
                 }
 
                 // Fix #161: undefined or null string sort bug.
@@ -518,7 +514,11 @@
                     bb = '';
                 }
                 
+				// IF both values are numeric, do a numeric comparison
                 if ($.isNumeric(aa) && $.isNumeric(bb)) {
+                    // Convert numerical values form string to float.
+                    aa = parseFloat(aa);
+                    bb = parseFloat(bb);
                     if (aa < bb) {
                         return order * -1;
                     }
@@ -528,6 +528,13 @@
                 if (aa === bb) {
                     return 0;
                 }
+
+				// If value is not a string, convert to string
+                if (typeof aa !== 'string')
+                {
+                    aa = aa.toString();
+                }
+
                 if (aa.localeCompare(bb) === -1) {
                     return order * -1;
                 }


### PR DESCRIPTION
As detailed here https://github.com/wenzhixin/bootstrap-table/issues/540 sorting can fail if the compared values are not both numeric or both string. This fixed by using numeric comparison if both are numeric, or reverting to string comparison. Value is converted to string if it is not, so localeCompare does not fail.