### PR TITLE
Fix for bug 1314

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -523,7 +523,7 @@
                     '',
                 '<div class="fixed-table-container">',
                 '<div class="fixed-table-header"><table></table></div>',
-                '<div class="fixed-table-body">',
+                '<div class="fixed-table-body"  style="position:relative;">',
                     '<div class="fixed-table-loading">',
                         this.options.formatLoadingMessage(),
                     '</div>',


### PR DESCRIPTION
Fix for bug https://github.com/wenzhixin/bootstrap-table/issues/1314 where reordering columns inside scrollable container isn't offset correctly.