### PR TITLE
Reworded 'Isolate the problem' and added link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,8 @@
 # Contributing to Bootstrap Table
 
-Looking to contribute something to Bootstrap Table? **Here's how you can help.**
+Looking to contribute something to Bootstrap Table? 
+
+**Here's how you can help.**
 
 Please take a moment to review this document in order to make the contribution
 process easy and effective for everyone involved.
@@ -67,11 +69,12 @@ Guidelines for bug reports:
 2. **Check if the issue has been fixed** &mdash; try to reproduce it using the
    latest `master` or development branch in the repository.
 
-3. **Isolate the problem** &mdash; ideally create a live example.
-   [This jsfiddle](http://jsfiddle.net/) is a helpful tools. Consider to use these templates:
+3. **Isolate the problem** &mdash; ideally create a live example. 
+    The web tool [jsfiddle](http://jsfiddle.net/) is a very helpful for this. Consider to use these templates:
     * [Table from html](http://jsfiddle.net/wenyi/e3nk137y/11/light/)
     * [Table from data](http://jsfiddle.net/wenyi/e3nk137y/13/light/)
     * [Table from url](http://jsfiddle.net/wenyi/e3nk137y/14/light/)
+    * Other templates can also be found at [jsFiddle Bootstrap](http://bootstrap-table.wenzhixin.net.cn/examples/#basic)
 
 
 A good bug report shouldn't leave others needing to chase you up for more


### PR DESCRIPTION
Not sure if you want all examples there, but reworded awkward sentence and added examples link you had in README.md.

Before doing this i did update README.md, but left just the link you had there. I was going to remove it but thought you wanted it highlighted more.

Maybe add these other links there too?