### PR TITLE
showRow & hideRow param checks, see #1742

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -2308,14 +2308,14 @@
     };
 
     BootstrapTable.prototype.showRow = function (params) {
-        if (!params.hasOwnProperty('index') || !params.hasOwnProperty('uniqueId')) {
+        if (!params.hasOwnProperty('index') && !params.hasOwnProperty('uniqueId')) {
             return;
         }
         this.toggleRow(params.index, params.uniqueId, true);
     };
 
     BootstrapTable.prototype.hideRow = function (params) {
-        if (!params.hasOwnProperty('index') || !params.hasOwnProperty('uniqueId')) {
+        if (!params.hasOwnProperty('index') && !params.hasOwnProperty('uniqueId')) {
             return;
         }
         this.toggleRow(params.index, params.uniqueId, false);


### PR DESCRIPTION
As seen in #1742, the param checks now require 'both' param, instead of option of which is most relevent.

Not sure when this snuck in, but easy fix.