### PR TITLE
Allow for multiple arguments

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -2251,7 +2251,7 @@
         'toggleView'
     ];
 
-    $.fn.bootstrapTable = function (option, _relatedTarget) {
+    $.fn.bootstrapTable = function (option) {
         var value;
 
         this.each(function () {

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -2269,7 +2269,8 @@
                     return;
                 }
 
-                value = data[option](_relatedTarget);
+                var args = Array.prototype.slice.call(arguments, 0);
+                value = data[option].apply(data, args);
 
                 if (option === 'destroy') {
                     $this.removeData('bootstrap.table');

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -2252,7 +2252,8 @@
     ];
 
     $.fn.bootstrapTable = function (option) {
-        var value;
+        var value,
+            args = Array.prototype.slice.call(arguments, 1);
 
         this.each(function () {
             var $this = $(this),
@@ -2269,7 +2270,6 @@
                     return;
                 }
 
-                var args = Array.prototype.slice.call(arguments, 0);
                 value = data[option].apply(data, args);
 
                 if (option === 'destroy') {


### PR DESCRIPTION
Current approach only allows for a singular argument @`_relatedTarget` passed to public
method. The new approach would allow for any amount of arguments.

__Reasoning__
I'm working on an extension and adding some additional `allowedMethods`. The methods require multiple arguments, and would ideally not have to wrap them in an object.