### PR TITLE
Fix cookieExpire to accept numbers > 9

### DIFF
--- a/src/extensions/cookie/bootstrap-table-cookie.js
+++ b/src/extensions/cookie/bootstrap-table-cookie.js
@@ -80,7 +80,7 @@
     };
 
     var calculateExpiration = function(cookieExpire) {
-        var time = cookieExpire.replace(/[0-9]/, ''); //s,mi,h,d,m,y
+        var time = cookieExpire.replace(/[0-9]*/, ''); //s,mi,h,d,m,y
         cookieExpire = cookieExpire.replace(/[A-Za-z]/, ''); //number
 
         switch (time.toLowerCase()) {


### PR DESCRIPTION
Without this a expire string such as "14d" gets parsed as "4d"