### PR TITLE
Update row uniqueid

### DIFF
--- a/docs/_i18n/en/documentation/methods.md
+++ b/docs/_i18n/en/documentation/methods.md
@@ -108,7 +108,7 @@ The calling method syntax: `$('#table').bootstrapTable('method', parameter);`.
         <td>params</td>
         <td>
         Update the specified row, the param contains following properties: <br>
-        index: the row index to be updated. <br>
+        index or uniqueId: the row index/uniqueId to be updated. <br>
         row: the new row data.
         </td>
     </tr>

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -2216,10 +2216,21 @@
     };
 
     BootstrapTable.prototype.updateRow = function (params) {
-        if (!params.hasOwnProperty('index') || !params.hasOwnProperty('row')) {
+        if ((!params.hasOwnProperty('index') && !params.hasOwnProperty('uniqueId')) || !params.hasOwnProperty('row')) {
             return;
         }
-        $.extend(this.data[params.index], params.row);
+
+        if (params.hasOwnProperty('uniqueId')) {
+            var row = this.getRowByUniqueId(params.uniqueId);
+            if (!row) {
+                return;
+            }
+            var rowIndex = $.inArray(row, this.options.data);
+            $.extend(this.options.data[rowIndex], params.row);
+
+        } else {
+            $.extend(this.data[params.index], params.row);
+        }
         this.initSort();
         this.initBody(true);
     };


### PR DESCRIPTION
What a terrible title for this!  It should be:

Expand `updateRow` params to accept `uniqueId`
-----------------------------------------------------------------

This pull request adds a new feature to the method `updateRow`.  It now allows the param of `uniqueId` in addition to `index` for the row to update.  

This is particularly useful if you are updating a row which is not currently visible to the user (therefor, no index is available for it).  It will update the row in the background and the updates will be displayed when the user changes their view.

I created a fiddle here: http://jsfiddle.net/thornomad/ooh23sdz/3/

Let me know if you have any questions and am hopeful it can be included.  I find it very useful.