### PR TITLE
Removed check prevent search trigger if searchText is the same.

### DIFF
--- a/dist/bootstrap-table.js
+++ b/dist/bootstrap-table.js
@@ -1038,9 +1038,6 @@
             $(event.currentTarget).val(text);
         }
 
-        if (text === this.searchText) {
-            return;
-        }
         this.searchText = text;
 
         this.options.pageNumber = 1;


### PR DESCRIPTION
Although this check prevents unnecessarily triggering a search if the text is the same, it also prevents filtering the table by the searchText in the options object sent to refreshOptions if the searchText is unchanged.

For example if the searchText is set to "asdf" and then I call refreshOptions with options where searchText is still "asdf", but has different data, the table will display all of the data in specified in the new options without filtering by the searchText. Thus the end result is the user sees the search text as "asdf", but the table shows rows which do not contain "asdf".

I don't know if this is the best fix for this because of the side effects some might have who are relying on this. I can't thing of too many use cases where this might occur, except perhaps quickly entering and deleting a character would cause a search which incurs a network request. It might be better to have an option which overrides the default behavior or have a means of forcing the search trigger when calling from refreshOptions, I really wanted to try out Github's automatic forking feature though.