### PR TITLE
Fix methods updateRow and updateByUniqueId

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -2392,9 +2392,10 @@
             if (rowId === -1) {
                 return;
             }
-            $.extend(that.data[rowId], params.row);
+            $.extend(that.options.data[rowId], params.row);
         });
 
+        this.initSearch();
         this.initSort();
         this.initBody(true);
     };
@@ -2418,9 +2419,10 @@
             if (!params.hasOwnProperty('index') || !params.hasOwnProperty('row')) {
                 return;
             }
-            $.extend(that.data[params.index], params.row);
+            $.extend(that.options.data[params.index], params.row);
         });
 
+        this.initSearch();
         this.initSort();
         this.initBody(true);
     };


### PR DESCRIPTION
### Problem
In a grid with the "search" feature, the `updateRow` and `updateByUniqueId` methods doesn't correctly update the data when something has been writen by the user in the "search box".

The technique issue (from my point of view, maybe I'm wrong) is the use of `this.data` instead of `this.options.data` in these both methods. From what I understand, `this.data` is used for data after being sorted, filtered... and `this.options.data` for the original data.

If what I understand is correct, then I saw `this.data` used in other methods (like `insertRow`), but I'm waiting for a confirmation about if I'm wrong or not.


### Live example

#### Fiddle link:
- with the bug (current master): https://jsfiddle.net/Lightsephi/fger316d/
- without the bug (this branch): https://jsfiddle.net/Lightsephi/cjkddhk0/

#### Action to follow:
- enter "2" in the search box
- click on the "Update row" button
- observe results (1)
- clear the search box content
- observe again the results (2)

#### Expected behavior:
at (1), the second line should appear with the new value "2"
at (2), both lines are shown correctly with "2" in the value column

#### Actual behavior:
at (1), nothing change
at (2), the second line has still "3" in the value column. The row hasn't been updated.



