### PR TITLE
fixed paginationSwitch for server-side #1677

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1749,10 +1749,9 @@
             },
             request;
 
-        if(this.options.pagination)
-        {
-        	params.pageSize = this.options.pageSize === this.options.formatAllRows() ?
-                    this.options.totalRows : this.options.pageSize;
+        if(this.options.pagination) {
+            params.pageSize = this.options.pageSize === this.options.formatAllRows() ?
+                this.options.totalRows : this.options.pageSize;
             params.pageNumber = this.options.pageNumber;
         }
 

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1742,15 +1742,19 @@
     BootstrapTable.prototype.initServer = function (silent, query) {
         var that = this,
             data = {},
-            params = {
-                pageSize: this.options.pageSize === this.options.formatAllRows() ?
-                    this.options.totalRows : this.options.pageSize,
-                pageNumber: this.options.pageNumber,
+            params = {                
                 searchText: this.searchText,
                 sortName: this.options.sortName,
                 sortOrder: this.options.sortOrder
             },
             request;
+
+        if(this.options.pagination)
+        {
+        	params.pageSize = this.options.pageSize === this.options.formatAllRows() ?
+                    this.options.totalRows : this.options.pageSize;
+            params.pageNumber = this.options.pageNumber;
+        }
 
         if (!this.options.url && !this.options.ajax) {
             return;


### PR DESCRIPTION
as see in #1677, server-side didnt check against this.options.pagination, so pagination-switch became ignored unless crude queryParam workaround. 

tested via http://jsfiddle.net/dabros/bosqoo29/4/ as no environment atm and couldnt get it to link in jsfiddle, though i done that in past, but its a friday ;)