### PR TITLE
Reorder Row issues

### DIFF
--- a/src/extensions/reorder-rows/bootstrap-table-reorder-rows.js
+++ b/src/extensions/reorder-rows/bootstrap-table-reorder-rows.js
@@ -91,7 +91,7 @@
         });
     };
 
-    BootstrapTable.prototype.onDrop = function (table, row) {
+    BootstrapTable.prototype.onDrop = function (table, droppedRow) {
         var tableBs = $(table),
             tableBsData = tableBs.data('bootstrap.table'),
             tableBsOptions = tableBs.data('bootstrap.table').options,
@@ -107,7 +107,7 @@
         tableBsOptions.data = newData;
 
         //Call the user defined function
-        tableBsOptions.onReorderRowsDrop.apply(table, row);
+        tableBsOptions.onReorderRowsDrop.apply(table, [droppedRow]);
 
         //Call the event reorder-row
         tableBsData.trigger('reorder-row', newData);

--- a/src/extensions/reorder-rows/bootstrap-table-reorder-rows.js
+++ b/src/extensions/reorder-rows/bootstrap-table-reorder-rows.js
@@ -107,7 +107,7 @@
         tableBsOptions.data = newData;
 
         //Call the user defined function
-        tableBsOptions.onReorderRowsDrop.apply(table, [droppedRow]);
+        tableBsOptions.onReorderRowsDrop.apply(table, [table, droppedRow]);
 
         //Call the event reorder-row
         tableBsData.trigger('reorder-row', newData);

--- a/src/extensions/reorder-rows/bootstrap-table-reorder-rows.js
+++ b/src/extensions/reorder-rows/bootstrap-table-reorder-rows.js
@@ -44,8 +44,6 @@
 
     BootstrapTable.prototype.init = function () {
 
-        _init.apply(this, Array.prototype.slice.apply(arguments));
-
         if (!this.options.reorderableRows) {
             return;
         }
@@ -62,6 +60,8 @@
                 onPostBody.apply();
             }, 1);
         };
+
+        _init.apply(this, Array.prototype.slice.apply(arguments));
     };
 
     BootstrapTable.prototype.initSearch = function () {


### PR DESCRIPTION
Hi,

I'm using reorder-row extension to reposition entities, but I've encountered an issue upon BootstrapTable.prototype.onDrop, which do not pass the correct arguments to the onReorderRowsDrop option callback (which should be the table and the moved row, as documented), but only the last row instance.

While making a fiddle, I've seen that the plugin do not work with table having client side data, because the init function override plugs onPostBody after calling parent.

I've fixed these two issues in this pull request. Here is a fiddle with the reordering not starting : <a href="http://jsfiddle.net/c74h2zoL/1/">http://jsfiddle.net/c74h2zoL/1/</a>, and with the initial issue on a server side table : <a href="http://jsfiddle.net/5gobzuff/2/">http://jsfiddle.net/5gobzuff/2/</a>.