### PR TITLE
Row state field value fix

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1248,6 +1248,8 @@
                                 (value && value.disabled) ? 'disabled' : undefined) +
                             ' />',
                         that.options.cardView ? '</div>' : '</td>'].join('');
+                        
+                    item[that.header.stateField] = value === true || (value && value.checked);
                 } else {
                     value = typeof value === 'undefined' || value === null ?
                         that.options.undefinedText : value;

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1456,11 +1456,11 @@
         });
     };
 
-    BootstrapTable.prototype.updateRows = function (checked) {
+    BootstrapTable.prototype.updateRows = function () {
         var that = this;
 
         this.$selectItem.each(function () {
-            that.data[$(this).data('index')][that.header.stateField] = $(this).prop('checked') && checked;
+            that.data[$(this).data('index')][that.header.stateField] = $(this).prop('checked');
         });
     };
 

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1460,7 +1460,7 @@
         var that = this;
 
         this.$selectItem.each(function () {
-            that.data[$(this).data('index')][that.header.stateField] = checked;
+            that.data[$(this).data('index')][that.header.stateField] = $(this).prop('checked') && checked;
         });
     };
 


### PR DESCRIPTION
Using "select all items" checkbox in the table header selects only enabled rows, but doesn't set proper state field value of disabled rows.

This little fix sets proper rows state field value depending on "checked" property of inputs.
