### PR TITLE
Update to methods to select rows by value and documentation

### DIFF
--- a/docs/_i18n/en/documentation/events.md
+++ b/docs/_i18n/en/documentation/events.md
@@ -77,14 +77,20 @@
     <tr>
         <td>onCheckAll</td>
         <td>check-all.bs.table</td>
-        <td>none</td>
-        <td>Fires when user check all rows.</td>
+        <td>rows</td>
+        <td>
+        Fires when user check all rows, the parameters contains: <br>
+        rows: array of records corresponding to newly checked rows.
+        </td>
     </tr>
     <tr>
         <td>onUncheckAll</td>
         <td>uncheck-all.bs.table</td>
-        <td>none</td>
-        <td>Fires when user uncheck all rows.</td>
+        <td>rows</td>
+        <td>
+        Fires when user uncheck all rows, the parameters contains: <br>
+        rows: array of records corresponding to previously checked rows.
+        </td>
     </tr>
     <tr>
         <td>onLoadSuccess</td>

--- a/docs/_i18n/en/documentation/methods.md
+++ b/docs/_i18n/en/documentation/methods.md
@@ -122,6 +122,28 @@ The calling method syntax: `$('#table').bootstrapTable('method', parameter);`.
         <td>Uncheck a row, the row index start with 0.</td>
     </tr>
     <tr>
+        <td>checkBy</td>
+        <td>params</td>
+        <td>
+        Check a row by array of values, the params contains:<br>
+        field: name of the field used to find records<br>
+        values: array of values for rows to check<br>
+        Example: <br>
+        $("#table").bootstrapTable("checkBy", {field:"field_name", values:["value1","value2","value3"]})
+        </td>
+    </tr>
+    <tr>
+        <td>uncheckBy</td>
+        <td>params</td>
+        <td>
+        Uncheck a row by array of values, the params contains:<br>
+        field: name of the field used to find records<br>
+        values: array of values for rows to uncheck<br>
+        Example: <br>
+        $("#table").bootstrapTable("uncheckBy", {field:"field_name", values:["value1","value2","value3"]})
+        </td>
+    </tr>
+    <tr>
         <td>resetView</td>
         <td>params</td>
         <td>Reset the bootstrap table view, for example reset the table height.</td>

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1548,12 +1548,15 @@
     };
     
     BootstrapTable.prototype.checkBy_ = function (checked, obj) {
-        if (!obj.hasOwnProperty("field") || !obj.hasOwnProperty("values")) {
+        if(!obj.hasOwnProperty('field') || !obj.hasOwnProperty('values')) {
             return;
         }
         
         var that = this;
         $.each(this.data, function (index, row) {
+            if(!row.hasOwnProperty(obj.field)) {
+                return false;
+            }
             if($.inArray(row[obj.field], obj.values) != -1) {
                 that.$selectItem.filter(sprintf('[data-index="%s"]', index)).prop('checked', checked);
                 row[that.header.stateField] = checked;

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1548,10 +1548,13 @@
     };
     
     BootstrapTable.prototype.checkBy_ = function (checked, obj) {
+        if (!obj.hasOwnProperty("field") || !obj.hasOwnProperty("values")) {
+            return;
+        }
+        
         var that = this;
-        var is_array = $.isArray(obj.value);
         $.each(this.data, function (index, row) {
-            if(is_array ? $.inArray(row[obj.field], obj.value) != -1 : row[obj.field] == obj.value) {
+            if($.inArray(row[obj.field], obj.values) != -1) {
                 that.$selectItem.filter(sprintf('[data-index="%s"]', index)).prop('checked', checked);
                 row[that.header.stateField] = checked;
                 that.trigger(checked ? 'check' : 'uncheck', row);  


### PR DESCRIPTION
Hi,

I've updated the documentation and made some changes in methods checkBy and uncheckBy (mentioned in https://github.com/wenzhixin/bootstrap-table/pull/532). Now the parameter is consistent with other methods like "remove".

Example:
$("#table").bootstrapTable("checkBy", {field:"field_name", values:["value1","value2","value3"]})
