### PR TITLE
Add support for filter control select list data to be passed in as JSON string and filter control starts with search

### DIFF
--- a/src/extensions/filter-control/README.md
+++ b/src/extensions/filter-control/README.md
@@ -40,7 +40,7 @@ Dependence if you use the datepicker option: [bootstrap-datepicker](https://gith
 ### filterData
 
 * type: String
-* description: Set custom select filter values, use `var:variable` to load from a variable or `url:http://www.example.com/data.json` to load from json file. 
+* description: Set custom select filter values, use `var:variable` to load from a variable or `url:http://www.example.com/data.json` to load from a remote json file or `jso:{key:data}` to load from a json string. 
 * default: `undefined`
 
 ### filterDatepickerOptions

--- a/src/extensions/filter-control/README.md
+++ b/src/extensions/filter-control/README.md
@@ -53,6 +53,11 @@ Dependence if you use the datepicker option: [bootstrap-datepicker](https://gith
 * description: Set to true if you want to use the strict search mode.
 * default: `false`
 
+### filterStartsWithSearch
+* type: Boolean
+* description: Set to true if you want to use the starts with search mode.
+* default: `false`
+
 ### Icons
 * clear: 'glyphicon-trash icon-clear'
 

--- a/src/extensions/filter-control/bootstrap-table-filter-control.js
+++ b/src/extensions/filter-control/bootstrap-table-filter-control.js
@@ -222,6 +222,12 @@
                             addOptionToSelectControl(selectControl, key, variableValues[key]);
                         }
                         break;
+                    case 'jso':
+                        var variableValues = JSON.parse(filterDataSource);
+                        for (var key in variableValues) {
+                            addOptionToSelectControl(selectControl, key, variableValues[key]);
+                        }
+                        break;
                 }
             }
         });

--- a/src/extensions/filter-control/bootstrap-table-filter-control.js
+++ b/src/extensions/filter-control/bootstrap-table-filter-control.js
@@ -325,7 +325,8 @@
         filterControl: undefined,
         filterData: undefined,
         filterDatepickerOptions: undefined,
-        filterStrictSearch: false
+        filterStrictSearch: false,
+        filterStartsWithSearch: false
     });
 
     $.extend($.fn.bootstrapTable.Constructor.EVENTS, {
@@ -451,6 +452,13 @@
                         value.toString().toLowerCase() === fval.toString().toLowerCase())) {
                         return false;
                     }
+                }
+                else if(thisColumn.filterStartsWithSearch){
+                  if (!($.inArray(key, that.header.fields) !== -1 &&
+                      (typeof value === 'string' || typeof value === 'number') &&
+                      (value + '').toLowerCase().indexOf(fval) == 0)) {
+                      return false;
+                  }
                 }
                 else {
                     if (!($.inArray(key, that.header.fields) !== -1 &&


### PR DESCRIPTION
For my application, `var:variable` would not work as the variable is not accessible using `window`. This allows an object to be passed in like so:

    var data = {
      key1: 'text1',
      key2: 'text2'
    };
    filterData = 'jso:' + JSON.stringify(data);

`filterStartsWithSearch = true;` makes the search be a 'starts with' search. The default is false. If `filterStrictSearch = true` then `filterStartsWithSearch` is ignored, which makes sense because strict search implies starts with.