### PR TITLE
refactor filter cookies extension to avoid dbcalls

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1121,6 +1121,7 @@
             this.data = f ? $.grep(this.options.data, function (item, i) {
                 for (var key in f) {
                     if ($.isArray(f[key])) {
+                        // TODO: remove this extra if statement
                         if ($.inArray(item[key], f[key]) === -1) {
                             return false;
                         }

--- a/src/extensions/cookie/bootstrap-table-cookie.js
+++ b/src/extensions/cookie/bootstrap-table-cookie.js
@@ -133,6 +133,38 @@
         return cookieExpire === undefined ? '' : '; max-age=' + cookieExpire;
     };
 
+    var initCookieFilters = function (bootstrapTable) {
+        setTimeout(function () {
+            var parsedCookieFilters = JSON.parse(getCookie(bootstrapTable, bootstrapTable.options.cookieIdTable, cookieIds.filterControl));
+
+            if (!bootstrapTable.options.filterControlValuesLoaded && parsedCookieFilters) {
+                bootstrapTable.options.filterControlValuesLoaded = true;
+
+                var cachedFilters = {},
+                    header = getCurrentHeader(bootstrapTable),
+                    searchControls = getCurrentSearchControls(bootstrapTable),
+
+                    applyCookieFilters = function (element, filteredCookies) {
+                        $(filteredCookies).each(function (i, cookie) {
+                            $(element).val(cookie.text);
+                            cachedFilters[cookie.field] = cookie.text;
+                        });
+                    };
+
+                header.find(searchControls).each(function () {
+                    var field = $(this).closest('[data-field]').data('field'),
+                        filteredCookies = $.grep(parsedCookieFilters, function (cookie) {
+                            return cookie.field === field;
+                        });
+
+                    applyCookieFilters(this, filteredCookies);
+                });
+
+                bootstrapTable.initColumnSearch(cachedFilters);
+            }
+        }, 250);
+    }
+
     $.extend($.fn.bootstrapTable.defaults, {
         cookie: false,
         cookieExpire: '2h',
@@ -191,32 +223,7 @@
                 }
 
                 setCookie(that, cookieIds.filterControl, JSON.stringify(that.options.filterControls));
-            }).on('post-body.bs.table', function () {
-                setTimeout(function () {
-                    if (!that.options.filterControlValuesLoaded) {
-                        that.options.filterControlValuesLoaded = true;
-                        var filterControl = JSON.parse(getCookie(that, that.options.cookieIdTable, cookieIds.filterControl));
-                        if (filterControl) {
-                            var field = null,
-                                result = [],
-                                header = getCurrentHeader(that),
-                                searchControls = getCurrentSearchControls(that);
-
-                            header.find(searchControls).each(function (index, ele) {
-                                field = $(this).closest('[data-field]').data('field');
-                                result = $.grep(filterControl, function (valueObj) {
-                                    return valueObj.field === field;
-                                });
-
-                                if (result.length > 0) {
-                                    $(this).val(result[0].text);
-                                    that.onColumnSearch({currentTarget: $(this)});
-                                }
-                            });
-                        }
-                    }
-                }, 250);
-            });
+            }).on('post-body.bs.table', initCookieFilters(that));
         }
         _init.apply(this, Array.prototype.slice.apply(arguments));
     };

--- a/src/extensions/filter-control/bootstrap-table-filter-control.js
+++ b/src/extensions/filter-control/bootstrap-table-filter-control.js
@@ -448,6 +448,19 @@
         }) : this.data;
     };
 
+    BootstrapTable.prototype.initColumnSearch = function(filterColumnsDefaults) {
+        copyValues(this);
+
+        if (filterColumnsDefaults) {
+            this.filterColumnsPartial = filterColumnsDefaults;
+            this.updatePagination();
+
+            for (var filter in filterColumnsDefaults) {
+              this.trigger('column-search', filter, filterColumnsDefaults[filter]);
+            }
+        }
+    };
+
     BootstrapTable.prototype.onColumnSearch = function (event) {
         copyValues(this);
         var text = $.trim($(event.currentTarget).val());
@@ -464,7 +477,6 @@
 
         this.options.pageNumber = 1;
         this.onSearch(event);
-        this.updatePagination();
         this.trigger('column-search', $field, text);
     };
 


### PR DESCRIPTION
There was an incompatibility between the cookies extension and the
filter control extension, which resulted in the following behavior:
on page load, every time that a cookie was found, it would be added to a list of
filter, and it would query the database again. This would result in (for
example) a series of three filters to force three separate database
calls, each database call accumulating the same params from the last.

This update fixes this issue. it also incorporates the change from issue
 #1605 -- in which updatePagination is called by onSearch(), but both
are included in the onColumnSearch() function, causing the table to
double all calls to the database.