### PR TITLE
Incorrect footer width when using Bootstrap 2

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1894,7 +1894,7 @@
         this.$tableBody.find('tbody tr:first-child:not(.no-records-found) > td').each(function (i) {
             $footerTd.eq(i).outerWidth($(this).outerWidth());
         });
-        if (this.$tableFooter.find('table').width() < this.$tableBody.find('table').innerWidth())
+        if (this.$tableFooter.find('table').width() != this.$tableBody.find('table').innerWidth())
         {
             this.$tableFooter.find('table').width(this.$tableBody.find('table').innerWidth());
         }

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1894,7 +1894,10 @@
         this.$tableBody.find('tbody tr:first-child:not(.no-records-found) > td').each(function (i) {
             $footerTd.eq(i).outerWidth($(this).outerWidth());
         });
-        this.$tableFooter.find('table').width(this.$tableBody.find('table').innerWidth());
+        if (this.$tableFooter.find('table').width() < this.$tableBody.find('table').innerWidth())
+        {
+            this.$tableFooter.find('table').width(this.$tableBody.find('table').innerWidth());
+        }
     };
 
     BootstrapTable.prototype.toggleColumn = function (index, checked, needUpdate) {

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1894,6 +1894,7 @@
         this.$tableBody.find('tbody tr:first-child:not(.no-records-found) > td').each(function (i) {
             $footerTd.eq(i).outerWidth($(this).outerWidth());
         });
+        this.$tableFooter.find('table').width(this.$tableBody.find('table').innerWidth());
     };
 
     BootstrapTable.prototype.toggleColumn = function (index, checked, needUpdate) {


### PR DESCRIPTION
When a table has a footer, there is a problem with setting the width of footer table. Here's the example: https://jsfiddle.net/2h9b8s8q
Columns in the footer table are slightly shifted. The problem is only when using Boostrap 2. With Boostrap 3 everything is OK.