### PR TITLE
Fixed ReorderRows init when reorderable is false

### DIFF
--- a/src/extensions/reorder-rows/bootstrap-table-reorder-rows.js
+++ b/src/extensions/reorder-rows/bootstrap-table-reorder-rows.js
@@ -45,6 +45,7 @@
     BootstrapTable.prototype.init = function () {
 
         if (!this.options.reorderableRows) {
+            _init.apply(this, Array.prototype.slice.apply(arguments));
             return;
         }
 


### PR DESCRIPTION
When the ReorderabledRows property is false or not present, the rest of
bootstraptable was not inited properly. (Since commit 6201df0)

This is a repeat of PR #1444. Sorry for leaving a driveby PR and then forgetting about it for so long.

@tm1000 provided the fiddles to show that it works:
Fiddle that proves it's broken: http://jsfiddle.net/5gobzuff/3/
Fiddle that Proves this is the proper fix: http://jsfiddle.net/5gobzuff/4/