### PR TITLE
Make 'selected' export properly using server pagination

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -2347,7 +2347,9 @@
         if (this.options.sidePagination === 'server') {
             this.options.totalRows = data.total;
             fixedScroll = data.fixedScroll;
-            data = data[this.options.dataField];
+            if (!$.isArray(data)) {
+                data = data[this.options.dataField];
+            }
         } else if (!$.isArray(data)) { // support fixedScroll
             fixedScroll = data.fixedScroll;
             data = data.data;


### PR DESCRIPTION
When using server side pagination, and export method is 'selected',
the original method will download all the data in the page.
The new method will download only selected rows.
Because selected rows are wrapped in an array, it does not have 'rows' field.
