### PR TITLE
Fix #229

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -661,10 +661,6 @@
                     return order * value;
                 }
 
-                if (value !== undefined) {
-                    return order * value;
-                }
-
                 // Fix #161: undefined or null string sort bug.
                 if (aa === undefined || aa === null) {
                     aa = '';

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -479,6 +479,10 @@
                 isVisible = 'hidden';
 
             if (!column.visible) {
+                // Fix #229. Default Sort order is wrong if data-visible="false" is set on the field referenced by data-sort-name.
+                if (column.field === that.options.sortName) {
+                    that.header.fields.push(column.field);
+                }
                 return;
             }
 


### PR DESCRIPTION
Fixed: Default Sort order is wrong if data-visible="false" is set on the field referenced by data-sort-name.