### PR TITLE
Fix #1556: Properly set main entry in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bootstrap-table",
   "description": "An extended Bootstrap table with radio, checkbox, sort, pagination, and other added features. (supports twitter bootstrap v2 and v3).",
   "version": "1.10.1",
-  "main": "Gruntfile.js",
+  "main": "./dist/bootstrap-table.js",
   "directories": {
     "doc": "docs"
   },


### PR DESCRIPTION
This makes it possible to use boostrap-table with webpack or browserify with a simple
```javascript
require('bootstrap-table');
```