### PR TITLE
Add column level string escaping

### DIFF
--- a/docs/_i18n/en/documentation/column-options.md
+++ b/docs/_i18n/en/documentation/column-options.md
@@ -254,5 +254,14 @@ function cellStyle(value, row, index, field) {
         True to search use formated data.
         </td>
     </tr>
+    <tr>
+        <td>escape</td>
+        <td>data-escape</td>
+        <td>Boolean</td>
+        <td>false</td>
+        <td>
+        Escapes a string for insertion into HTML, replacing &, <, >, ", `, and ' characters.
+        </td>
+    </tr>
 </tbody>
 </table>

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -524,7 +524,8 @@
         cellStyle: undefined,
         searchable: true,
         searchFormatter: true,
-        cardVisible: true
+        cardVisible: true,
+        escape : false
     };
 
     BootstrapTable.EVENTS = {
@@ -826,6 +827,10 @@
                     text = '';
                     that.header.stateField = column.field;
                     that.options.singleSelect = true;
+                }
+                
+                if(column.escape) {
+                	that.options.escapeColumn = true;
                 }
 
                 html.push(text);
@@ -1699,6 +1704,10 @@
 
                 if (that.options.cardView && !column.cardVisible) {
                     return;
+                }
+                
+                if(that.columns[j].escape) {
+                	value_ = escapeHTML(value_);
                 }
 
                 style = sprintf('style="%s"', csses.concat(that.header.styles[j]).join('; '));

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -830,10 +830,6 @@
                     that.header.stateField = column.field;
                     that.options.singleSelect = true;
                 }
-                
-                if(column.escape) {
-                	that.options.escapeColumn = true;
-                }
 
                 html.push(text);
                 html.push('</div>');


### PR DESCRIPTION
https://github.com/wenzhixin/bootstrap-table/issues/1049

Issue 1049 was resolved by adding a table-wide escape option.  This pull request adds the ability to escape on the column level so certain columns can still have markup in them with the `data-escape` attribute on the `<th>` element.
