### PR TITLE
Add option for specifying locale as an option

### DIFF
--- a/docs/_i18n/en/documentation/table-options.md
+++ b/docs/_i18n/en/documentation/table-options.md
@@ -502,7 +502,7 @@ The table options are defined in `jQuery.fn.bootstrapTable.defaults`.
         <li>Then tries the locale with <code>'_'</code> translated to 
         <code>'-'</code> and the region code upper cased,</li>
         <li>Then tries the the short locale code (i.e. <code>'fr'</code> instead of <code>'fr-CA'</code>),</li>
-        <li>And finally will use the last local file loaded (or the dfault locale if no locales loaded).</li>
+        <li>And finally will use the last locale file loaded (or the default locale if no locales loaded).</li>
         </ol>
         If left undfined or an empty string, uses the last locale loaded (or <code>'en-US'</code>
         if no locale files loaded).

--- a/docs/_i18n/en/documentation/table-options.md
+++ b/docs/_i18n/en/documentation/table-options.md
@@ -491,7 +491,7 @@ The table options are defined in `jQuery.fn.bootstrapTable.defaults`.
     </tr>
      <tr>
         <td>locale</td>
-        <td>data-local</td>
+        <td>data-locale</td>
         <td>string</td>
         <td>undefined</td>
         <td>

--- a/docs/_i18n/en/documentation/table-options.md
+++ b/docs/_i18n/en/documentation/table-options.md
@@ -489,5 +489,24 @@ The table options are defined in `jQuery.fn.bootstrapTable.defaults`.
         Support all custom attributes.
         </td>
     </tr>
-    </tbody>
+     <tr>
+        <td>locale</td>
+        <td>data-local</td>
+        <td>string</td>
+        <td>undefined</td>
+        <td>
+        Sets the locale to use (i.e. <code>'fr-CA'</code>). Locale files must be pre-loaded.
+        Allows for fallback locales, if loaded, in the following order:<br>
+        <ol>
+        <li>First tries for the locale as specified,</li>
+        <li>Then tries the locale with <code>'_'</code> translated to 
+        <code>'-'</code> and the region code upper cased,</li>
+        <li>Then tries the the short locale code (i.e. <code>'fr'</code> instead of <code>'fr-CA'</code>),</li>
+        <li>And finally will use the last local file loaded (or the dfault locale if no locales loaded).</li>
+        </ol>
+        If left undfined or an empty string, uses the last locale loaded (or <code>'en-US'</code>
+        if no locale files loaded).
+        </td>
+    </tr>
+   </tbody>
 </table>

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -452,11 +452,22 @@
         this.initServer();
     };
 
