### PR TITLE
Fix data field

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1460,7 +1460,7 @@
                     data_ = '',
                     rowspan_ = '',
                     title_ = '',
-                    column = that.columns[getFieldIndex(that.columns, field)];
+                    column = that.columns[j];
 
                 if (!column.visible) {
                     return;

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -2045,7 +2045,7 @@
           relativeIndex = absoluteIndex;
       $.each(this.header.fields, function (j, field) {
           var column = that.columns[j];
-          if (j < absoluteIndex) {
+          if (j > absoluteIndex) {
             return false;
           }
           if (!column.visible) {

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1647,7 +1647,7 @@
             that.trigger(checked ? 'check' : 'uncheck', row, $this);
         });
 
-        $.each(this.header.events, function (j, events) {
+        $.each(this.header.events, function (i, events) {
             if (!events) {
                 return;
             }
@@ -1656,8 +1656,8 @@
                 events = calculateObjectValue(null, events);
             }
 
-            var fieldIndex = that.getFieldIndex(j);
-            var field = that.header.fields[fieldIndex];
+            var field = that.header.fields[i],
+                fieldIndex = $.inArray(field, that.getVisibleFields());
 
             if (that.options.detailView && !that.options.cardView) {
                 fieldIndex += 1;

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -2041,7 +2041,8 @@
     };
 
     BootstrapTable.prototype.getFieldIndex = function (absoluteIndex) {
-      var relativeIndex = absoluteIndex;
+      var that = this,
+          relativeIndex = absoluteIndex;
       $.each(this.header.fields, function (j, field) {
           var column = that.columns[j];
           if (j < absoluteIndex) {

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1647,7 +1647,7 @@
             that.trigger(checked ? 'check' : 'uncheck', row, $this);
         });
 
-        $.each(this.header.events, function (i, events) {
+        $.each(this.header.events, function (fieldIndex, events) {
             if (!events) {
                 return;
             }
@@ -1656,8 +1656,7 @@
                 events = calculateObjectValue(null, events);
             }
 
-            var field = that.header.fields[i],
-                fieldIndex = $.inArray(field, that.getVisibleFields());
+            var field = that.header.fields[fieldIndex];
 
             if (that.options.detailView && !that.options.cardView) {
                 fieldIndex += 1;

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1647,7 +1647,7 @@
             that.trigger(checked ? 'check' : 'uncheck', row, $this);
         });
 
-        $.each(this.header.events, function (fieldIndex, events) {
+        $.each(this.header.events, function (j, events) {
             if (!events) {
                 return;
             }
@@ -1656,6 +1656,7 @@
                 events = calculateObjectValue(null, events);
             }
 
+            var fieldIndex = that.getFieldIndex(j);
             var field = that.header.fields[fieldIndex];
 
             if (that.options.detailView && !that.options.cardView) {
@@ -2038,6 +2039,20 @@
         });
         return visibleFields;
     };
+
+    BootstrapTable.prototype.getFieldIndex = function (absoluteIndex) {
+      var relativeIndex = absoluteIndex;
+      $.each(this.header.fields, function (j, field) {
+          var column = that.columns[j];
+          if (j < absoluteIndex) {
+            return false;
+          }
+          if (!column.visible) {
+            relativeIndex--;
+          }
+        });
+        return relativeIndex;
+    }
 
     // PUBLIC FUNCTION DEFINITION
     // =======================


### PR DESCRIPTION
As identified in issue #1649 this fixes issues with setting events for columns where the data-field parameter is set to the same field. Although this field is optional using it should not break expected functionality. Further more from the issue I identified, a similar problem is also seen when setting the visible parameter. It seemed like the way that the column information was being fetched using the getFieldIndex method was on purpose as if using that method added functionality. I mostly removed extra functions and used indexes that were already calculated and available.