### PR TITLE
getRowIdViaUniqueId method

### DIFF
--- a/docs/_i18n/en/documentation/methods.md
+++ b/docs/_i18n/en/documentation/methods.md
@@ -122,7 +122,13 @@ The calling method syntax: `$('#table').bootstrapTable('method', parameter);`.
         row: the new row data.
         </td>
     </tr>
-	<tr>
+    <tr>
+        <td>getRowIdViaUniqueId</td>
+        <td>id</td>
+        <td>Returns row id based on unique id provided to it.
+        If the unique id can't be found in the table it will return "-1".</td>
+    </tr>
+    <tr>
         <td>showRow</td>
         <td>params</td>
         <td>Show the specified row. the param contains following properties:

--- a/docs/_i18n/en/documentation/methods.md
+++ b/docs/_i18n/en/documentation/methods.md
@@ -123,7 +123,7 @@ The calling method syntax: `$('#table').bootstrapTable('method', parameter);`.
         </td>
     </tr>
     <tr>
-        <td>getRowIdViaUniqueId</td>
+        <td>getRowIdByUniqueId</td>
         <td>id</td>
         <td>Returns row id based on unique id provided to it.
         If the unique id can't be found in the table it will return "-1".</td>

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -2203,7 +2203,7 @@
         return dataRow;
     };
 
-    BootstrapTable.prototype.getRowIdViaUniqueId = function(uniqueId){
+    BootstrapTable.prototype.getRowIdByUniqueId = function(uniqueId){
         var rowId;
         rowId = $.inArray(this.getRowByUniqueId(uniqueId), this.options.data);
         return rowId;
@@ -2618,7 +2618,7 @@
         'getSelections', 'getAllSelections', 'getData',
         'load', 'append', 'prepend', 'remove', 'removeAll',
         'insertRow', 'updateRow', 'updateCell', 'updateByUniqueId', 'removeByUniqueId',
-        'getRowByUniqueId', 'getRowIdViaUniqueId', 'showRow', 'hideRow', 'getRowsHidden',
+        'getRowByUniqueId', 'getRowIdByUniqueId', 'showRow', 'hideRow', 'getRowsHidden',
         'mergeCells',
         'checkAll', 'uncheckAll',
         'check', 'uncheck',

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -2203,6 +2203,12 @@
         return dataRow;
     };
 
+    BootstrapTable.prototype.getRowIdViaUniqueId = function(uniqueId){
+        var rowId;
+        rowId = $.inArray(this.getRowByUniqueId(uniqueId), this.options.data);
+        return rowId;
+    };
+
     BootstrapTable.prototype.removeByUniqueId = function (id) {
         var len = this.options.data.length,
             row = this.getRowByUniqueId(id);
@@ -2612,7 +2618,7 @@
         'getSelections', 'getAllSelections', 'getData',
         'load', 'append', 'prepend', 'remove', 'removeAll',
         'insertRow', 'updateRow', 'updateCell', 'updateByUniqueId', 'removeByUniqueId',
-        'getRowByUniqueId', 'showRow', 'hideRow', 'getRowsHidden',
+        'getRowByUniqueId', 'getRowIdViaUniqueId', 'showRow', 'hideRow', 'getRowsHidden',
         'mergeCells',
         'checkAll', 'uncheckAll',
         'check', 'uncheck',


### PR DESCRIPTION
New method that returns row id based on unique id provided to it.
If the unique id cant be found in the table it will return "-1".

The idea behind the new method is that there are some method right now that don't support unique id (like updateCell, expandRow, collapseRow...), with getRowIdViaUniqueId  you will be able to fetch the row id before calling other methods.