### PR TITLE
Fixed  key-events on toolbar elements

### DIFF
--- a/src/extensions/key-events/bootstrap-table-key-events.js
+++ b/src/extensions/key-events/bootstrap-table-key-events.js
@@ -32,7 +32,7 @@
                     $toggle = that.$toolbar.find('button[name="toggle"]'),
                     $paginationSwitch = that.$toolbar.find('button[name="paginationSwitch"]');
 
-                if (document.activeElement === $search.get(0)) {
+                if (document.activeElement === $search.get(0) || !$.contains(document.activeElement ,that.$toolbar.get(0))) {
                     return true;
                 }
 


### PR DESCRIPTION
Fixed  key-events, when the  's', 'r', 't', 'p', 'left', and 'right' keys are press on toolbar elements, the key-events it will not run.