### PR TITLE
sortName fails in cookie extension

### DIFF
--- a/src/extensions/cookie/bootstrap-table-cookie.js
+++ b/src/extensions/cookie/bootstrap-table-cookie.js
@@ -246,7 +246,7 @@
         //sortOrder
         this.options.sortOrder = sortOrderCookie ? sortOrderCookie : 'asc';
         //sortName
-        this.options.sortName = sortOrderNameCookie ? sortOrderNameCookie : undefined;
+        this.options.sortName = sortOrderNameCookie ? sortOrderNameCookie : this.options.sortName;
         //pageNumber
         this.options.pageNumber = pageNumberCookie ? +pageNumberCookie : this.options.pageNumber;
         //pageSize


### PR DESCRIPTION
There is an issue from the cookie extension.

at line 249:
"this.options.sortName = sortOrderNameCookie ? sortOrderNameCookie : undefined;"

The option will always be "undefined" in the first table load. You can't pre-set a column to be sorted in "start-up".

By change this to the default sort options:
"this.options.sortName = sortOrderNameCookie ? sortOrderNameCookie : this.options.sortName"

This will take the defined column or choose "undefined".

Best regards
KlapZaZa