### PR TITLE
ColumnSearch after click on clear button in IE

### DIFF
--- a/src/extensions/filter-control/bootstrap-table-filter-control.js
+++ b/src/extensions/filter-control/bootstrap-table-filter-control.js
@@ -246,6 +246,24 @@
                 }, that.options.searchTimeOut);
             });
 
+            header.off('mouseup', 'input').on('mouseup', 'input', function (event) {
+                var $input = $(this),
+                oldValue = $input.val();
+
+                if (oldValue == "") return;
+
+                setTimeout(function(){
+                    var newValue = $input.val();
+
+                    if (newValue == ""){
+                        clearTimeout(timeoutId);
+                        timeoutId = setTimeout(function () {
+                            that.onColumnSearch(event);
+                        }, that.options.searchTimeOut);
+                    }
+                }, 1);
+            });
+
             if (header.find('.date-filter-control').length > 0) {
                 $.each(that.columns, function (i, column) {
                     if (column.filterControl !== undefined && column.filterControl.toLowerCase() === 'datepicker') {

--- a/src/extensions/filter-control/bootstrap-table-filter-control.js
+++ b/src/extensions/filter-control/bootstrap-table-filter-control.js
@@ -250,12 +250,12 @@
                 var $input = $(this),
                 oldValue = $input.val();
 
-                if (oldValue == "") return;
+                if (oldValue === "") return;
 
                 setTimeout(function(){
                     var newValue = $input.val();
 
-                    if (newValue == ""){
+                    if (newValue === ""){
                         clearTimeout(timeoutId);
                         timeoutId = setTimeout(function () {
                             that.onColumnSearch(event);


### PR DESCRIPTION
Internet Explorer adds a clear button in input. Unfortunately the columnSearch is not trigger when the clear button is pressed.

To fixe this, we have to listen to the 'mouseup' event trigger par the clear button (http://stackoverflow.com/questions/14498396/event-fired-when-clearing-text-input-on-ie10-with-clear-icon)