### PR TITLE
fix #2188. Reset the offset to 0 on Table refresh

### DIFF
--- a/docs/_i18n/en/documentation/table-options.md
+++ b/docs/_i18n/en/documentation/table-options.md
@@ -619,5 +619,12 @@ function rowStyle(value, row, index) {
         if no locale files loaded).
         </td>
     </tr>
+    <tr>
+        <td>resetOffset</td>
+        <td>data-reset-offset</td>
+        <td>Boolean</td>
+        <td>False</td>
+        <td>True will set pageNumber to 1. Offset will be 0 while pageNumber is 1</td>
+    </tr>
    </tbody>
 </table>

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -359,6 +359,8 @@
         iconSize: undefined,
         buttonsClass: 'default',
         iconsPrefix: 'glyphicon', // glyphicon of fa (font awesome)
+        // fix #2188. Reset the offset to 0 on Table refresh
+        resetOffset: false,
         icons: {
             paginationSwitchDown: 'glyphicon-collapse-down icon-chevron-down',
             paginationSwitchUp: 'glyphicon-collapse-up icon-chevron-up',
@@ -2690,6 +2692,11 @@
     };
 
     BootstrapTable.prototype.refresh = function (params) {
+        // fix #2188. Reset the offset to 0 on Table refresh
+        if (params && params.resetOffset) {
+            this.options.resetOffset = true;
+            this.options.pageNumber = 1;
+        }
         if (params && params.url) {
             this.options.pageNumber = 1;
         }


### PR DESCRIPTION
Use refresh example:
$('#table').bootstrapTable('refresh', {resetOffset: true});
