### PR TITLE
add iconSizeClass

### DIFF
--- a/src/extensions/export/bootstrap-table-export.js
+++ b/src/extensions/export/bootstrap-table-export.js
@@ -44,11 +44,14 @@
             var that = this,
                 $btnGroup = this.$toolbar.find('>.btn-group'),
                 $export = $btnGroup.find('div.export');
-
             if (!$export.length) {
+                var iconSizeClass= '';
+                if (this.options.exportIconSize) {
+                    iconSizeClass = ' btn-'+ this.options.exportIconSize; 
+                }
                 $export = $([
                     '<div class="export btn-group">',
-                        '<button class="btn btn-default dropdown-toggle" ' +
+                        '<button class="btn btn-default dropdown-toggle'+iconSizeClass+'" ' +
                             'data-toggle="dropdown" type="button">',
                             sprintf('<i class="%s %s"></i> ', this.options.iconsPrefix, this.options.icons.export),
                             '<span class="caret"></span>',


### PR DESCRIPTION
IconSize is not changing according to tableGrid IconSize option. So, I added an extra option "exportIconSize" that allow to define an icon size.
It would be much better, if we managed to inherit the main table iconSize option and have the possibility to override it in the plugin options. Instead of defining an extra option.