### PR TITLE
Fix 835: Accessing field name in formatter

### DIFF
--- a/docs/_i18n/en/documentation/column-options.md
+++ b/docs/_i18n/en/documentation/column-options.md
@@ -140,6 +140,7 @@ The column options is defined in `jQuery.fn.bootstrapTable.columnDefaults`.
         <td>Function</td>
         <td>undefined</td>
         <td>
+        The context (this) is the column Object. <br>
         The cell formatter function, take three parameters: <br>
         value: the field value. <br>
         row: the row record data.<br>
@@ -151,7 +152,7 @@ The column options is defined in `jQuery.fn.bootstrapTable.columnDefaults`.
         <td>Function</td>
         <td>undefined</td>
         <td>
-        The context (this) is the column Object.
+        The context (this) is the column Object. <br>
         The function, take one parameter: <br>
         data: Array of all the  data rows. <br>
         the function should return a string with the text to show in the footer cell.

--- a/docs/_i18n/es/documentation/column-options.md
+++ b/docs/_i18n/es/documentation/column-options.md
@@ -139,6 +139,7 @@ Las propiedades de la columna están definidas en `jQuery.fn.bootstrapTable.colu
         <td>Function</td>
         <td>undefined</td>
         <td>
+        El contexto (this) es el objecto columna. <br>
         La función de formateo de la celda, toma tres parámetros: <br>
         value: el valor del campo. <br>
         row: los datos de la fila.<br>
@@ -150,7 +151,7 @@ Las propiedades de la columna están definidas en `jQuery.fn.bootstrapTable.colu
         <td>Function</td>
         <td>undefined</td>
         <td>
-        El contexto (this) es el objecto columna.
+        El contexto (this) es el objecto columna. <br>
         La función toma un parámetro: <br>
         data: Array de todas las filas. <br>
         La función debe retornar un string con el texto a mostrar en el footer.

--- a/docs/_i18n/zh-cn/documentation/column-options.md
+++ b/docs/_i18n/zh-cn/documentation/column-options.md
@@ -140,6 +140,7 @@ The column options is defined in `jQuery.fn.bootstrapTable.columnDefaults`.
         <td>Function</td>
         <td>undefined</td>
         <td>
+        The context (this) is the column Object. <br>
         The cell formatter function, take three parameters: <br>
         value: the field value. <br>
         row: the row record data.<br>
@@ -151,7 +152,7 @@ The column options is defined in `jQuery.fn.bootstrapTable.columnDefaults`.
         <td>Function</td>
         <td>undefined</td>
         <td>
-        The context (this) is the column Object.
+        The context (this) is the column Object. <br>
         The function, take one parameter: <br>
         data: Array of all the  data rows. <br>
         the function should return a string with the text to show in the footer cell.

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -952,11 +952,13 @@
             this.data = s ? $.grep(this.data, function (item, i) {
                 for (var key in item) {
                     key = $.isNumeric(key) ? parseInt(key, 10) : key;
-                    var value = item[key];
+                    var value = item[key],
+                        column = that.options.columns[getFieldIndex(that.options.columns, key)],
+                        j = $.inArray(key, that.header.fields);
 
                     // Fix #142: search use formated data
-                    value = calculateObjectValue(that.header,
-                        that.header.formatters[$.inArray(key, that.header.fields)],
+                    value = calculateObjectValue(column,
+                        that.header.formatters[j],
                         [value, item, i], value);
 
                     var index = $.inArray(key, that.header.fields);
@@ -1290,7 +1292,7 @@
 
                 style = sprintf('style="%s"', csses.concat(that.header.styles[j]).join('; '));
 
-                value = calculateObjectValue(that.header,
+                value = calculateObjectValue(column,
                     that.header.formatters[j], [value, item, i], value);
 
                 // handle td's id and class


### PR DESCRIPTION
This pull request is to change the context (this) of the formatter function in column options. The present context is `header`, which I believe serves no practical purpose. The change will instead pass the `column` as the context, which I feel is more intuitive.

Some key points:

- More intuitive
- Allows end developer to access field name options at `this.field`
- Makes the function uniform with the `footerFormatter`

Fix was suggested in: [Issue # 835](https://github.com/wenzhixin/bootstrap-table/issues/835)