### PR TITLE
adds a numericOnly sort option

### DIFF
--- a/src/extensions/natural-sorting/README.md
+++ b/src/extensions/natural-sorting/README.md
@@ -8,6 +8,18 @@ Use Plugin: [bootstrap-table-natural-sorting](https://github.com/wenzhixin/boots
 <script src="extensions/natural-sorting/bootstrap-table-natural-sorting.js"></script>
 ```
 
-### Options
+add a data-sorter atribute to any th. 
+*e.g.* ```<th data-sortable="true" data-sorter="alphanum">Price</th>```
 
-* Just add data-sorter="alphanum" to any th
+## Options
+
+* *alphanum* - sort alpha or numeric content naturally.
+    This can be used in columns that contain text or numeric content. 
+    Numbers will be sorted as expected 
+
+* *numericOnly* - extract numeric content and sort numerically.  
+  This can be used in columns that contain formated numeric content. 
+  e.g. $ and , will be removed, then Numbers will be sorted as expected
+  an alpha sort crrently sorts these as ASCII so you get $1, $100, $2, $20
+  instead of $1, $2, $20, $100.
+

--- a/src/extensions/natural-sorting/README.md
+++ b/src/extensions/natural-sorting/README.md
@@ -9,17 +9,19 @@ Use Plugin: [bootstrap-table-natural-sorting](https://github.com/wenzhixin/boots
 ```
 
 add a data-sorter atribute to any th. 
-*e.g.* ```<th data-sortable="true" data-sorter="alphanum">Price</th>```
+*e.g.* ``` <th data-sortable="true" data-sorter="alphanum">Price</th>```
 
 ## Options
 
-* *alphanum* - sort alpha or numeric content naturally.
-    This can be used in columns that contain text or numeric content. 
-    Numbers will be sorted as expected 
+### alphanum
+* sort alpha or numeric content naturally.
+* This can be used in columns that contain text or numeric content. 
+* Numbers will be sorted as expected and not in ASCII order 
 
-* *numericOnly* - extract numeric content and sort numerically.  
-  This can be used in columns that contain formated numeric content. 
-  e.g. $ and , will be removed, then Numbers will be sorted as expected
-  an alpha sort crrently sorts these as ASCII so you get $1, $100, $2, $20
+### numericOnly
+* extract numeric content and sort numerically.  
+* This can be used in columns that contain formated numeric content. 
+*  *e.g.* $ and , will be removed, then Numbers will be sorted as expected
+* an alpha sort crrently sorts these as ASCII so you get $1, $100, $2, $20
   instead of $1, $2, $20, $100.
 

--- a/src/extensions/natural-sorting/bootstrap-table-natural-sorting.js
+++ b/src/extensions/natural-sorting/bootstrap-table-natural-sorting.js
@@ -2,10 +2,11 @@
  * @author: Brian Huisman
  * @webSite: http://www.greywyvern.com
  * @version: v1.0.0
- * JS function to allow natural sorting on bootstrap-table columns
- * just add data-sorter="alphanum" to any th
+ * JS functions to allow natural sorting on bootstrap-table columns
+ * add data-sorter="alphanum" or data-sorter="numericOnly" to any th
  *
  * @update Dennis Hernández <http://djhvscf.github.io/Blog>
+ * @update Duane May
  */
 
 function alphanum(a, b) {
@@ -44,4 +45,16 @@ function alphanum(a, b) {
     }
   }
   return aa.length - bb.length;
+}
+
+function numericOnly(a, b) {
+    function stripNonNumber(s) {
+        s = s.replace(new RegExp(/[^0-9]/g), "");
+        return parseInt(s.toLowerCase());
+    }
+
+    aa = stripNonNumber(a);
+    bb = stripNonNumber(b);
+
+    return aa - bb;
 }

--- a/src/extensions/natural-sorting/bootstrap-table-natural-sorting.js
+++ b/src/extensions/natural-sorting/bootstrap-table-natural-sorting.js
@@ -50,11 +50,8 @@ function alphanum(a, b) {
 function numericOnly(a, b) {
     function stripNonNumber(s) {
         s = s.replace(new RegExp(/[^0-9]/g), "");
-        return parseInt(s.toLowerCase());
+        return parseInt(s, 10);
     }
 
-    aa = stripNonNumber(a);
-    bb = stripNonNumber(b);
-
-    return aa - bb;
+    return stripNonNumber(a) - stripNonNumber(b);
 }


### PR DESCRIPTION
This change adds a numericOnly sort option. I added it to the existing natural-sorting package, since they both deal with sorting of the columns. We could expand this extension to offer other types of sort. I didn't rename it for backward compatibility.