### PR TITLE
fix searchtext cookie set by column filters

### DIFF
--- a/src/extensions/cookie/bootstrap-table-cookie.js
+++ b/src/extensions/cookie/bootstrap-table-cookie.js
@@ -317,8 +317,12 @@
     };
 
     BootstrapTable.prototype.onSearch = function () {
-        _onSearch.apply(this, Array.prototype.slice.apply(arguments));
-        setCookie(this, cookieIds.searchText, this.searchText);
+        var target = Array.prototype.slice.apply(arguments);
+        _onSearch.apply(this, target);
+
+        if ($(target[0].currentTarget).parent().hasClass('search')) {
+          setCookie(this, cookieIds.searchText, this.searchText);
+        }
     };
 
     BootstrapTable.prototype.deleteCookie = function (cookieName) {


### PR DESCRIPTION
related Issue #1749 

fix: only save cookie if the onSearch function comes from the search text field. 

bug fiddle: http://jsfiddle.net/fnvk8xwa/3/
fix fiddle: http://jsfiddle.net/y32egy35/4/

steps to reproduce

> to see the issue, in the second column titled 'stars' type in the following string: 'boot'
> now, you should see that the table has no elements in the star column with the text 'boot' since the column has only numbers

> now reload the page
> you will see that boot is searched for in all columns and is in the searchtext box

in the fixed version, the last point does not happen, there is no text in the searchtext box and the filter is only in the column filter