### PR TITLE
Check length when comparing in refreshOptions

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -2463,7 +2463,7 @@
 
     BootstrapTable.prototype.refreshOptions = function (options) {
         //If the objects are equivalent then avoid the call of destroy / init methods
-        if (compareObjects(this.options, options, false)) {
+        if (compareObjects(this.options, options, true)) {
             return;
         }
         this.options = $.extend(this.options, options);


### PR DESCRIPTION
If we don't check length in compareObjects, we won't notice when the new
options object has had a new property added. (Because compareObjects
otherways only checks that everything present in the old options exist
in the new, not the other way round.) This might be especially relevant
when you want to activate an extension like reorderableRows.