### PR TITLE
add data-data-field option for compability with different REST backends

### DIFF
--- a/docs/_i18n/en/documentation/table-options.md
+++ b/docs/_i18n/en/documentation/table-options.md
@@ -108,6 +108,13 @@ The table options are defined in `jQuery.fn.bootstrapTable.defaults`.
         <td>The data to be loaded.</td>
     </tr>
     <tr>
+        <td>dataField</td>
+        <td>data-data-field</td>
+        <td>String</td>
+        <td>'rows'</td>
+        <td>Key in incoming json containing rows data list.</td>
+    </tr>
+    <tr>
         <td>ajax</td>
         <td>data-ajax</td>
         <td>Function</td>

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -234,6 +234,7 @@
         striped: false,
         columns: [[]],
         data: [],
+        dataField: 'rows',
         method: 'get',
         url: undefined,
         ajax: undefined,
@@ -2019,7 +2020,7 @@
         if (this.options.sidePagination === 'server') {
             this.options.totalRows = data.total;
             fixedScroll = data.fixedScroll;
-            data = data.rows;
+            data = data[this.options.dataField];
         } else if (!$.isArray(data)) { // support fixedScroll
             fixedScroll = data.fixedScroll;
             data = data.data;


### PR DESCRIPTION
Ability to customize this option will let more simply integration with backend. Default value is backward-compatibility with current realization.