### PR TITLE
Export extension: support .xlsx format

### DIFF
--- a/src/extensions/export/README.md
+++ b/src/extensions/export/README.md
@@ -25,7 +25,7 @@ Use Plugin: [tableExport.jquery.plugin](https://github.com/hhurz/tableExport.jqu
 ### exportTypes
 
 * type: Array
-* description: export types, support types: 'json', 'xml', 'png', 'csv', 'txt', 'sql', 'doc', 'excel', 'pdf'.
+* description: export types, support types: 'json', 'xml', 'png', 'csv', 'txt', 'sql', 'doc', 'excel', 'xlsx', 'pdf'.
 * default: `['json', 'xml', 'csv', 'txt', 'sql', 'excel']`
 
 ### exportOptions

--- a/src/extensions/export/bootstrap-table-export.js
+++ b/src/extensions/export/bootstrap-table-export.js
@@ -16,6 +16,7 @@
         sql: 'SQL',
         doc: 'MS-Word',
         excel: 'MS-Excel',
+        xlsx: 'MS-Excel (OpenXML)',
         powerpoint: 'MS-Powerpoint',
         pdf: 'PDF'
     };


### PR DESCRIPTION
Plugin [tableExport.jquery.plugin](https://github.com/hhurz/tableExport.jquery.plugin) is already supported .xlsx format (Office Open XML Workbook, or someone called 'MS Excel 2007+ XML Format'), just modified for that.
