### PR TITLE
Add res to parameter of onLoadError

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1696,7 +1696,7 @@
                 that.trigger('load-success', res);
             },
             error: function (res) {
-                that.trigger('load-error', res.status);
+                that.trigger('load-error', res.status, res);
             },
             complete: function () {
                 if (!silent) {


### PR DESCRIPTION
Right now, the parameter of `onLoadError` is `status` only ( http://bootstrap-table.wenzhixin.net.cn/documentation/#events ).
However I need more information such as JSON encoded error messages.
This pull request adds `res` to the second parameter to `onLoadError`.

Could you have a look and merge this?
Thanks!