### PR TITLE
Adding support for custom sorters – multi-sort (sortPriority)

### DIFF
--- a/src/extensions/multiple-sort/bootstrap-table-multiple-sort.js
+++ b/src/extensions/multiple-sort/bootstrap-table-multiple-sort.js
@@ -204,7 +204,7 @@
             return {
               asc: 'Ascending',
               desc: 'Descending'
-            }
+        }
         }
     });
 
@@ -298,11 +298,21 @@
                 if (typeof aa !== 'string') {
                     aa = aa.toString();
                 }
+                var hasSorter = $.grep(that.columns, function(e){
+                    return (e.field === that.options.sortPriority[i].sortName && e.sorter)
+                });
+                
+                var sorter;
+                if (hasSorter[0]) {
+                    sorter = hasSorter[0].sorter;
+                } else {
+                    sorter = cmp;
+                }
 
                 arr1.push(
-                    order * cmp(aa, bb));
+                    order * sorter(aa, bb));
                 arr2.push(
-                    order * cmp(bb, aa));
+                    order * sorter(bb, aa));
             }
 
             return cmp(arr1, arr2);


### PR DESCRIPTION
If a custom sorter exists, use it.  Otherwise, use the default sorter function.  

Currently, having a custom sorter + multi-sort gets messed up since the default sorter is not apt for all cases.

This should make it so that sortPriority = [{"sortName":"DAY_ID","sortOrder":"desc"},{"sortName":"RESPONSES","sortOrder":"desc"}] works even when the DAY_ID and RESPONSES fields have custom sorters.
