### PR TITLE
Filtered checkbox rows not being checked correctly

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1978,7 +1978,7 @@
         }
 
         var that = this;
-        $.each(this.options.data, function (index, row) {
+        $.each(this.data, function (index, row) {
             if (!row.hasOwnProperty(obj.field)) {
                 return false;
             }


### PR DESCRIPTION
When the list is filtered, the indexes are based on the core dataset not
on the filtered dataset.