### PR TITLE
fix #2014 - ints break getFieldIndex

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -610,6 +610,10 @@
             var column = [];
 
             $(this).find('th').each(function () {
+                // Fix #2014 - getFieldIndex and elsewhere assume this is string, causes issues if not
+                if (typeof $(this).data('field') !== 'undefined') {
+                    $(this).data('field', new String($(this).data('field')).valueOf()); 
+                }
                 column.push($.extend({}, {
                     title: $(this).html(),
                     'class': $(this).attr('class'),


### PR DESCRIPTION
fix #2014 - toggleColumn (due to getFieldIndex) fails unless column.field is string, and likely any other getFieldIndex calls too.

Force it to be stored as string around line 618 (`initTable`) 

OR fix when this is compared, which appears to only be line 49 (`getFieldIndex`). 

But since a wider search for ".field" showed the second approach might not cover all 'other' quirks if js doesnt natively store this as string, so went with forcing it in `initTable`. I went with `new String(oldval).valueOf()` over something like `"" + oldval` to help answer outside use cases as `new String()` (i assume) is more robust than forced concat.

Changes can be proofed using https://jsfiddle.net/dabros/johm6kd3/2/

---

As a side note, `var column` (~line 610) is misleading as it is actually the array of all columns in the current `<tr>`. Maybe a rename to `rowcols` would make this more obvious.