### PR TITLE
Calculate column Index differently for events/toggle. Fix #1649

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -55,6 +55,18 @@
         return index;
     };
 
+    var getFieldIndexFromColumnIndex = function (columns, fieldIndex) {
+        $.each(columns, function (i, column) {
+          if (!column.visible) {
+            fieldIndex--;
+          }
+          if (i == fieldIndex) {
+            return false;
+          }
+        });
+        return fieldIndex;
+    };
+
     // http://jsfiddle.net/wenyi/47nz7ez9/3/
     var setFieldIndex = function (columns) {
         var i, j, k,
@@ -1034,8 +1046,7 @@
             $keepOpen.find('input').off('click').on('click', function () {
                 var $this = $(this);
 
-                that.toggleColumn(getFieldIndex(that.columns,
-                    $(this).data('field')), $this.prop('checked'), false);
+                that.toggleColumn($(this).val(), $this.prop('checked'), false);
                 that.trigger('column-switch', $(this).data('field'), $this.prop('checked'));
             });
         }
@@ -1510,7 +1521,7 @@
                     data_ = '',
                     rowspan_ = '',
                     title_ = '',
-                    column = that.columns[getFieldIndex(that.columns, field)];
+                    column = that.columns[j];
 
                 if (!column.visible) {
                     return;
@@ -1707,7 +1718,7 @@
             }
 
             var field = that.header.fields[i],
-                fieldIndex = $.inArray(field, that.getVisibleFields());
+                fieldIndex = getFieldIndexFromColumnIndex(that.columns, i);
 
             if (that.options.detailView && !that.options.cardView) {
                 fieldIndex += 1;


### PR DESCRIPTION
Second attempt at fixing #1649 by calculating the index for the columns. Kept @wenzhixin comments in mind and the same bugs are not present. I think this is just a starting point. If this doesn't break anything I think there are more places that the index could be calculated based on the given index instead of the key name.