### PR TITLE
Fix the clickToSelect to work correctly with links

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1670,8 +1670,8 @@
             that.trigger(e.type === 'click' ? 'click-cell' : 'dbl-click-cell', field, value, item, $td);
             that.trigger(e.type === 'click' ? 'click-row' : 'dbl-click-row', item, $tr);
 
-            // if click to select - then trigger the checkbox/radio click
-            if (e.type === 'click' && that.options.clickToSelect && column.clickToSelect) {
+            // if click to select - then trigger the checkbox/radio click unless the target is a link
+            if (e.type === 'click' && that.options.clickToSelect && column.clickToSelect && !$(e.target).is('a')) {
                 var $selectItem = $tr.find(sprintf('[name="%s"]', that.options.selectItemName));
                 if ($selectItem.length) {
                     $selectItem[0].click(); // #144: .trigger('click') bug


### PR DESCRIPTION
Fixes #2154. As described the row should be selected on click only when the target is not a link, so user can easily open a link in a new tab with middle-click without selecting the checkbox.
Example: https://jsfiddle.net/20rxmcxt/