### PR TITLE
Fixed ReorderRows init when reorderable is false

### DIFF
--- a/src/extensions/reorder-rows/bootstrap-table-reorder-rows.js
+++ b/src/extensions/reorder-rows/bootstrap-table-reorder-rows.js
@@ -45,6 +45,7 @@
     BootstrapTable.prototype.init = function () {
 
         if (!this.options.reorderableRows) {
+            _init.apply(this, Array.prototype.slice.apply(arguments));
             return;
         }
 


### PR DESCRIPTION
When the ReorderabledRows property is false or not present, the rest of
bootstraptable was not inited properly. (Since commit 6201df0bb)