### PR TITLE
保留card-view的占位以兼容正确的事件绑定fieldIndex

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1523,7 +1523,8 @@
 
                     // Hide empty data on Card view when smartDisplay is set to true.
                     if (that.options.cardView && that.options.smartDisplay && value === '') {
-                        text = '';
+                        // Should set a placeholder for event binding correct fieldIndex
+                        text = '<div class="card-view"></div>';
                     }
                 }
 


### PR DESCRIPTION
smartDisplay会删掉card-view，将导致后面事件绑定无法正确绑定到被删掉card-view之后的$td上。见 line 1648:
$td = $tr.find(that.options.cardView ? '.card-view' : 'td').eq(fieldIndex)