### PR TITLE
fixed page list

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1377,7 +1377,7 @@
             }
 
             $.each(pageList, function (i, page) {
-                if (!that.options.smartDisplay || i === 0 || pageList[i - 1] <= that.options.totalRows) {
+                if (!that.options.smartDisplay || i === 0 || pageList[i - 1] < that.options.totalRows) {
                     var active;
                     if ($allSelected) {
                         active = page === that.options.formatAllRows() ? ' class="active"' : '';


### PR DESCRIPTION
If the total number of records matches one of the numbers in the page list, the next next greater number in the page list is still displayed when it should not be. 

Example...
http://jsfiddle.net/e3nk137y/7102/

In this case there are 65 total records so the page list should be 10,25,50,65. But it also shows 100 which it shouldn't.