### PR TITLE
Fix for #2220

### DIFF
--- a/src/extensions/export/bootstrap-table-export.js
+++ b/src/extensions/export/bootstrap-table-export.js
@@ -100,6 +100,15 @@
                         var data = that.getData(),
                             selectedData = that.getAllSelections();
 
+                        // Quick fix #2220
+                        if (that.options.sidePagination === 'server') {
+                            data = {total: that.options.totalRows};
+                            data[that.options.dataField] = that.getData();
+
+                            selectedData = {total: that.options.totalRows};
+                            selectedData[that.options.dataField] = that.getAllSelections();
+                        }
+
                         that.load(selectedData);
                         doExport();
                         that.load(data);


### PR DESCRIPTION
Quick fix for #2220, but looks like overall this needs a bit of refactoring since it's a workaround. This only solves the problem with exporting selected data - exporting all still does not work. 

The problem this has solved is that `load` expects the data in the format I've written there when `data-side-pagination=true`. Ideally it would be best to avoid needing to check that condition since the data has already been standardised on the first call to `load`, but I thought for now it's best not to touch the code base that much when there are no unit tests etc. If there is a more permanent fix that doesn't require a lot of refactoring, let me know and I'll amend it.