### PR TITLE
Print extension - add printFormatter column option

### DIFF
--- a/src/extensions/print/README.md
+++ b/src/extensions/print/README.md
@@ -48,6 +48,12 @@ Adds a button to the toolbar for printing the table in a predefined configurable
 * description: set true to hide this column in the printed page. 
 * default: `false`
 
+### printFormatter
+
+* type: Function
+* description: function(value, row, index) - returns a string. Formats the cell values for this column in the printed table. Function behaviour is similar to the 'formatter' column option
+* default: `undefined`
+
 ## Icons
 
 * print: `'glyphicon-print icon-share'`

--- a/src/extensions/print/bootstrap-table-print.js
+++ b/src/extensions/print/bootstrap-table-print.js
@@ -27,7 +27,8 @@
     });
     $.extend($.fn.bootstrapTable.COLUMN_DEFAULTS, {
         printFilter: undefined, //set value to filter by in print page
-        printIgnore: false //boolean, set true to ignore this column in the print page
+        printIgnore: false, //boolean, set true to ignore this column in the print page
+        printFormatter:undefined //function(value, row, index), formats the cell value for this column in the printed table. Function behaviour is similar to the 'formatter' column option
     });
     $.extend($.fn.bootstrapTable.defaults.icons, {
         print: 'glyphicon-print icon-share'
@@ -53,6 +54,15 @@
                     '</button>'].join('')).appendTo($btnGroup);
 
                 $print.click(function () {
+                    function formatValue(row, i, column ) {
+                        var value = row[column.field];
+                        if (typeof column.printFormatter === 'function') {
+                            return  column.printFormatter.apply(column, [value, row, i]);
+                        }
+                        else {
+                            return  value || "-";
+                        }
+                    }
                     function buildTable(data,columns) {
                         var out = "<table><thead><tr>";
                         for(var h = 0; h < columns.length; h++) {
@@ -65,7 +75,7 @@
                             out += "<tr>";
                             for(var j = 0; j < columns.length; j++) {
                                 if(!columns[j].printIgnore) {
-                                    out += ("<td>"+(data[i][columns[j].field]||"-")+"</td>");
+                                    out += ("<td>"+ formatValue(data[i], i, columns[j])+"</td>");
                                 }
                             }
                             out += "</tr>";


### PR DESCRIPTION
New column option 'printFormatter':  a function that formats the cell values for this column in the printed table. Function behaviour is similar to the 'formatter' column option
