### PR TITLE
Use default settings when cookie settings dont exist

### DIFF
--- a/src/extensions/cookie/bootstrap-table-cookie.js
+++ b/src/extensions/cookie/bootstrap-table-cookie.js
@@ -244,9 +244,9 @@
             searchTextCookie = getCookie(this, this.options.cookieIdTable, cookieIds.searchText);
 
         //sortOrder
-        this.options.sortOrder = sortOrderCookie ? sortOrderCookie : 'asc';
+        this.options.sortOrder = sortOrderCookie ? sortOrderCookie : this.options.sortOrder;
         //sortName
-        this.options.sortName = sortOrderNameCookie ? sortOrderNameCookie : undefined;
+        this.options.sortName = sortOrderNameCookie ? sortOrderNameCookie : this.options.sortName;
         //pageNumber
         this.options.pageNumber = pageNumberCookie ? +pageNumberCookie : this.options.pageNumber;
         //pageSize


### PR DESCRIPTION
When no cookie setting exists use the default setting provided by bootstrap table (or the table itself) for sort name and sort order