### PR TITLE
correction regex to match 'mi'

### DIFF
--- a/src/extensions/cookie/bootstrap-table-cookie.js
+++ b/src/extensions/cookie/bootstrap-table-cookie.js
@@ -104,7 +104,7 @@
 
     var calculateExpiration = function(cookieExpire) {
         var time = cookieExpire.replace(/[0-9]*/, ''); //s,mi,h,d,m,y
-        cookieExpire = cookieExpire.replace(/[A-Za-z]/, ''); //number
+        cookieExpire = cookieExpire.replace(/[A-Za-z]{1,2}}/, ''); //number
 
         switch (time.toLowerCase()) {
             case 's':


### PR DESCRIPTION
Fixes #2515 

The current Regex replace only one character.
"10s" = "10"
"10mi" = "10i"

Therefore is the max-age = NaN

The Safari Browser dont accept a cookie with max-age = NaN