### PR TITLE
Adapted to Catalan translation conventions

### DIFF
--- a/src/locale/bootstrap-table-ca-ES.js
+++ b/src/locale/bootstrap-table-ca-ES.js
@@ -1,13 +1,14 @@
 /**
  * Bootstrap Table Catalan translation
- * Author: Marc Pina<iwalkalone69@gmail.com>
+ * Authors: Marc Pina<iwalkalone69@gmail.com>
+ *          Claudi Martinez<claudix.kernel@gmail.com>
  */
 (function ($) {
     'use strict';
 
     $.fn.bootstrapTable.locales['ca-ES'] = {
         formatLoadingMessage: function () {
-            return 'Si us plau esperi...';
+            return 'Espereu, si us plau...';
         },
         formatRecordsPerPage: function (pageNumber) {
             return pageNumber + ' resultats per pàgina';
@@ -16,19 +17,19 @@
             return 'Mostrant de ' + pageFrom + ' fins ' + pageTo + ' - total ' + totalRows + ' resultats';
         },
         formatSearch: function () {
-            return 'Buscar';
+            return 'Cerca';
         },
         formatNoMatches: function () {
             return 'No s\'han trobat resultats';
         },
         formatPaginationSwitch: function () {
-            return 'Amagar/Mostrar paginació';
+            return 'Amaga/Mostra paginació';
         },
         formatRefresh: function () {
-            return 'Refrescar';
+            return 'Refresca';
         },
         formatToggle: function () {
-            return 'Amagar/Mostrar';
+            return 'Alterna formatació';
         },
         formatColumns: function () {
             return 'Columnes';


### PR DESCRIPTION
Most of software Catalan translations follow some conventions stated by [Softcatalà](https://www.softcatala.org/), a non-profit organization that collaborates in translating famous programs such as Android OS, Linux OS, LibreOffice, Abiword or GIMP. Some of these conventions deal with the verbal tense and level of formality messages should be written in. For example, when the machine sends a message to the user, it must use the Catalan "vós" (2nd formal person) form, whereas imperative must be used when the user orders the machine to run a command.
For example: 
- A button with the command "Search" --> "Cerca"
- A button with the command "Delete" --> "Esborra"
- The message "You can't delete this row" --> "No podeu esborrar aquesta fila"
- The message "please, wait" --> "Espereu, si us plau"

A guide on Catalan translation for software can be found here: https://www.softcatala.org/wiki/Guia_d'estil/Guia_2010/Tota