### PR TITLE
Added a 'getAllSelections' method to get checked rows across all pages and filters

### DIFF
--- a/docs/_i18n/en/documentation/methods.md
+++ b/docs/_i18n/en/documentation/methods.md
@@ -26,7 +26,12 @@ The calling method syntax: `$('#table').bootstrapTable('method', parameter);`.
     <tr>
         <td>getSelections</td>
         <td>none</td>
-        <td>Return all selected rows, when no record selected, am empty array will return.</td>
+        <td>Return selected rows, when no record selected, am empty array will return.</td>
+    </tr>
+    <tr>
+        <td>getAllSelections</td>
+        <td>none</td>
+        <td>Return selected rows in all pages, when no record selected, am empty array will return.</td>
     </tr>
     <tr>
         <td>getData</td>

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1836,6 +1836,14 @@
         });
     };
 
+    BootstrapTable.prototype.getAllSelections = function () {
+        var that = this;
+
+        return $.grep(this.options.data, function (row) {
+            return row[that.header.stateField];
+        });
+    };
+
     BootstrapTable.prototype.checkAll = function () {
         this.checkAll_(true);
     };
@@ -2014,7 +2022,7 @@
 
     var allowedMethods = [
         'getOptions',
-        'getSelections', 'getData',
+        'getSelections', 'getAllSelections', 'getData',
         'load', 'append', 'prepend', 'remove',
         'insertRow', 'updateRow',
         'showRow', 'hideRow', 'getRowsHidden',


### PR DESCRIPTION
The 'getSelections' method doesn't work properly when you enable paging and/or have filters on your table. This method will get all selected rows. 