### PR TITLE
Update css to fix no-border issue: #1936

### DIFF
--- a/src/bootstrap-table.css
+++ b/src/bootstrap-table.css
@@ -25,6 +25,10 @@
     border-right: 2px solid transparent;
 }
 
+.bootstrap-table .table.table-no-bordered > tbody > tr > td:last-child {
+    border-right: none;
+}
+
 .fixed-table-container {
     position: relative;
     clear: both;


### PR DESCRIPTION
**EDIT - IMPORTANT**

Just noticed the way he hiding that column in https://jsfiddle.net/gwjwin/gt0Ladad/1/

Instead, use `data-visible` like seen in https://jsfiddle.net/dabros/gt0Ladad/2/, and no issue

@wenzhixin - close this if you happy its his fault for not reading doco.

<br/>
---
**Original post content**
---

As seen in #1936, issues with scroll bars in no-border table

---

The issue appears to be this rule:

```css
.bootstrap-table .table.table-no-bordered > thead > tr > th, .bootstrap-table .table.table-no-bordered > tbody > tr > td {
    border-right: 2px solid transparent;
}
```

There is no matching rule when not `.table-no-bordered`.

If you just remove this (or change to `border-right:none`) the only side effect i can see is when there are results, small border appears between tbody > tr > td, which this 2px border covers (and ofcourse you lose a little bit of padding, though still 8px from td rule).

So to keep that 2px border padding but avoid scroll issue i added this rule:

```css
.bootstrap-table .table.table-no-bordered > tbody > tr > td:last-child {
    border-right: none;
}
```

This commit atm includes both rules, to keep the 2px border for whatever reason it was first created, though you could just change the 2px to `border-right:none` if that approach is preferred.