### PR TITLE
Support two new events in the editable plugin

### DIFF
--- a/src/extensions/editable/README.md
+++ b/src/extensions/editable/README.md
@@ -40,7 +40,7 @@ parameters: field, row, oldValue, $el
 
 Fired when an editable cell is opened for edits.
 
-parameters: field, row, $el
+parameters: field, row, $el, editable
 
 ### onEditableHidden(editable-hidden.bs.table)
 

--- a/src/extensions/editable/README.md
+++ b/src/extensions/editable/README.md
@@ -36,6 +36,18 @@ Fired when an editable cell is saved.
 
 parameters: field, row, oldValue, $el
 
+### onEditableShown(editable-shown.bs.table)
+
+Fired when an editable cell is opened for edits.
+
+parameters: field, row, $el
+
+### onEditableHidden(editable-hidden.bs.table)
+
+Fired when an editable cell is hidden / closed.
+
+parameters: field, row, $el
+
 ## The existing problems
 
 * Editable extension does not support searchable in the select type.

--- a/src/extensions/editable/bootstrap-table-editable.js
+++ b/src/extensions/editable/bootstrap-table-editable.js
@@ -15,7 +15,7 @@
         onEditableSave: function (field, row, oldValue, $el) {
             return false;
         },
-        onEditableShown: function (field, row, $el) {
+        onEditableShown: function (field, row, $el, editable) {
             return false;
         },
         onEditableHidden: function (field, row, $el) {
@@ -98,11 +98,10 @@
                         index = $(this).parents('tr[data-index]').data('index'),
                         row = data[index];
                     
-                    that.trigger('editable-hidden', column.field, row, $(this));
+                    that.trigger('editable-hidden', column.field, row, $(this), editable);
                 });
         });
         this.trigger('editable-init');
     };
 
 }(jQuery);
-

--- a/src/extensions/editable/bootstrap-table-editable.js
+++ b/src/extensions/editable/bootstrap-table-editable.js
@@ -14,12 +14,20 @@
         },
         onEditableSave: function (field, row, oldValue, $el) {
             return false;
+        },
+        onEditableShown: function (field, row, $el) {
+            return false;
+        },
+        onEditableHidden: function (field, row, $el) {
+            return false;
         }
     });
 
     $.extend($.fn.bootstrapTable.Constructor.EVENTS, {
         'editable-init.bs.table': 'onEditableInit',
-        'editable-save.bs.table': 'onEditableSave'
+        'editable-save.bs.table': 'onEditableSave',
+        'editable-shown.bs.table': 'onEditableShown',
+        'editable-hidden.bs.table': 'onEditableHidden'
     });
 
     var BootstrapTable = $.fn.bootstrapTable.Constructor,
@@ -34,7 +42,7 @@
             return;
         }
 
-        $.each(this.columns, function (i, column) {
+        $.each(this.options.columns, function (i, column) {
             if (!column.editable) {
                 return;
             }
@@ -61,7 +69,7 @@
             return;
         }
 
-        $.each(this.columns, function (i, column) {
+        $.each(this.options.columns, function (i, column) {
             if (!column.editable) {
                 return;
             }
@@ -76,8 +84,27 @@
                     row[column.field] = params.submitValue;
                     that.trigger('editable-save', column.field, row, oldValue, $(this));
                 });
+            that.$body.find('a[data-name="' + column.field + '"]').editable(column.editable)
+                .off('shown').on('shown', function (e, params) {
+                    var data = that.getData(),
+                        index = $(this).parents('tr[data-index]').data('index'),
+                        row = data[index];
+
+                    row[column.field] = params.submitValue;
+                    that.trigger('editable-shown', column.field, row, $(this));
+                });
+            that.$body.find('a[data-name="' + column.field + '"]').editable(column.editable)
+                .off('hidden').on('hidden', function (e, params) {
+                    var data = that.getData(),
+                        index = $(this).parents('tr[data-index]').data('index'),
+                        row = data[index];
+
+                    row[column.field] = params.submitValue;
+                    that.trigger('editable-hidden', column.field, row, $(this));
+                });
         });
         this.trigger('editable-init');
     };
 
 }(jQuery);
+

--- a/src/extensions/editable/bootstrap-table-editable.js
+++ b/src/extensions/editable/bootstrap-table-editable.js
@@ -42,7 +42,7 @@
             return;
         }
 
-        $.each(this.options.columns, function (i, column) {
+        $.each(this.columns, function (i, column) {
             if (!column.editable) {
                 return;
             }
@@ -69,7 +69,7 @@
             return;
         }
 
-        $.each(this.options.columns, function (i, column) {
+        $.each(this.columns, function (i, column) {
             if (!column.editable) {
                 return;
             }

--- a/src/extensions/editable/bootstrap-table-editable.js
+++ b/src/extensions/editable/bootstrap-table-editable.js
@@ -85,21 +85,19 @@
                     that.trigger('editable-save', column.field, row, oldValue, $(this));
                 });
             that.$body.find('a[data-name="' + column.field + '"]').editable(column.editable)
-                .off('shown').on('shown', function (e, params) {
+                .off('shown').on('shown', function (e) {
                     var data = that.getData(),
                         index = $(this).parents('tr[data-index]').data('index'),
                         row = data[index];
-
-                    row[column.field] = params.submitValue;
+                    
                     that.trigger('editable-shown', column.field, row, $(this));
                 });
             that.$body.find('a[data-name="' + column.field + '"]').editable(column.editable)
-                .off('hidden').on('hidden', function (e, params) {
+                .off('hidden').on('hidden', function (e, editable) {
                     var data = that.getData(),
                         index = $(this).parents('tr[data-index]').data('index'),
                         row = data[index];
-
-                    row[column.field] = params.submitValue;
+                    
                     that.trigger('editable-hidden', column.field, row, $(this));
                 });
         });


### PR DESCRIPTION
For my project, and for others too (I believe), it would be beneficiary to add support for the two additional events in the x-editable plugin - `shown` and `hidden` so we could do even more with the plugin, since this is the easiest way to bind events to it.
The readme for plugin is also updated with the changes.