### PR TITLE
Rendering detail view directly with detailFormatter

### DIFF
--- a/docs/_i18n/en/documentation/table-options.md
+++ b/docs/_i18n/en/documentation/table-options.md
@@ -401,8 +401,8 @@ The table options are defined in `jQuery.fn.bootstrapTable.defaults`.
         <td>detailFormatter</td>
         <td>data-detail-formatter</td>
         <td>Function</td>
-        <td>function(index, row) {<br>return '';<br>}</td>
-        <td>Format your detail view when <code>detailView</code> is set to <code>true</code>.</td>
+        <td>function(index, row, element) {<br>return '';<br>}</td>
+        <td>Format your detail view when <code>detailView</code> is set to <code>true</code>. Return a String and it will be appended into the detail view cell, optionally render the element directly using the third parameter which is a jQuery element of the target cell.</td>
     </tr>
     <tr>
         <td>searchAlign</td>

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1667,10 +1667,13 @@
                 that.trigger('collapse-row', index, row);
             } else {
                 $this.find('i').attr('class', sprintf('%s %s', that.options.iconsPrefix, that.options.icons.detailClose));
-                $tr.after(sprintf('<tr class="detail-view"><td colspan="%s">%s</td></tr>',
-                    $tr.find('td').length, calculateObjectValue(that.options,
-                        that.options.detailFormatter, [index, row], '')));
-                that.trigger('expand-row', index, row, $tr.next().find('td'));
+                $tr.after(sprintf('<tr class="detail-view"><td colspan="%s"></td></tr>', $tr.find('td').length));
+                var $element = $tr.next().find('td');
+                var content = calculateObjectValue(that.options, that.options.detailFormatter, [index, row, $element], '');
+                if($element.length == 1) {
+                  $element.append(content);
+                }
+                that.trigger('expand-row', index, row, $element);
             }
             that.resetView();
         });

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1670,8 +1670,8 @@
                 $tr.after(sprintf('<tr class="detail-view"><td colspan="%s"></td></tr>', $tr.find('td').length));
                 var $element = $tr.next().find('td');
                 var content = calculateObjectValue(that.options, that.options.detailFormatter, [index, row, $element], '');
-                if($element.length == 1) {
-                  $element.append(content);
+                if($element.length === 1) {
+                    $element.append(content);
                 }
                 that.trigger('expand-row', index, row, $element);
             }


### PR DESCRIPTION
Adds a third parameter to detailFormatter method passing the jQuery element of the new cell that will contain the detail view. This allows a developer to render directly into the cell which can be advantageous in some circumstances. If the method returns with the element still empty the string returned from detailFormatter will be appended, maintaining backwards compatibility with previous versions.