### PR TITLE
Added new param for updateCell method to avoid table reinitialization

### DIFF
--- a/docs/_i18n/en/documentation/methods.md
+++ b/docs/_i18n/en/documentation/methods.md
@@ -161,6 +161,8 @@ The calling method syntax: `$('#table').bootstrapTable('method', parameter);`.
         index: the row index. <br>
         field: the field name.<br>
         value: the new field value.
+        <br>
+        To disable table re-initialization you can set <code>{reinit: false}</code>
         </td>
     </tr>
     <tr>

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -2390,8 +2390,7 @@
         }
         this.data[params.index][params.field] = params.value;
 
-        var reinit = params.reinit;
-        if (params.reinit===false || params.reinit === 'false') {
+        if (params.reinit === false || params.reinit === 'false') {
             return;
         }
         this.initSort();

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -2391,7 +2391,9 @@
         this.data[params.index][params.field] = params.value;
 
         var reinit = params.reinit;
-        if (reinit===false || reinit==='false') return;
+        if (params.reinit===false || params.reinit === 'false') {
+            return;
+        }
         this.initSort();
         this.initBody(true);
     };

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -2390,7 +2390,7 @@
         }
         this.data[params.index][params.field] = params.value;
 
-        if (params.reinit === false || params.reinit === 'false') {
+        if (params.reinit === false) {
             return;
         }
         this.initSort();

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1764,7 +1764,7 @@
     BootstrapTable.prototype.initServer = function (silent, query) {
         var that = this,
             data = {},
-            params = {                
+            params = {
                 searchText: this.searchText,
                 sortName: this.options.sortName,
                 sortOrder: this.options.sortOrder
@@ -2389,6 +2389,9 @@
             return;
         }
         this.data[params.index][params.field] = params.value;
+
+        var reinit = params.reinit;
+        if (reinit===false || reinit==='false') return;
         this.initSort();
         this.initBody(true);
     };


### PR DESCRIPTION
New parameter 'reinit' for updateCell method. Providing <code>{reinit:false}</code> when calling updateCell method,  initSort() and initBody() methods are not executed. New parameter helps to solve issue #1498