### PR TITLE
Fix #980

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1452,7 +1452,7 @@
             var $this = $(this),
                 $tr = $this.parent().parent(),
                 index = $tr.data('index'),
-                row = that.options.data[index];
+                row = data[index]; // Fix #980 Detail view, when searching, returns wrong row
 
             // remove and update
             if ($tr.next().is('tr.detail-view')) {


### PR DESCRIPTION
Fix #980 Detail view, when searching, returns wrong row

```initBody``` was using ```that.options.data``` (the full table data) instead of ```data``` (the current filtered data) to form the Detail view