### PR TITLE
Expand `filterBy` to accept and array of values

### DIFF
--- a/docs/_i18n/en/documentation/methods.md
+++ b/docs/_i18n/en/documentation/methods.md
@@ -258,7 +258,7 @@ The calling method syntax: `$('#table').bootstrapTable('method', parameter);`.
     <tr>
         <td>filterBy</td>
         <td>params</td>
-        <td>(Can use only in client-side)Filter data in table, eg. you can filter <code>{age: 10}</code> to show the data only age is equal to 10.</td>
+        <td>(Can use only in client-side) Filter data in table, e.g. you can filter <code>{age: 10}</code> to show the data only age is equal to 10.  You can also filter with an array of values, as in: <code>{age: 10, hairColor: ["blue", "red", "green"]} to find data where age is equal to 10 and hairColor is either blue, red, or green.</td>
     </tr>
     <tr>
         <td>selectPage</td>

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1085,7 +1085,11 @@
             // Check filter
             this.data = f ? $.grep(this.options.data, function (item, i) {
                 for (var key in f) {
-                    if (item[key] !== f[key]) {
+                    if ($.isArray(f[key])) {
+                        if ($.inArray(item[key], f[key]) === -1) {
+                            return false;
+                        }
+                    } else if (item[key] !== f[key]) {
                         return false;
                     }
                 }


### PR DESCRIPTION
This pull requests allows a user to specify an array of values when using `filterBy`; this is really useful when you need to create a more complex filter.

    $table.bootstrapTable('filterBy', {
        age: [10, 11, 12]
    });

I also updated the documentation and created a fiddle to test it:

http://jsfiddle.net/thornomad/1xrtz4do/