### PR TITLE
Restore focus of filter-controls after clone headers

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1789,6 +1789,20 @@
             getScrollBarWidth() : 0;
 
         this.$el.css('margin-top', -this.$header.outerHeight());
+
+        if($(':focus').length > 0) {
+            var $th = $(':focus').parents('th');
+            if($th.length > 0) {
+                var dataField = $th.attr('data-field');
+                if(dataField !== undefined) {
+                    var $headerTh = this.$header.find("[data-field='" + dataField + "']");
+                    if($headerTh.length > 0) {
+                        $headerTh.find(":input").addClass("focus-temp");
+                    }                
+                }
+            }
+        }
+
         this.$header_ = this.$header.clone(true, true);
         this.$selectAll_ = this.$header_.find('[name="btSelectAll"]');
         this.$tableHeader.css({
@@ -1797,6 +1811,11 @@
             .html('').attr('class', this.$el.attr('class'))
             .append(this.$header_);
 
+        var $focus = $('.focus-temp:visible:eq(0)');
+        if($focus.length > 0) {
+            $focus.focus();
+            this.$header.find('.focus-temp').removeClass('focus-temp');
+        }
         // fix bug: $.data() is not working as expected after $.append()
         this.$header.find('th[data-field]').each(function (i) {
             that.$header_.find(sprintf('th[data-field="%s"]', $(this).data('field'))).data($(this).data());

--- a/src/extensions/filter-control/bootstrap-table-filter-control.js
+++ b/src/extensions/filter-control/bootstrap-table-filter-control.js
@@ -62,7 +62,7 @@
     };
 
     var addOptionToSelectControl = function (selectControl, value, text) {
-        //selectControl = $(selectControl.get(0));
+        selectControl = $(selectControl.get(selectControl.length - 1));
         if (existsOptionInSelectControl(selectControl, value)) {
             selectControl.append($("<option></option>")
                 .attr("value", value)
@@ -87,11 +87,9 @@
     };
 
     var existsOptionInSelectControl = function (selectControl, value) {
-        var options = selectControl.get(0).options,
-            iOpt = 0;
-
-        for (; iOpt < options.length; iOpt++) {
-            if (options[iOpt].value === value) {
+        var options = selectControl.get(selectControl.length - 1).options;
+        for (var i = 0; i < options.length; i++) {
+            if (options[i].value === value) {
                 //The value is nor valid to add
                 return false;
             }
@@ -375,7 +373,7 @@
                         if (column.filterData === undefined || column.filterData.toLowerCase() === 'column') {
                             var selectControl = $('.' + column.field);
                             if (selectControl !== undefined && selectControl.length > 0) {
-                                if (selectControl.get(0).options.length === 0) {
+                                if (selectControl.get(selectControl.length - 1).options.length === 0) {
                                     //Added the default option
                                     addOptionToSelectControl(selectControl, '', '');
                                 }

--- a/src/extensions/filter-control/bootstrap-table-filter-control.js
+++ b/src/extensions/filter-control/bootstrap-table-filter-control.js
@@ -62,7 +62,7 @@
     };
 
     var addOptionToSelectControl = function (selectControl, value, text) {
-        selectControl = $(selectControl.get(selectControl.length - 1));
+        //selectControl = $(selectControl.get(0));
         if (existsOptionInSelectControl(selectControl, value)) {
             selectControl.append($("<option></option>")
                 .attr("value", value)
@@ -87,9 +87,11 @@
     };
 
     var existsOptionInSelectControl = function (selectControl, value) {
-        var options = selectControl.get(selectControl.length - 1).options;
-        for (var i = 0; i < options.length; i++) {
-            if (options[i].value === value) {
+        var options = selectControl.get(0).options,
+            iOpt = 0;
+
+        for (; iOpt < options.length; iOpt++) {
+            if (options[iOpt].value === value) {
                 //The value is nor valid to add
                 return false;
             }
@@ -373,7 +375,7 @@
                         if (column.filterData === undefined || column.filterData.toLowerCase() === 'column') {
                             var selectControl = $('.' + column.field);
                             if (selectControl !== undefined && selectControl.length > 0) {
-                                if (selectControl.get(selectControl.length - 1).options.length === 0) {
+                                if (selectControl.get(0).options.length === 0) {
                                     //Added the default option
                                     addOptionToSelectControl(selectControl, '', '');
                                 }


### PR DESCRIPTION
Given the table height is set
When a search with a filter-control is done 
Then the headers are clone and replace 
And the focus of the filter-control is lost

This pull request try to avoid this situation, by restoring the focus after cloning the headers. The result is not perfect, because the focus is lost during a few ms. And, if the page contains multiple tables with same data-field, then it can be the false control who has focus.