### PR TITLE
Fix #1578 : group-columns not updating on data-visible

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -737,7 +737,7 @@
                     $.each(column.parents,function(k,lookupStr) {              
                     	var lookupKeys = lookupStr.split("."),
                       	    parentCol = that.options.columns[lookupKeys[0]][lookupKeys[1]];
-                        parentCol.colspan += (column.visible) ? 1 : -1;
+                        parentCol.colspan += parentCol.colspan += (column.visible) ? 1 : (parentCol.colspan > 0) ? -1 : 0;
                         parentCol.visible = (parentCol.colspan > 0);
                   	});
                 }
@@ -799,6 +799,10 @@
                     }
 
                     visibleColumns[column.field] = column;
+                    
+                } else if (!column.visible) {
+                    // Fix #1578 - needed to pickup on multi-level th visibility
+                    return;
                 }
 
                 html.push('<th' + sprintf(' title="%s"', column.titleTooltip),

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -732,12 +732,12 @@
             
         $.each(this.options.columns, function(i, columns) {
             $.each(columns, function(j, column) {
-                column.colspan = 0;
+                column.colspan = 1;
                 if(typeof column.parents !== 'undefined') {
                     $.each(column.parents,function(k,lookupStr) {              
                     	var lookupKeys = lookupStr.split("."),
                       	    parentCol = that.options.columns[lookupKeys[0]][lookupKeys[1]];
-                        parentCol.colspan += parentCol.colspan += (column.visible) ? 1 : (parentCol.colspan > 0) ? -1 : 0;
+                        parentCol.colspan += (column.visible) ? 1 : (parentCol.colspan > 0) ? -1 : 0;
                         parentCol.visible = (parentCol.colspan > 0);
                   	});
                 }

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -732,12 +732,12 @@
             
         $.each(this.options.columns, function(i, columns) {
             $.each(columns, function(j, column) {
-                column.colspan = 1;
+                column.colspan = 0;
                 if(typeof column.parents !== 'undefined') {
                     $.each(column.parents,function(k,lookupStr) {              
                     	var lookupKeys = lookupStr.split("."),
                       	    parentCol = that.options.columns[lookupKeys[0]][lookupKeys[1]];
-                        parentCol.colspan += (column.visible) ? 1 : (parentCol.colspan > 0) ? -1 : 0;
+                        parentCol.colspan += (column.visible) ? 1 : (parentCol.colspan > 1) ? -1 : 0;
                         parentCol.visible = (parentCol.colspan > 0);
                   	});
                 }

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1840,7 +1840,8 @@
             }
 
             var field = that.header.fields[i],
-                fieldIndex = getFieldIndexFromColumnIndex(that.columns, i);
+                // Fix #1578 - TODO REVERTME DEBUG - temp disable to rule this out from breaking my changes
+                fieldIndex = $.inArray(field, that.getVisibleFields()); // getFieldIndexFromColumnIndex(that.columns, i);
 
             if (that.options.detailView && !that.options.cardView) {
                 fieldIndex += 1;

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -107,6 +107,32 @@
                 }
             }
         }
+        
+        var vColumns = []; // new Array(totalCol);
+        for(k = 0; k < totalCol; k++){
+            vColumns[k] = [];
+        }
+        
+        for (i = 0; i < columns.length; i++) {
+            var jCurrentCol = 0;
+            for (j = 0; j < columns[i].length; j++) {
+                var jColSpan = columns[i][j].colspan || 1;
+                
+                for(k = jCurrentCol; k < (jCurrentCol + jColSpan); k++)
+                {
+                	vColumns[k][i] = i + "." + j;
+                    if(i > 0) {
+                      	if(typeof columns[i][j].parents === 'undefined') {
+                        	columns[i][j].parents = [];
+                        }
+                        $.each(vColumns[k].slice(0,i), function(vcolInd,vcolVal) {
+            	          	columns[i][j].parents.push(vcolVal);            
+                        });
+                    }
+                }
+                jCurrentCol += jColSpan;
+            }
+        }
     };
 
     var getScrollBarWidth = function () {
@@ -703,6 +729,20 @@
             cellStyles: [],
             searchables: []
         };
+            
+        $.each(this.options.columns, function(i, columns) {
+            $.each(columns, function(j, column) {
+                column.colspan = 0;
+                if(typeof column.parents !== 'undefined') {
+                    $.each(column.parents,function(k,lookupStr) {              
+                    	var lookupKeys = lookupStr.split("."),
+                      	    parentCol = that.options.columns[lookupKeys[0]][lookupKeys[1]];
+                        parentCol.colspan += (column.visible) ? 1 : -1;
+                        parentCol.visible = (parentCol.colspan > 0);
+                  	});
+                }
+            });
+        });
 
         $.each(this.options.columns, function (i, columns) {
             html.push('<tr>');

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -120,7 +120,7 @@
                 
                 for(k = jCurrentCol; k < (jCurrentCol + jColSpan); k++)
                 {
-                	vColumns[k][i] = i + "." + j;
+                    vColumns[k][i] = i + "." + j;
                     if(i > 0) {
                       	if(typeof columns[i][j].parents === 'undefined') {
                         	columns[i][j].parents = [];


### PR DESCRIPTION
Fix #1578 - group-columns with varying data-visibility of any columns never updated colspan nor hid uneeded group-column/parents.

See usage at http://jsfiddle.net/dabros/92a57s7L/10/ (where local copy disabled and external resources posting to a specific commit is used)

Im still unsure whether my `vColumns` code (in `SetFieldIndex`) is most efficient approach, but setting parents there and overwriting `data-visible` & `colspan` in `initTable` is best approach i can think of.

I also take the assumption that lowest level (last group with parents) decide overall `data-visible` of the parents, but that makes sense as fiddle proves this works in usual approach and if you hide parent group-column but have child visible, that is user error so ofcourse parent group-column should be visible.
