### PR TITLE
The error in the method getItemField

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -210,7 +210,9 @@
         }
         var props = field.split('.');
         for (var p in props) {
-            value = value && value[props[p]];
+            if (props.hasOwnProperty(p)) {
+                value = value && value[props[p]];
+            }
         }
         return escape ? escapeHTML(value) : value;
     };


### PR DESCRIPTION
In actual version of bootstrap-table (1.11.0) found an error that occurs when if the application code is available code: 
`Array.prototype.xxx = function () {}`
A detailed written about the issue [here](http://stackoverflow.com/questions/780422/what-causes-this-error-with-for-in-after-assigning-array-prototype-indexof).

To fix the error in the method getItemField should be added to the condition with hasOwnProperty:
```
for (var p in props) {
    if (props.hasOwnProperty(p)) {
        value = value && value[props[p]];
    }
```}