### PR TITLE
Fixes #1248 - IE8 does not support indexOf()

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1151,7 +1151,7 @@
                 var pageLst = typeof this.options.pageList === 'string' ?
                     this.options.pageList.replace('[', '').replace(']', '')
                         .replace(/ /g, '').toLowerCase().split(',') : this.options.pageList;
-                if (pageLst.indexOf(this.options.formatAllRows().toLowerCase()) > -1) {
+                if ($.inArray(this.options.formatAllRows().toLowerCase(), pageLst)  > -1) {
                     $allSelected = true;
                 }
             }


### PR DESCRIPTION
IE8 does not support the Array.prototype.indexOf().  Replaced with jQuery.inArray().