### PR TITLE
added 'field' from description into parameter column

### DIFF
--- a/docs/_i18n/en/documentation/events.md
+++ b/docs/_i18n/en/documentation/events.md
@@ -44,7 +44,7 @@ $('#table').on('event-name.bs.table', function (e, arg1, arg2, ...) {
     <tr>
         <td>onClickRow</td>
         <td>click-row.bs.table</td>
-        <td>row, $element</td>
+        <td>row, $element, field</td>
         <td>
         Fires when user click a row, the parameters contain: <br>
         row: the record corresponding to the clicked row, <br>
@@ -55,7 +55,7 @@ $('#table').on('event-name.bs.table', function (e, arg1, arg2, ...) {
     <tr>
         <td>onDblClickRow</td>
         <td>dbl-click-row.bs.table</td>
-        <td>row, $element</td>
+        <td>row, $element, field</td>
         <td>
         Fires when user double click a row, the parameters contain: <br>
         row: the record corresponding to the clicked row, <br>


### PR DESCRIPTION
added 'field' from description into parameter column

Mentioned in right column, but make more visible and consistent with other events doco

**IMPORTANT** 

@wenzhixin @djhvscf 

was looking at adding referance to when `this`could be used to access table object, as ive had to repeat it multiple times for various issues. 

Im just a little unsure of which or all events that applies to, as consistency is key for doco, and i really think pointing users to that for all relevant events can help them out alot (i certaintly didnt realise it till it was raised to me, makes absolute sense now why `$element` and such are param, but wouldnt have occured to me in advance, and other users making some mistake)