### PR TITLE
Added filterStrictSearch option and updated docs

### DIFF
--- a/docs/_i18n/en/extensions/filter-control.md
+++ b/docs/_i18n/en/extensions/filter-control.md
@@ -24,6 +24,13 @@ Dependence if you use the datepicker option: [bootstrap-datepicker](https://gith
 * default: `false`
 
 
+### filterStrictSearch
+
+* type: Boolean
+* description: Set true to enable the strict search in column.
+* default: `false`
+
+
 ## Column options
 
 ### filterControl

--- a/src/extensions/filter-control/bootstrap-table-filter-control.js
+++ b/src/extensions/filter-control/bootstrap-table-filter-control.js
@@ -242,7 +242,8 @@
     $.extend($.fn.bootstrapTable.COLUMN_DEFAULTS, {
         filterControl: undefined,
         filterData: undefined,
-        filterDatepickerOptions: undefined
+        filterDatepickerOptions: undefined,
+        filterStrictSearch: false
     });
 
     $.extend($.fn.bootstrapTable.Constructor.EVENTS, {
@@ -366,17 +367,27 @@
         //Check partial column filter
         this.data = fp ? $.grep(this.data, function (item, i) {
             for (var key in fp) {
+                var thisColumn = that.columns[$.fn.bootstrapTable.utils.getFieldIndex(that.columns, key)];
                 var fval = fp[key].toLowerCase();
                 var value = item[key];
                 value = $.fn.bootstrapTable.utils.calculateObjectValue(that.header,
                     that.header.formatters[$.inArray(key, that.header.fields)],
                     [value, item, i], value);
 
-                if (!($.inArray(key, that.header.fields) !== -1 &&
-                    (typeof value === 'string' || typeof value === 'number') &&
-                    (value + '').toLowerCase().indexOf(fval) !== -1)) {
-                    return false;
+                if(thisColumn.filterStrictSearch===true){
+                    if (!($.inArray(key, that.header.fields) !== -1 &&
+                        (typeof value === 'string' || typeof value === 'number') &&
+                        value.toLowerCase() === fval.toLowerCase())) {
+                        return false;
+                    }
                 }
+                else{
+                    if (!($.inArray(key, that.header.fields) !== -1 &&
+                        (typeof value === 'string' || typeof value === 'number') &&
+                        (value + '').toLowerCase().indexOf(fval) !== -1)) {
+                        return false;
+                    }
+                };
             }
             return true;
         }) : this.data;


### PR DESCRIPTION
Have added new option to 'filter-control' extention: now user can choose how to search matches in column.
In practice: <th data-field="items_class" data-filter-control="select" data-filter-strict-search="true"> - use strict search. Default value for data-filter-strict-search is 'false'.