### PR TITLE
After reordering columns, reinitialise the toolbar

### DIFF
--- a/src/extensions/reorder-columns/bootstrap-table-reorder-columns.js
+++ b/src/extensions/reorder-columns/bootstrap-table-reorder-columns.js
@@ -144,6 +144,7 @@
                 for (var i = 0; i < ths.length; i++ ) {
                     columnIndex = $.fn.bootstrapTable.utils.getFieldIndex(that.columns, ths[i]);
                     if (columnIndex !== -1) {
+                        that.columns[columnIndex].fieldIndex = i;
                         columns.push(that.columns[columnIndex]);
                         that.columns.splice(columnIndex, 1);
                     }
@@ -169,7 +170,9 @@
 
                 that.header.fields = ths;
                 that.header.formatters = formatters;
+                that.initHeader();
                 that.initToolbar();
+                that.initBody();
                 that.resetView();
                 that.trigger('reorder-column', ths);
             }

--- a/src/extensions/reorder-columns/bootstrap-table-reorder-columns.js
+++ b/src/extensions/reorder-columns/bootstrap-table-reorder-columns.js
@@ -169,6 +169,7 @@
 
                 that.header.fields = ths;
                 that.header.formatters = formatters;
+                that.initToolbar();
                 that.resetView();
                 that.trigger('reorder-column', ths);
             }


### PR DESCRIPTION
This pull requests fixes a bug with the reorder columns extension.

Steps to reproduce:
- Open http://issues.wenzhixin.net.cn/bootstrap-table/#extensions/reorder-columns.html
- Drag and drop column ID to the second position
- Click on the top right icon, to open the menu to hide/show columns
- Click the checkbox for "Item Name"
- Instead of hiding the "Item Name" column, the "ID" column is hidden

I found out that "resetView" did not update the toolbar menu. We need to run "initToolbar" too after a column reorder.
