### PR TITLE
Fixed Italian translation

### DIFF
--- a/src/locale/bootstrap-table-it-IT.js
+++ b/src/locale/bootstrap-table-it-IT.js
@@ -1,6 +1,7 @@
 /**
  * Bootstrap Table Italian translation
  * Author: Davide Renzi<davide.renzi@gmail.com>
+ * Author: Davide Borsatto <davide.borsatto@gmail.com>
  */
 (function ($) {
     'use strict';
@@ -10,7 +11,7 @@
             return 'Caricamento in corso...';
         },
         formatRecordsPerPage: function (pageNumber) {
-            return pageNumber + ' records per pagina';
+            return pageNumber + ' elementi per pagina';
         },
         formatShowingRows: function (pageFrom, pageTo, totalRows) {
             return 'Pagina ' + pageFrom + ' di ' + pageTo + ' (' + totalRows + ' records)';
@@ -19,13 +20,13 @@
             return 'Cerca';
         },
         formatNoMatches: function () {
-            return 'Nessun record trovato';
+            return 'Nessun elemento trovato';
         },
         formatRefresh: function () {
-            return 'Rinfrescare';
+            return 'Aggiorna';
         },
         formatToggle: function () {
-            return 'Alternare';
+            return 'Alterna';
         },
         formatColumns: function () {
             return 'Colonne';


### PR DESCRIPTION
- Changed verb forms to imperative in order to be consistent with overall web usage
- Translated "record(s)" into the proper Italian noun "elemento"/"elementi"