### PR TITLE
Bug Fix: selectAll checkbox not reflecting changes

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -790,6 +790,8 @@
             .on('click', '[name="btSelectAll"]', function () {
                 var checked = $(this).prop('checked');
                 that[checked ? 'checkAll' : 'uncheckAll']();
+                
+                that.updateSelected();
             });
     };
 


### PR DESCRIPTION
The current master branch version has a bug that selectAll checkbox not reflecting changes accordingly to highlight all rows in the table.
I located the problem is there is a missing update for the selection.