### PR TITLE
Fix bug assigned sortable arrowArrows

### DIFF
--- a/src/extensions/multiple-sort/bootstrap-table-multiple-sort.js
+++ b/src/extensions/multiple-sort/bootstrap-table-multiple-sort.js
@@ -127,6 +127,7 @@
                         $($alert).remove();
                     }
 
+                    that.options.sortName = "";
                     that.onMultipleSort();
                     $sortModal.modal('hide');
                 }


### PR DESCRIPTION
Set empty string value for that.options.sortName, to prevent any assigned sortable arrows being set in initBody() > getCaretHtml()