### PR TITLE
Added an option to disable local filtering

### DIFF
--- a/src/extensions/filter-control/bootstrap-table-filter-control.js
+++ b/src/extensions/filter-control/bootstrap-table-filter-control.js
@@ -361,6 +361,10 @@
     BootstrapTable.prototype.initSearch = function () {
         _initSearch.apply(this, Array.prototype.slice.apply(arguments));
 
+        if ('filterRemote' in this.options && this.options.filterRemote) {
+            return;
+        }
+
         var that = this;
         var fp = $.isEmptyObject(this.filterColumnsPartial) ? null : this.filterColumnsPartial;
 


### PR DESCRIPTION
Hi,

First of all thanks for bootstrap-table, which is a great tool.

I'm using the filter-control extension with a remote json data source. The filter-control plugin allows me to filter the data server-side. This data is then formatted according to my needs and the json stream is returned.

The issue I'm facing is that the plugin automatically filters the data after it was returned (in the initSearch() function). I need to disable this local filtering, since it removes lines that shoud not be removed.

This commits allows to add a filterRemote option to the table (or data-filter-remote="true" when creating the table), which disables local filtering.

Cheers,