### PR TITLE
Adjusted the clicked column logic to take into account visibility.

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1728,7 +1728,7 @@
                 $tr = $td.parent(),
                 item = that.data[$tr.data('index')],
                 index = $td[0].cellIndex,
-                field = that.header.fields[that.options.detailView && !that.options.cardView ? index - 1 : index],
+                field = that.getVisibleFields()[that.options.detailView && !that.options.cardView ? index - 1 : index],
                 column = that.columns[getFieldIndex(that.columns, field)],
                 value = getItemField(item, field, that.options.escape);
 


### PR DESCRIPTION
An incorrect field is detected as soon as there an invisible column before the clicked cell's column.

Here's a test case to reproduce:

https://jsfiddle.net/ojf0035g/2/

Note how the first column (`Item ID`) is configured to be non clickable while it's not the case for the second one (`Item Name`) since it inherits the table `data-click-to-select="true"` option. If you try to click on a cell of the `Item Name` column you'll notice nothing happen.