### PR TITLE
Methods 'updateRow' and 'updateByUniqueId' can now take either a row …

### DIFF
--- a/docs/_i18n/en/documentation/methods.md
+++ b/docs/_i18n/en/documentation/methods.md
@@ -108,7 +108,7 @@ The calling method syntax: `$('#table').bootstrapTable('method', parameter);`.
         <td>updateRow</td>
         <td>params</td>
         <td>
-        Update the specified row, the param contains following properties: <br>
+        Update the specified row(s), each param contains following properties: <br>
         index: the row index to be updated. <br>
         row: the new row data.
         </td>
@@ -117,7 +117,7 @@ The calling method syntax: `$('#table').bootstrapTable('method', parameter);`.
         <td>updateByUniqueId</td>
         <td>params</td>
         <td>
-        Update the specified row, the param contains following properties: <br>
+        Update the specified row(s), each param contains following properties: <br>
         id: a row id where the id should be the uniqueid field assigned to the table. <br>
         row: the new row data.
         </td>

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -2306,19 +2306,24 @@
     };
 
     BootstrapTable.prototype.updateByUniqueId = function (params) {
-        var rowId;
+        var that = this;
+        var allParams = $.isArray(params) ? params : [ params ];
 
-        if (!params.hasOwnProperty('id') || !params.hasOwnProperty('row')) {
-            return;
-        }
+        $.each(allParams, function(i, params) {
+            var rowId;
 
-        rowId = $.inArray(this.getRowByUniqueId(params.id), this.options.data);
+            if (!params.hasOwnProperty('id') || !params.hasOwnProperty('row')) {
+                return;
+            }
 
-        if (rowId === -1) {
-            return;
-        }
+            rowId = $.inArray(that.getRowByUniqueId(params.id), that.options.data);
 
-        $.extend(this.data[rowId], params.row);
+            if (rowId === -1) {
+                return;
+            }
+            $.extend(that.data[rowId], params.row);
+        });
+
         this.initSort();
         this.initBody(true);
     };
@@ -2335,10 +2340,16 @@
     };
 
     BootstrapTable.prototype.updateRow = function (params) {
-        if (!params.hasOwnProperty('index') || !params.hasOwnProperty('row')) {
-            return;
-        }
-        $.extend(this.data[params.index], params.row);
+        var that = this;
+        var allParams = $.isArray(params) ? params : [ params ];
+
+        $.each(allParams, function(i, params) {
+            if (!params.hasOwnProperty('index') || !params.hasOwnProperty('row')) {
+                return;
+            }
+            $.extend(that.data[params.index], params.row);
+        });
+
         this.initSort();
         this.initBody(true);
     };


### PR DESCRIPTION
Methods 'updateRow' and 'updateByUniqueId' can now take either a row or an array of rows as parameter.

This change allows an array of rows to be updated at once.

The alternative way is to call N times the "updateRow" for each updated row, however the "initSort" and "initBody" will also be done N times.

Allowing these methods to take an array of rows as parameter will remove the useless overhead cost of "initSort" and "initBody" calls.