### PR TITLE
print extension - retain UI filtering and sort order

### DIFF
--- a/src/extensions/print/README.md
+++ b/src/extensions/print/README.md
@@ -16,6 +16,12 @@ Adds a button to the toolbar for printing the table in a predefined configurable
 * description: Set true to show the Print button on the toolbar.
 * default: `false`
 
+### printAsFilteredAndSortedOnUI
+
+* type: Boolean
+* description: When true - print table as sorted and filtered on UI. Please note that if true is set, along with explicit predefined print options for filtering and sorting (printFilter, printSortOrder, printSortColumn)- then they will be applied on data already filtered and sorted by UI controls. For printing data as filtered and sorted on UI - do not set these 3 options: printFilter, printSortOrder, printSortColumn
+* default: `true`
+
 ### printSortColumn
 
 * type: String

--- a/src/extensions/print/bootstrap-table-print.js
+++ b/src/extensions/print/bootstrap-table-print.js
@@ -21,6 +21,9 @@
     }
     $.extend($.fn.bootstrapTable.defaults, {
         showPrint: false,
+        printAsFilteredAndSortedOnUI: true, //boolean, when true - print table as sorted and filtered on UI.
+                                            //Please note that if true is set, along with explicit predefined print options for filtering and sorting (printFilter, printSortOrder, printSortColumn)- then they will be applied on data already filtered and sorted by UI controls.
+                                            //For printing data as filtered and sorted on UI - do not set these 3 options:printFilter, printSortOrder, printSortColumn
         printSortColumn: undefined  , //String, set column field name to be sorted by
         printSortOrder: 'asc', //String: 'asc' , 'desc'  - relevant only if printSortColumn is set
         printPageBuilder: function(table){return printPageBuilderDefault(table)} // function, receive html <table> element as string, returns html string for printing. by default delegates to function printPageBuilderDefault(table). used for styling and adding header or footer
@@ -112,7 +115,7 @@
                         newWin.print();
                         newWin.close();
                     };
-                    doPrint(that.options.data.slice(0));
+                    doPrint(that.options.printAsFilteredAndSortedOnUI? that.getData() : that.options.data.slice(0));
                 });
             }
         }


### PR DESCRIPTION
Added boolean option - **printAsFilteredAndSortedOnUI**.  Default: _true_.
When true - print table as sorted and filtered on UI.
