### PR TITLE
Fixed a bug in the calculation of toolbar and pagination heights

### DIFF
--- a/src/bootstrap-table.css
+++ b/src/bootstrap-table.css
@@ -304,3 +304,10 @@ div.fixed-table-scroll-outer {
     height: 150px;
     overflow: hidden;
 }
+
+/* for get correct heights  */
+.fixed-table-toolbar:after, .fixed-table-pagination:after {
+  content:"";
+  display:block;
+  clear:both;
+}

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -190,16 +190,6 @@
         return text;
     };
 
-    var getRealHeight = function ($el) {
-        var height = 0;
-        $el.children().each(function () {
-            if (height < $(this).outerHeight(true)) {
-                height = $(this).outerHeight(true);
-            }
-        });
-        return height;
-    };
-
     var getRealDataAttr = function (dataAttr) {
         for (var attr in dataAttr) {
             var auxAttr = attr.split(/(?=[A-Z])/).join('-').toLowerCase();
@@ -2297,8 +2287,8 @@
             this.$selectItem.length === this.$selectItem.filter(':checked').length);
 
         if (this.options.height) {
-            var toolbarHeight = getRealHeight(this.$toolbar),
-                paginationHeight = getRealHeight(this.$pagination),
+            var toolbarHeight = this.$toolbar.outerHeight(true),
+                paginationHeight = this.$pagination.outerHeight(true),
                 height = this.options.height - toolbarHeight - paginationHeight;
 
             this.$tableContainer.css('height', height + 'px');


### PR DESCRIPTION
Fixed a bug in the calculation of toolbar and pagination heights, if there is a inner div on the next line.
Demo bug: http://jsfiddle.net/xbyoLyxt/3/
Demo fix: http://jsfiddle.net/1dLt903z/1/

".fixed-table-toolbar", ".fixed-table-pagination" may contain two floating div. If inner div on the next line then function "getRealHeight" return incorrect value.
For get correct height with call outerHeight(true) need add clearfix solution (http://stackoverflow.com/a/1633170). Function "getRealHeight" is no longer used.