### PR TITLE
Prevent use of multiSort function after table loading when sorting server side.

### DIFF
--- a/src/extensions/multiple-sort/bootstrap-table-multiple-sort.js
+++ b/src/extensions/multiple-sort/bootstrap-table-multiple-sort.js
@@ -244,7 +244,7 @@
             });
 
             this.$el.on('load-success.bs.table', function() {
-                if (!isSingleSort && that.options.sortPriority !== null && typeof that.options.sortPriority === 'object') {
+                if (!isSingleSort && that.options.sortPriority !== null && typeof that.options.sortPriority === 'object' && that.options.sidePagination !== 'server') {
                     that.onMultipleSort();
                 }
             });


### PR DESCRIPTION
I'm binding to the `multiple-sort.bs.table` event to trigger `bootstrapTable('refresh')` but without this change it goes into an infinite loop of requests. 
