### PR TITLE
Recursive merging column options from html and from js.

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -393,7 +393,7 @@
 
             columns.push(column);
         });
-        this.options.columns = $.extend([], columns, this.options.columns);
+        this.options.columns = $.extend(true, [], columns, this.options.columns);
         $.each(this.options.columns, function (i, column) {
             that.options.columns[i] = $.extend({}, BootstrapTable.COLUMN_DEFAULTS,
                 {field: i}, column); // when field is undefined, use index instead


### PR DESCRIPTION
If create table html headers and then init bootstrapTable with column options, all column options defined in html will lost.