### PR TITLE
Enabled data attributes for editable column.

### DIFF
--- a/src/extensions/editable/bootstrap-table-editable.js
+++ b/src/extensions/editable/bootstrap-table-editable.js
@@ -47,14 +47,34 @@
                 return;
             }
 
+            var editableOptions = {}, editableDataMarkup = [], editableDataPrefix = 'editable-';
+
+            var processDataOptions = function(key, value) {
+              // Replace camel case with dashes.
+              var dashKey = key.replace(/([A-Z])/g, function($1){return "-"+$1.toLowerCase();});
+              if (dashKey.slice(0, editableDataPrefix.length) == editableDataPrefix) {
+                var dataKey = dashKey.replace(editableDataPrefix, 'data-');
+                editableOptions[dataKey] = value;
+              }
+            };
+
+            $.each(that.options, processDataOptions);
+
             var _formatter = column.formatter;
             column.formatter = function (value, row, index) {
                 var result = _formatter ? _formatter(value, row, index) : value;
+
+                $.each(column, processDataOptions);
+
+                $.each(editableOptions, function (key, value) {
+                    editableDataMarkup.push(' ' + key + '="' + value + '"');
+                });
 
                 return ['<a href="javascript:void(0)"',
                     ' data-name="' + column.field + '"',
                     ' data-pk="' + row[that.options.idField] + '"',
                     ' data-value="' + result + '"',
+                    editableDataMarkup.join(''),
                     '>' + '</a>'
                 ].join('');
             };


### PR DESCRIPTION
I need to set editable options via data attributes. Since #1832 shows that I'm not alone I decided to open a pull request. I'm really sure that my code needs improvement but it solves the issue:

https://jsfiddle.net/fsauter/6da007fm/

It enables you to add table and specific column data attributes. All editable data attributes must be prefixed with "editable" (see below). Note that table wide options are used for every column but can be overriden.

````html
<table id="dispatch-type-list"
  data-url="data/url.json"
  data-id-field="id"
  data-editable-emptytext="This field is empty"
  data-editable-url="/my/editable/update/path">
  <thead>
    <tr>
      <th class="col-md-1" data-field="id" data-sortable="true" data-align="center">#</th>
      <th class="col-md-3" data-field="name" data-editable="true">Name</th>
      <th class="col-md-7" data-field="description" data-editable="true" data-editable-emptytext="This will override the empty text option of the table.">Description</th>
      <th class="col-md-1" data-align="center" data-formatter="formatter.actions">Actions</th>
    </tr>
  </thead>
</table>
````

So it would be nice to see, that something like this will find its way into the editable extension. Can you help me to improve and integrate it?