### PR TITLE
Fix padding in footer.

### DIFF
--- a/src/bootstrap-table.css
+++ b/src/bootstrap-table.css
@@ -17,7 +17,7 @@
 .bootstrap-table .table:not(.table-condensed) > thead > tr > td,
 .bootstrap-table .table:not(.table-condensed) > tbody > tr > td,
 .bootstrap-table .table:not(.table-condensed) > tfoot > tr > td {
-    padding: 8px !important;
+    padding: 8px;
 }
 
 .bootstrap-table .table.table-no-bordered > thead > tr > th,
@@ -274,6 +274,7 @@
 .bootstrap-table .fixed-table-footer .table {
     border-bottom: none;
     border-radius: 0;
+    padding: 0 !important;
 }
 
 .pull-right .dropdown-menu {


### PR DESCRIPTION
Fixed padding issues with footer that was making the columns too wide. As addressed in #1613. Concerned about removing the `!important` from line 20. But otherwise the problem still persisted and was overwriting the solution.