### PR TITLE
Add rememberOrder option to table

### DIFF
--- a/docs/_i18n/en/documentation/table-options.md
+++ b/docs/_i18n/en/documentation/table-options.md
@@ -87,8 +87,8 @@ The table options are defined in `jQuery.fn.bootstrapTable.defaults`.
         <td>rememberOrder</td>
         <td>data-remember-order</td>
         <td>Boolean</td>
-        <td>true</td>
-        <td>Set <code>false</code> to reset the order to the default (set by column's order attribute) on every sort action for a column that is not currently sorted.</td>
+        <td>false</td>
+        <td>Set <code>true</code> remember the order for each column.</td>
     </tr>
     <tr>
         <td>iconsPrefix</td>

--- a/docs/_i18n/en/documentation/table-options.md
+++ b/docs/_i18n/en/documentation/table-options.md
@@ -84,6 +84,13 @@ The table options are defined in `jQuery.fn.bootstrapTable.defaults`.
         <td>True to get a stable sorting. We will add <code>_position</code> property to the row.</td>
     </tr>
     <tr>
+        <td>rememberOrder</td>
+        <td>data-remember-order</td>
+        <td>Boolean</td>
+        <td>true</td>
+        <td>Set <code>false</code> to reset the order to the default (set by column's order attribute) on every sort action for a column that is not currently sorted.</td>
+    </tr>
+    <tr>
         <td>iconsPrefix</td>
         <td>data-icons-prefix</td>
         <td>String</td>

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -286,6 +286,7 @@
         sortName: undefined,
         sortOrder: 'asc',
         sortStable: false,
+        rememberOrder: true,
         striped: false,
         columns: [[]],
         data: [],
@@ -1020,7 +1021,11 @@
             this.options.sortOrder = this.options.sortOrder === 'asc' ? 'desc' : 'asc';
         } else {
             this.options.sortName = $this.data('field');
-            this.options.sortOrder = $this.data('order') === 'asc' ? 'desc' : 'asc';
+            if(this.options.rememberOrder) {
+                this.options.sortOrder = $this.data('order') === 'asc' ? 'desc' : 'asc';
+            } else {
+                this.options.sortOrder = this.options.columns[0].find(function(option) { return option.field === $this.data('field'); }).order;
+            }
         }
         this.trigger('sort', this.options.sortName, this.options.sortOrder);
 

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -286,7 +286,7 @@
         sortName: undefined,
         sortOrder: 'asc',
         sortStable: false,
-        rememberOrder: true,
+        rememberOrder: false,
         striped: false,
         columns: [[]],
         data: [],
@@ -1021,10 +1021,12 @@
             this.options.sortOrder = this.options.sortOrder === 'asc' ? 'desc' : 'asc';
         } else {
             this.options.sortName = $this.data('field');
-            if(this.options.rememberOrder) {
+            if (this.options.rememberOrder) {
                 this.options.sortOrder = $this.data('order') === 'asc' ? 'desc' : 'asc';
             } else {
-                this.options.sortOrder = this.options.columns[0].find(function(option) { return option.field === $this.data('field'); }).order;
+                this.options.sortOrder = this.options.columns[0].filter(function(option) {
+                    return option.field === $this.data('field');
+                })[0].order;
             }
         }
         this.trigger('sort', this.options.sortName, this.options.sortOrder);


### PR DESCRIPTION
Applies the changes indicated in #2141.
This provides more natural and intuitive behaviour. When the option is set to false, on a first click on a sort arrow for a column that is not currently sorted, table always gets sorted in the same order, thus only when followed by a second click it gets sorted in the opposite order.
