### PR TITLE
editable columns error when refreshOptions

### DIFF
--- a/src/extensions/editable/bootstrap-table-editable.js
+++ b/src/extensions/editable/bootstrap-table-editable.js
@@ -60,6 +60,9 @@
 
             $.each(that.options, processDataOptions);
 
+			column.formatter || column.formatter = function (value, row, index) {
+				return value;
+			};
             column._formatter = column._formatter? column._formatter: column.formatter;
             column.formatter = function (value, row, index) {
                 var result = column._formatter? column._formatter(value, row, index): value;

--- a/src/extensions/editable/bootstrap-table-editable.js
+++ b/src/extensions/editable/bootstrap-table-editable.js
@@ -60,9 +60,9 @@
 
             $.each(that.options, processDataOptions);
 
-            var _formatter = column.formatter;
+            column._formatter = column._formatter? column._formatter: column.formatter;
             column.formatter = function (value, row, index) {
-                var result = _formatter ? _formatter(value, row, index) : value;
+                var result = column._formatter? column._formatter(value, row, index): value;
 
                 $.each(column, processDataOptions);
 

--- a/src/extensions/editable/bootstrap-table-editable.js
+++ b/src/extensions/editable/bootstrap-table-editable.js
@@ -60,9 +60,9 @@
 
             $.each(that.options, processDataOptions);
 
-			column.formatter || column.formatter = function (value, row, index) {
-				return value;
-			};
+            column.formatter || column.formatter = function (value, row, index) {
+                return value;
+            };
             column._formatter = column._formatter? column._formatter: column.formatter;
             column.formatter = function (value, row, index) {
                 var result = column._formatter? column._formatter(value, row, index): value;


### PR DESCRIPTION
failed to render editable columns after 'refreshOptions'. https://github.com/wenzhixin/bootstrap-table/issues/2120. I stored the formatter function defined in `columns` option as  column._formatter. When 'refreshOptions' method is called, `column._formatter` will be checked and called firstly.