### PR TITLE
Unified naming of MS in type names.

### DIFF
--- a/dist/extensions/export/bootstrap-table-export.js
+++ b/dist/extensions/export/bootstrap-table-export.js
@@ -14,8 +14,8 @@
         txt: 'TXT',
         sql: 'SQL',
         doc: 'MS-Word',
-        excel: 'Ms-Excel',
-        powerpoint: 'Ms-Powerpoint',
+        excel: 'MS-Excel',
+        powerpoint: 'MS-Powerpoint',
         pdf: 'PDF'
     };
 

--- a/dist/extensions/export/bootstrap-table-export.js
+++ b/dist/extensions/export/bootstrap-table-export.js
@@ -14,8 +14,8 @@
         txt: 'TXT',
         sql: 'SQL',
         doc: 'MS-Word',
-        excel: 'MS-Excel',
-        powerpoint: 'MS-Powerpoint',
+        excel: 'Ms-Excel',
+        powerpoint: 'Ms-Powerpoint',
         pdf: 'PDF'
     };
 

--- a/docs/dist/extensions/export/bootstrap-table-export.js
+++ b/docs/dist/extensions/export/bootstrap-table-export.js
@@ -14,8 +14,8 @@
         txt: 'TXT',
         sql: 'SQL',
         doc: 'MS-Word',
-        excel: 'Ms-Excel',
-        powerpoint: 'Ms-Powerpoint',
+        excel: 'MS-Excel',
+        powerpoint: 'MS-Powerpoint',
         pdf: 'PDF'
     };
 

--- a/src/extensions/export/bootstrap-table-export.js
+++ b/src/extensions/export/bootstrap-table-export.js
@@ -14,8 +14,8 @@
         txt: 'TXT',
         sql: 'SQL',
         doc: 'MS-Word',
-        excel: 'Ms-Excel',
-        powerpoint: 'Ms-Powerpoint',
+        excel: 'MS-Excel',
+        powerpoint: 'MS-Powerpoint',
         pdf: 'PDF'
     };
 


### PR DESCRIPTION
To improve the readability I unified the naming of the type names. "MS-Word" was already with capital MS, but MS-Excel and MS-Powerpoint not.