### PR TITLE
Use options for detailView's open/close icons

### DIFF
--- a/docs/_i18n/en/documentation/table-options.md
+++ b/docs/_i18n/en/documentation/table-options.md
@@ -90,7 +90,7 @@ The table options is defined in `jQuery.fn.bootstrapTable.defaults`.
         &nbsp;&nbsp;<i>detailClose:</i> 'glyphicon-minus icon-minus'<br/>
         }
         </td>
-        <td>Defines icons that used for refresh, toggle and columns buttons</td>
+        <td>Defines icons used in the toolbar, pagination, and details view.</td>
     </tr>
     <tr>
         <td>columns</td>

--- a/docs/_i18n/en/documentation/table-options.md
+++ b/docs/_i18n/en/documentation/table-options.md
@@ -80,11 +80,15 @@ The table options is defined in `jQuery.fn.bootstrapTable.defaults`.
         <td>icons</td>
         <td>data-icons</td>
         <td>Object</td>
-        <td>{<br/>
-        &nbsp;&nbsp;refresh: 'glyphicon-refresh icon-refresh',<br/>
-        &nbsp;&nbsp;toggle: 'glyphicon-list-alt icon-list-alt',<br/>
-        &nbsp;&nbsp;columns: 'glyphicon-th icon-th'<br/>
-        }</td>
+        <td><pre>{
+  paginationSwitchDown: 'glyphicon-collapse-down icon-chevron-down',
+  paginationSwitchUp: 'glyphicon-collapse-up icon-chevron-up',
+  refresh: 'glyphicon-refresh icon-refresh',
+  toggle: 'glyphicon-list-alt icon-list-alt',
+  columns: 'glyphicon-th icon-th',
+  detailOpen: 'glyphicon-plus icon-plus',
+  detailClose: 'glyphicon-minus icon-minus'
+}</pre></td>
         <td>Defines icons that used for refresh, toggle and columns buttons</td>
     </tr>
     <tr>

--- a/docs/_i18n/en/documentation/table-options.md
+++ b/docs/_i18n/en/documentation/table-options.md
@@ -80,7 +80,8 @@ The table options is defined in `jQuery.fn.bootstrapTable.defaults`.
         <td>icons</td>
         <td>data-icons</td>
         <td>Object</td>
