### PR TITLE
Ability to skip initial first load from remote

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -148,6 +148,7 @@
         method: 'get',
         url: undefined,
         ajax: undefined,
+        deferServer: false,
         cache: true,
         contentType: 'application/json',
         dataType: 'json',
@@ -1377,6 +1378,11 @@
             request;
 
         if (!this.options.url && !this.options.ajax) {
+            return;
+        }
+        
+        if (this.options.deferServer) {
+            this.options.deferServer = false;
             return;
         }
 


### PR DESCRIPTION
We need the ability to load first locally (perhaps server-side reads some params from URL, runs database query, and outputs HTML table for client-side to work with locally). Then load from remote on all further interactions. 

This is **progressive enhancement** and good for **SEO** purposes. Google bot will see the HTML, regardless of whether it can run the javascript on the page. Also this prevents an unnecessary extra ajax call at the first page load when using remote. This makes a lot of sense for apps that are using the *history pushState* (where I can update the browser address bar without refreshing the page).

*Note*: You can immediately do this once the page has loaded with the `refresh` method, but it's also an unnecessary extra ajax call. We just want the *url* set, no ajax call.
