### PR TITLE
'records' to 'rows' as per #1496

### DIFF
--- a/src/locale/bootstrap-table-en-US.js
+++ b/src/locale/bootstrap-table-en-US.js
@@ -10,7 +10,7 @@
             return 'Loading, please wait...';
         },
         formatRecordsPerPage: function (pageNumber) {
-            return pageNumber + ' records per page';
+            return pageNumber + ' rows per page';
         },
         formatShowingRows: function (pageFrom, pageTo, totalRows) {
             return 'Showing ' + pageFrom + ' to ' + pageTo + ' of ' + totalRows + ' rows';

--- a/src/locale/bootstrap-table-en-US.js.template
+++ b/src/locale/bootstrap-table-en-US.js.template
@@ -10,7 +10,7 @@
             return 'Loading, please wait...';
         },
         formatRecordsPerPage: function (pageNumber) {
-            return pageNumber + ' records per page';
+            return pageNumber + ' rows per page';
         },
         formatShowingRows: function (pageFrom, pageTo, totalRows) {
             return 'Showing ' + pageFrom + ' to ' + pageTo + ' of ' + totalRows + ' rows';

--- a/src/locale/bootstrap-table-nl-NL.js
+++ b/src/locale/bootstrap-table-nl-NL.js
@@ -10,7 +10,7 @@
             return 'Laden, even geduld...';
         },
         formatRecordsPerPage: function (pageNumber) {
-            return pageNumber + ' records per pagina';
+            return pageNumber + ' rows per pagina';
         },
         formatShowingRows: function (pageFrom, pageTo, totalRows) {
             return 'Toon ' + pageFrom + ' tot ' + pageTo + ' van ' + totalRows + ' records';


### PR DESCRIPTION
#1496

Starting looking at all languages, but too hard to ensure translation accuracy so just searched for those using both 'records' and 'rows' and forced consistency of 'rows' as per discussion