### PR TITLE
Added new feature method: updateByUniqueId (PR to develop)

### DIFF
--- a/docs/_i18n/en/documentation/methods.md
+++ b/docs/_i18n/en/documentation/methods.md
@@ -112,6 +112,15 @@ The calling method syntax: `$('#table').bootstrapTable('method', parameter);`.
         row: the new row data.
         </td>
     </tr>
+    <tr>
+        <td>updateByUniqueId</td>
+        <td>params</td>
+        <td>
+        Update the specified row, the param contains following properties: <br>
+        id: a row id where the id should be the uniqueid field assigned to the table. <br>
+        row: the new row data.
+        </td>
+    </tr>
 	<tr>
         <td>showRow</td>
         <td>params</td>

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -2200,7 +2200,11 @@
             return;
         }
 
-        rowId = this.options.data.indexOf(this.getRowByUniqueId(params.id));
+        rowId = $.inArray(this.getRowByUniqueId(params.id), this.options.data);
+
+        if (rowId === -1) {
+            return;
+        }
 
         $.extend(this.data[rowId], params.row);
         this.initSort();

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -2193,6 +2193,20 @@
         this.initBody(true);
     };
 
+    BootstrapTable.prototype.updateByUniqueId = function (params) {
+        var rowId;
+
+        if (!params.hasOwnProperty('id') || !params.hasOwnProperty('row')) {
+            return;
+        }
+
+        rowId = this.options.data.indexOf(this.getRowByUniqueId(params.id));
+
+        $.extend(this.data[rowId], params.row);
+        this.initSort();
+        this.initBody(true);
+    };
+
     BootstrapTable.prototype.insertRow = function (params) {
         if (!params.hasOwnProperty('index') || !params.hasOwnProperty('row')) {
             return;
@@ -2566,7 +2580,7 @@
         'getOptions',
         'getSelections', 'getAllSelections', 'getData',
         'load', 'append', 'prepend', 'remove', 'removeAll',
-        'insertRow', 'updateRow', 'updateCell', 'removeByUniqueId',
+        'insertRow', 'updateRow', 'updateCell', 'updateByUniqueId', 'removeByUniqueId',
         'getRowByUniqueId', 'showRow', 'hideRow', 'getRowsHidden',
         'mergeCells',
         'checkAll', 'uncheckAll',


### PR DESCRIPTION
Allows for a row to be selected by UniqueId and then updated with new data. Leverages the existing getRowByUniqueId and has a precedent in removeByUniqueId.