### PR TITLE
Add data variable to post-body trigger

### DIFF
--- a/docs/_i18n/en/documentation/events.md
+++ b/docs/_i18n/en/documentation/events.md
@@ -204,7 +204,7 @@ $('#table').on('event-name.bs.table', function (e, arg1, arg2, ...) {
     <tr>
         <td>onPostBody</td>
         <td>post-body.bs.table</td>
-        <td>none</td>
+        <td>data</td>
         <td>Fires after the table body is rendered and available in the DOM</td>
     </tr>
     <tr>

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1825,7 +1825,7 @@
         this.updateSelected();
         this.resetView();
 
-        this.trigger('post-body');
+        this.trigger('post-body', data);
     };
 
     BootstrapTable.prototype.initServer = function (silent, query) {


### PR DESCRIPTION
The `onPreBody` event is passed the `data` variable, however, the `onPostBody` is not.  Am not sure if this is by design or just hadn't been implemented.

In my one use case, I want to execute the method `mergeCells` in `onPostBody()` and need access to the `data` variable.