### PR TITLE
Load Grunt only in development

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "directories": {
     "doc": "docs"
   },
-  "dependencies": {
+  "devDependencies": {
     "grunt-contrib-copy": "^0.8.0",
     "grunt-contrib-concat": "^0.5.1",
     "grunt-contrib-clean": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "doc": "docs"
   },
   "devDependencies": {
+    "cz-conventional-changelog": "^1.1.5",
     "grunt-contrib-copy": "^0.8.0",
     "grunt-contrib-concat": "^0.5.1",
     "grunt-contrib-clean": "^0.6.0",
@@ -34,9 +35,6 @@
     "url": "https://github.com/wenzhixin/bootstrap-table/issues"
   },
   "homepage": "https://github.com/wenzhixin/bootstrap-table",
-  "devDependencies": {
-    "cz-conventional-changelog": "^1.1.5"
-  },
   "config": {
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"


### PR DESCRIPTION
This PR is a fix for #1902.

The benefit of this is that developers of the library still get Grunt when they checkout or download the source and run `npm install`, while end users don't get Grunt when they run `npm install bootstrap-table`.  End users don't need Grunt to be installed by this library because either they already have it on their own or they are not using it.