### PR TITLE
Add exportIconSize option

### DIFF
--- a/src/extensions/export/bootstrap-table-export.js
+++ b/src/extensions/export/bootstrap-table-export.js
@@ -24,6 +24,7 @@
         exportDataType: 'basic', // basic, all, selected
         // 'json', 'xml', 'png', 'csv', 'txt', 'sql', 'doc', 'excel', 'powerpoint', 'pdf'
         exportTypes: ['json', 'xml', 'csv', 'txt', 'sql', 'excel'],
+        exportIconSize: undefined,
         exportOptions: {}
     });
 
@@ -41,10 +42,14 @@
                 $export = $btnGroup.find('div.export');
 
             if (!$export.length) {
+                var iconSizeClass= '';
+                if (this.exportIconSize) {
+                    iconSizeClass = 'btn-'+ this.options.exportIconSize + ' '; 
+                }
                 $export = $([
                     '<div class="export btn-group">',
                         '<button class="btn btn-default dropdown-toggle" ' +
-                            ' btn-'+ this.options.iconSize + ' ' +
+                            iconSizeClass +
                             'data-toggle="dropdown" type="button">',
                             '<i class="glyphicon glyphicon-export icon-share"></i> ',
                             '<span class="caret"></span>',

--- a/src/extensions/export/bootstrap-table-export.js
+++ b/src/extensions/export/bootstrap-table-export.js
@@ -44,6 +44,7 @@
                 $export = $([
                     '<div class="export btn-group">',
                         '<button class="btn btn-default dropdown-toggle" ' +
+                            ' btn-'+ BootstrapTable.options.iconSize + ' ' +
                             'data-toggle="dropdown" type="button">',
                             '<i class="glyphicon glyphicon-export icon-share"></i> ',
                             '<span class="caret"></span>',

--- a/src/extensions/export/bootstrap-table-export.js
+++ b/src/extensions/export/bootstrap-table-export.js
@@ -44,7 +44,7 @@
                 $export = $([
                     '<div class="export btn-group">',
                         '<button class="btn btn-default dropdown-toggle" ' +
-                            ' btn-'+ BootstrapTable.options.iconSize + ' ' +
+                            ' btn-'+ this.options.iconSize + ' ' +
                             'data-toggle="dropdown" type="button">',
                             '<i class="glyphicon glyphicon-export icon-share"></i> ',
                             '<span class="caret"></span>',

--- a/src/extensions/export/bootstrap-table-export.js
+++ b/src/extensions/export/bootstrap-table-export.js
@@ -44,12 +44,11 @@
             if (!$export.length) {
                 var iconSizeClass= '';
                 if (this.options.exportIconSize) {
-                    iconSizeClass = 'btn-'+ this.options.exportIconSize + ' '; 
+                    iconSizeClass = ' btn-'+ this.options.exportIconSize; 
                 }
                 $export = $([
                     '<div class="export btn-group">',
-                        '<button class="btn btn-default dropdown-toggle" ' +
-                            iconSizeClass +
+                        '<button class="btn btn-default dropdown-toggle'+iconSizeClass+'" ' +
                             'data-toggle="dropdown" type="button">',
                             '<i class="glyphicon glyphicon-export icon-share"></i> ',
                             '<span class="caret"></span>',

--- a/src/extensions/export/bootstrap-table-export.js
+++ b/src/extensions/export/bootstrap-table-export.js
@@ -43,7 +43,7 @@
 
             if (!$export.length) {
                 var iconSizeClass= '';
-                if (this.exportIconSize) {
+                if (this.options.exportIconSize) {
                     iconSizeClass = 'btn-'+ this.options.exportIconSize + ' '; 
                 }
                 $export = $([


### PR DESCRIPTION
If iconSize property of BootstapTable is set, the export button did not follow the specified size. So I added an option to this extension to allow setting the button of the export button iconsize. 