-    BootstrapTable.prototype.initLocaler = function () {
-        // apply locale if found, otherwaise use default/last loaded
-        if (this.options.locale && this.locales[this.options.locale]) {
-            $.extend(this.options, $.fn.bootstrapTable.locales[this.options.locale]);
-        }
+    BootstrapTable.prototype.initLocale = function () {
+		if (this.options.locale) {
+			var parts = this.options.locale.split(/-|_/);
+			parts[0].toLowerCase();
+			parts[1] && parts[1].toUpperCase();
+			if ($.fn.bootstrapTable.locales[this.options.locale]) {
+				// locale as requested
+				$.extend(this.options, $.fn.bootstrapTable.locales[this.options.locale]);
+			} else if ($.fn.bootstrapTable.locales[parts.join('-')]) {
+				// locale with sep set to - (in case original was specified with _)
+				$.extend(this.options, $.fn.bootstrapTable.locales[parts.join('-')]);
+			} else if ($.fn.bootstrapTable.locales[parts[0]]) {
+				// short locale language code (i.e. 'en')
+				$.extend(this.options, $.fn.bootstrapTable.locales[parts[0]]);
+			}
+		}
     };
     
     BootstrapTable.prototype.initContainer = function () {

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -453,21 +453,21 @@
     };
 
     BootstrapTable.prototype.initLocale = function () {
-		if (this.options.locale) {
-			var parts = this.options.locale.split(/-|_/);
-			parts[0].toLowerCase();
-			parts[1] && parts[1].toUpperCase();
-			if ($.fn.bootstrapTable.locales[this.options.locale]) {
-				// locale as requested
-				$.extend(this.options, $.fn.bootstrapTable.locales[this.options.locale]);
-			} else if ($.fn.bootstrapTable.locales[parts.join('-')]) {
-				// locale with sep set to - (in case original was specified with _)
-				$.extend(this.options, $.fn.bootstrapTable.locales[parts.join('-')]);
-			} else if ($.fn.bootstrapTable.locales[parts[0]]) {
-				// short locale language code (i.e. 'en')
-				$.extend(this.options, $.fn.bootstrapTable.locales[parts[0]]);
-			}
-		}
+        if (this.options.locale) {
+            var parts = this.options.locale.split(/-|_/);
+            parts[0].toLowerCase();
+            parts[1] && parts[1].toUpperCase();
+            if ($.fn.bootstrapTable.locales[this.options.locale]) {
+                // locale as requested
+                $.extend(this.options, $.fn.bootstrapTable.locales[this.options.locale]);
+            } else if ($.fn.bootstrapTable.locales[parts.join('-')]) {
+                // locale with sep set to - (in case original was specified with _)
+                $.extend(this.options, $.fn.bootstrapTable.locales[parts.join('-')]);
+            } else if ($.fn.bootstrapTable.locales[parts[0]]) {
+                // short locale language code (i.e. 'en')
+                $.extend(this.options, $.fn.bootstrapTable.locales[parts[0]]);
+            }
+        }
     };
     
     BootstrapTable.prototype.initContainer = function () {

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -185,6 +185,7 @@
 
     BootstrapTable.DEFAULTS = {
         classes: 'table table-hover',
+        locale: undefined,
         height: undefined,
         undefinedText: '-',
         sortName: undefined,
@@ -347,7 +348,7 @@
 
     BootstrapTable.LOCALES = [];
 
-    BootstrapTable.LOCALES['en-US'] = {
+    BootstrapTable.LOCALES['en-US'] = BootstrapTable.LOCALES['en'] = {
         formatLoadingMessage: function () {
             return 'Loading, please wait...';
         },
@@ -439,6 +440,7 @@
     };
 
     BootstrapTable.prototype.init = function () {
+        this.initLocale();
         this.initContainer();
         this.initTable();
         this.initHeader();
@@ -450,6 +452,13 @@
         this.initServer();
     };
 
+    BootstrapTable.prototype.initLocaler = function () {
+        // apply locale if found, otherwaise use default/last loaded
+        if (this.options.locale && this.locales[this.options.locale]) {
+            $.extend(this.options, $.fn.bootstrapTable.locales[this.options.locale]);
+        }
+    };
+    
     BootstrapTable.prototype.initContainer = function () {
         this.$container = $([
             '<div class="bootstrap-table">',

--- a/src/extensions/mobile/bootstrap-table-mobile.js
+++ b/src/extensions/mobile/bootstrap-table-mobile.js
@@ -70,6 +70,7 @@
         mobileResponsive: false,
         minWidth: 562,
         minHeight: undefined,
+        heightThreshold: 100, // just slightly larger than mobile chrome's auto-hiding toolbar
         checkOnInit: true,
         toggled: false
     });


### PR DESCRIPTION
Adds option to allow locale to be specified as a option.  Assumes that the required locale files have been pre-loaded.

First attempts to find local as specified and uses it if found.
Then tries checking if local was specified with `_` insterad of `-` (translates `_` to `-`)
And if that is not found it tries for a short language only locale (ie.e `en` instead of `en-US`)
And if that is not found, then the defaults are left as is.

Example:

`<table data-toggle="table" data-locale='en_ZZ"></table>`

- First tries to extend with `en_ZZ`, but cant find it,
- Then tries `en-ZZ`, but cant find it
- Then tries `en`, and finds it (it is an alias of `en-US`)
