### PR TITLE
field name with dot character

### DIFF
--- a/src/extensions/filter-control/bootstrap-table-filter-control.js
+++ b/src/extensions/filter-control/bootstrap-table-filter-control.js
@@ -144,7 +144,7 @@
 
             $.each(bootstrapTable.header.fields, function (j, field) {
                 var column = bootstrapTable.columns[$.fn.bootstrapTable.utils.getFieldIndex(bootstrapTable.columns, field)],
-                    selectControl = $('.' + column.field);
+                    selectControl = $('.' + escapeID(column.field));
 
 
                 if (isColumnSearchableViaSelect(column) && isFilterDataNotGiven(column) && hasSelectControlElement(selectControl)) {
@@ -163,6 +163,10 @@
         }
 
     };
+    
+    var escapeID = function( id ) {
+       return String(id).replace( /(:|\.|\[|\]|,)/g, "\\$1" );
+    }
 
     var createControls = function (that, header) {
         var addedFilterControl = false,
@@ -201,7 +205,7 @@
             if (column.filterData !== undefined && column.filterData.toLowerCase() !== 'column') {
                 var filterDataType = column.filterData.substring(0, 3);
                 var filterDataSource = column.filterData.substring(4, column.filterData.length);
-                var selectControl = $('.' + column.field);
+                var selectControl = $('.' + escapeID(column.field));
                 addOptionToSelectControl(selectControl, '', '');
 
                 switch (filterDataType) {


### PR DESCRIPTION
Prevent error when field name is like this "field.name".
I escape field name so filter inputs can be found using jquery, because you are searching an object in jquery like $(.field.name) you will get undefined.