### PR TITLE
Fix #1991 - Call to `resetFooter` after save

### DIFF
--- a/src/extensions/editable/bootstrap-table-editable.js
+++ b/src/extensions/editable/bootstrap-table-editable.js
@@ -104,6 +104,7 @@
                     $(this).data('value', params.submitValue);
                     row[column.field] = params.submitValue;
                     that.trigger('editable-save', column.field, row, oldValue, $(this));
+                    that.resetFooter();
                 });
             that.$body.find('a[data-name="' + column.field + '"]').editable(column.editable)
                 .off('shown').on('shown', function (e, editable) {


### PR DESCRIPTION
Footer contents updated via call to `resetFooter` (which itself checks for `showFooter`) following call to save changes.
Fix for issue reported in #1991 
fiddle: http://jsfiddle.net/dabros/Lr056k01/1/