### PR TITLE
Update column-options, added "width" note

### DIFF
--- a/docs/_i18n/en/documentation/column-options.md
+++ b/docs/_i18n/en/documentation/column-options.md
@@ -109,8 +109,7 @@ The column options is defined in `jQuery.fn.bootstrapTable.columnDefaults`.
         <td>data-width</td>
         <td>Number {Pixels or Percentage}</td>
         <td>undefined</td>
-        <td>The width of column. If not defined, the width will auto expand to fit its contents. Also you can add '%' to your number and
-		the bootstrapTable will use the percentage unit, otherwise, you can add or no the 'px' to your number and then the bootstrapTable will use the pixels</td>
+        <td>The width of column. If not defined, the width will auto expand to fit its contents. Though if the table is left responsive and sized too small this 'width' might be ignored (use min/max-width via class or such then). Also you can add '%' to your number and the bootstrapTable will use the percentage unit, otherwise, leave as number (or add 'px') to make it use pixels.</td>
     </tr>
     <tr>
         <td>sortable</td>


### PR DESCRIPTION
follow up from https://github.com/wenzhixin/bootstrap-table/issues/1291

I cleaned up the paragraph and added a short note as needs it here and/or in an example to make more obvious that "width" does not always stick around with many columns, though this can be seen in http://issues.wenzhixin.net.cn/bootstrap-table/#options/large-columns.html but a solution against that is not.

Can maybe be added in that example too, but the doco is higher visibility so would leave here too even if.