### PR TITLE
Remove extra db call to server when possible

### DIFF
--- a/src/extensions/filter-control/README.md
+++ b/src/extensions/filter-control/README.md
@@ -47,6 +47,13 @@ Dependence if you use the datepicker option: [bootstrap-datepicker](https://gith
 * description: Set to true if you want to use the strict search mode.
 * default: `false`
 
+### filterData
+
+* type: Object
+* description: Used to set default values for the `select` filterControl. Use this way:(in the document head)`var filterDefaults = {somekey: 'somevalue'}` (in the column th definition)`data-filter-data='var:filterDefaults'`. In order for the server to make only one call with serverside pagination, this field must be set for all selects. Otherwise, the client will make an initial call to the server to populate the dropdown list with data.
+* default: `undefined`
+
+
 ### Icons
 * clear: 'glyphicon-trash icon-clear'
 


### PR DESCRIPTION
Bootstrap table does a db call for initial data to the server. This
causes the client to make two db calls. one when the client initializes( gets default sorting), and another when filtering the database based on the cookies that are saved on the browser. this change removes that extra initial db call under three
conditions:

1) the cookies option is set to true
2) there are cookies associated to this table
3) all select dropdown filters have default values

this change also updates the documentation for filterControl, in order
to add the proper usage for the property `filterData`.