-        <td><pre>{
+        <td>```javascript
+{
   paginationSwitchDown: 'glyphicon-collapse-down icon-chevron-down',
   paginationSwitchUp: 'glyphicon-collapse-up icon-chevron-up',
   refresh: 'glyphicon-refresh icon-refresh',
@@ -88,7 +89,9 @@ The table options is defined in `jQuery.fn.bootstrapTable.defaults`.
   columns: 'glyphicon-th icon-th',
   detailOpen: 'glyphicon-plus icon-plus',
   detailClose: 'glyphicon-minus icon-minus'
-}</pre></td>
+}
+```
+</td>
         <td>Defines icons that used for refresh, toggle and columns buttons</td>
     </tr>
     <tr>

--- a/docs/_i18n/en/documentation/table-options.md
+++ b/docs/_i18n/en/documentation/table-options.md
@@ -81,13 +81,13 @@ The table options is defined in `jQuery.fn.bootstrapTable.defaults`.
         <td>data-icons</td>
         <td>Object</td>
         <td>{<br/>
-        &nbsp;&nbsp;<b>paginationSwitchDown:</b> 'glyphicon-collapse-down icon-chevron-down',<br/>
-        &nbsp;&nbsp;<b>paginationSwitchUp:</b> 'glyphicon-collapse-up icon-chevron-up',<br/>
-        &nbsp;&nbsp;<b>refresh:</b> 'glyphicon-refresh icon-refresh',<br/>
-        &nbsp;&nbsp;<b>toggle:</b> 'glyphicon-list-alt icon-list-alt',<br/>
-        &nbsp;&nbsp;<b>columns:</b> 'glyphicon-th icon-th',<br/>
-        &nbsp;&nbsp;<b>detailOpen:</b> 'glyphicon-plus icon-plus',<br/>
-        &nbsp;&nbsp;<b>detailClose:</b> 'glyphicon-minus icon-minus'<br/>
+        &nbsp;&nbsp;<i>paginationSwitchDown:</i> 'glyphicon-collapse-down icon-chevron-down',<br/>
+        &nbsp;&nbsp;<i>paginationSwitchUp:</i> 'glyphicon-collapse-up icon-chevron-up',<br/>
+        &nbsp;&nbsp;<i>refresh:</i> 'glyphicon-refresh icon-refresh',<br/>
+        &nbsp;&nbsp;<i>toggle:</i> 'glyphicon-list-alt icon-list-alt',<br/>
+        &nbsp;&nbsp;<i>columns:</i> 'glyphicon-th icon-th',<br/>
+        &nbsp;&nbsp;<i>detailOpen:</i> 'glyphicon-plus icon-plus',<br/>
+        &nbsp;&nbsp;<i>detailClose:</i> 'glyphicon-minus icon-minus'<br/>
         }
         </td>
         <td>Defines icons that used for refresh, toggle and columns buttons</td>

--- a/docs/_i18n/en/documentation/table-options.md
+++ b/docs/_i18n/en/documentation/table-options.md
@@ -80,18 +80,16 @@ The table options is defined in `jQuery.fn.bootstrapTable.defaults`.
         <td>icons</td>
         <td>data-icons</td>
         <td>Object</td>
-        <td>```javascript
-{
-  paginationSwitchDown: 'glyphicon-collapse-down icon-chevron-down',
-  paginationSwitchUp: 'glyphicon-collapse-up icon-chevron-up',
-  refresh: 'glyphicon-refresh icon-refresh',
-  toggle: 'glyphicon-list-alt icon-list-alt',
-  columns: 'glyphicon-th icon-th',
-  detailOpen: 'glyphicon-plus icon-plus',
-  detailClose: 'glyphicon-minus icon-minus'
-}
-```
-</td>
+        <td>{<br/>
+        &nbsp;&nbsp;<b>paginationSwitchDown:</b> 'glyphicon-collapse-down icon-chevron-down',<br/>
+        &nbsp;&nbsp;<b>paginationSwitchUp:</b> 'glyphicon-collapse-up icon-chevron-up',<br/>
+        &nbsp;&nbsp;<b>refresh:</b> 'glyphicon-refresh icon-refresh',<br/>
+        &nbsp;&nbsp;<b>toggle:</b> 'glyphicon-list-alt icon-list-alt',<br/>
+        &nbsp;&nbsp;<b>columns:</b> 'glyphicon-th icon-th',<br/>
+        &nbsp;&nbsp;<b>detailOpen:</b> 'glyphicon-plus icon-plus',<br/>
+        &nbsp;&nbsp;<b>detailClose:</b> 'glyphicon-minus icon-minus'<br/>
+        }
+        </td>
         <td>Defines icons that used for refresh, toggle and columns buttons</td>
     </tr>
     <tr>

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -237,7 +237,9 @@
             paginationSwitchUp: 'glyphicon-collapse-up icon-chevron-up',
             refresh: 'glyphicon-refresh icon-refresh',
             toggle: 'glyphicon-list-alt icon-list-alt',
-            columns: 'glyphicon-th icon-th'
+            columns: 'glyphicon-th icon-th',
+            detailOpen: 'glyphicon-plus icon-plus',
+            detailClose: 'glyphicon-minus icon-minus'
         },
 
         rowStyle: function (row, index) {
@@ -1279,7 +1281,7 @@
             if (!this.options.cardView && this.options.detailView) {
                 html.push('<td>',
                     '<a class="detail-icon" href="javascript:">',
-                    '<i class="glyphicon glyphicon-plus icon-plus"></i>',
+                    sprintf('<i class="%s %s"></i>', this.options.iconsPrefix, this.options.icons.detailOpen),
                     '</a>',
                     '</td>');
             }
@@ -1435,11 +1437,11 @@
 
             // remove and update
             if ($tr.next().is('tr.detail-view')) {
-                $this.find('i').attr('class', 'glyphicon glyphicon-plus icon-plus');
+                $this.find('i').attr('class', sprintf('%s %s', that.options.iconsPrefix, that.options.icons.detailOpen));
                 $tr.next().remove();
                 that.trigger('collapse-row', index, row);
             } else {
-                $this.find('i').attr('class', 'glyphicon glyphicon-minus icon-minus');
+                $this.find('i').attr('class', sprintf('%s %s', that.options.iconsPrefix, that.options.icons.detailClose));
                 $tr.after(sprintf('<tr class="detail-view"><td colspan="%s">%s</td></tr>',
                     $tr.find('td').length, calculateObjectValue(that.options,
                         that.options.detailFormatter, [index, row], '')));


### PR DESCRIPTION
Puts the plus/minus icons in the that.options.icons array, and allow them to be changed using detailOpen and detailClose