### PR TITLE
Don't click the checkbox if it is the first field

### DIFF
--- a/src/extensions/filter-control/bootstrap-table-filter-control.js
+++ b/src/extensions/filter-control/bootstrap-table-filter-control.js
@@ -499,7 +499,10 @@
             // which ones are going to be present.
             if (controls.length > 0) {
                 this.filterColumnsPartial = {};
-                $(controls[0]).trigger(controls[0].tagName === 'INPUT' ? 'keyup' : 'change');
+                var element = _.find(controls, function(value) {
+                  return !(value.tagName == 'INPUT' && value.type == 'checkbox')
+                });
+                $(element).trigger(element.tagName === 'INPUT' ? 'keyup' : 'change');
             }
 
             if (search.length > 0) {


### PR DESCRIPTION
If you use a checkbox in the first column to enable/disable all rows,
this field gets clicked when clicking the clear button. Which leads
to a filter with "checkbox" "on" state.

This fix searches for the first field that is not a checkbox.
