### PR TITLE
Fix #688: Maintain sorting on refresh flattened json

### DIFF
--- a/src/extensions/flatJSON/bootstrap-table-flatJSON.js
+++ b/src/extensions/flatJSON/bootstrap-table-flatJSON.js
@@ -27,8 +27,8 @@
         _initTable = BootstrapTable.prototype.initTable;
 
     BootstrapTable.prototype.initData = function (data) {
-        _initData.apply(this, Array.prototype.slice.apply(arguments));
         flatJSON(this, data === undefined ? this.options.data : data);
+        _initData.apply(this, Array.prototype.slice.apply(arguments));
     };
 
     BootstrapTable.prototype.init = function () {


### PR DESCRIPTION
I changed a line to fix issue https://github.com/wenzhixin/bootstrap-table/issues/688. Please review.