### PR TITLE
Decrement totalRows on remove if using serverside pagination

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -2391,6 +2391,9 @@
             }
             if ($.inArray(row[params.field], params.values) !== -1) {
                 this.options.data.splice(i, 1);
+                if (this.options.sidePagination === 'server') {
+                    this.options.totalRows -= 1;
+                }
             }
         }
 


### PR DESCRIPTION
Bootstrap tables does not decrement the number of total rows when a row is removed with serverside pagination enabled. 

This causes an issue when someone removes all rows in the last page. In that case the calculated offset is invalid and will show an empty table as result. This fix decrements the total number of rows set by the server and will fix this behavior after a table refresh.