### PR TITLE
Fix context for cols with same field and formatter

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1485,7 +1485,8 @@
                 csses = [],
                 data_ = '',
                 attributes = {},
-                htmlAttributes = [];
+                htmlAttributes = [],
+                fieldCounts = {};
 
             style = calculateObjectValue(this.options, this.options.rowStyle, [item, i], style);
 
@@ -1546,7 +1547,15 @@
                     data_ = '',
                     rowspan_ = '',
                     title_ = '',
-                    column = that.columns[getFieldIndex(that.columns, field)];
+                    column = {};
+
+                if (!fieldCounts.hasOwnProperty(field)) {
+                    fieldCounts[field] = 1;
+                } else {
+                    fieldCounts[field]++;
+                }
+
+                column = that.columns[getFieldIndex(that.columns, field, fieldCounts[field])];
 
                 if (!column.visible) {
                     return;

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -42,12 +42,18 @@
         return result;
     };
 
-    var getFieldIndex = function (columns, field) {
-        var index = -1;
+    var getFieldIndex = function (columns, field, fieldCount) {
+        var index = -1, count = 0;
 
         $.each(columns, function (i, column) {
             if (column.field === field) {
                 index = i;
+                count++;
+
+                if (fieldCount !== undefined) {
+                    return count < fieldCount;
+                }
+
                 return false;
             }
             return true;


### PR DESCRIPTION
Fix issue discovered in #1986 where columns of the same field and formatter would only ever send the context of the first column to said formatter