### PR TITLE
Bootstrap Table Defer URL Extension

### DIFF
--- a/src/extensions/defer-url/README.md
+++ b/src/extensions/defer-url/README.md
@@ -1,0 +1,17 @@
+# Table Defer URL
+
+Use Plugin: [bootstrap-table-defer-url](https://github.com/wenzhixin/bootstrap-table/tree/master/src/extensions/defer-url)
+
+## Usage
+
+```html
+<script src="extensions/defer-url/bootstrap-table-defer-url.js"></script>
+```
+
+## Options
+
+### deferUrl
+
+* type: String
+* description: When using server-side processing, the default mode of operation for bootstrap-table is to simply throw away any data that currently exists in the table and make a request to the server to get the first page of data to display. This is fine for an empty table, but if you already have the first page of data displayed in the plain HTML, it is a waste of resources. As such, you can use data-defer-url instead of data-url to allow you to instruct bootstrap-table to not make that initial request, rather it will use the data already on the page.
+* default: `null`

--- a/src/extensions/defer-url/bootstrap-table-defer-url.js
+++ b/src/extensions/defer-url/bootstrap-table-defer-url.js
@@ -7,7 +7,7 @@
  * such, you can use data-defer-url instead of data-url to allow you to instruct
  * bootstrap-table to not make that initial request, rather it will use the data
  * already on the page.
- * 
+ *
  * @author: Ruben Suarez
  * @webSite: http://rubensa.eu.org
  * @version: v1.0.0
@@ -28,10 +28,5 @@
         if (this.options.deferUrl) {
             this.options.url = this.options.deferUrl;
         }
-
-        // reset variable to original initServer function, so that future calls
-        // to initServer
-        // use the original function from this point on.
-        BootstrapTable.prototype.initServer = _initServer;
     }
 })(jQuery);

--- a/src/extensions/defer-url/bootstrap-table-defer-url.js
+++ b/src/extensions/defer-url/bootstrap-table-defer-url.js
@@ -1,0 +1,37 @@
+/**
+ * When using server-side processing, the default mode of operation for
+ * bootstrap-table is to simply throw away any data that currently exists in the
+ * table and make a request to the server to get the first page of data to
+ * display. This is fine for an empty table, but if you already have the first
+ * page of data displayed in the plain HTML, it is a waste of resources. As
+ * such, you can use data-defer-url instead of data-url to allow you to instruct
+ * bootstrap-table to not make that initial request, rather it will use the data
+ * already on the page.
+ * 
+ * @author: Ruben Suarez
+ * @webSite: http://rubensa.eu.org
+ * @version: v1.0.0
+ */
+
+(function($) {
+    'use strict';
+
+    $.extend($.fn.bootstrapTable.defaults, {
+        deferUrl : undefined
+    });
+
+    var BootstrapTable = $.fn.bootstrapTable.Constructor, _init = BootstrapTable.prototype.init;
+
+    BootstrapTable.prototype.init = function() {
+        _init.apply(this, Array.prototype.slice.apply(arguments));
+
+        if (this.options.deferUrl) {
+            this.options.url = this.options.deferUrl;
+        }
+
+        // reset variable to original initServer function, so that future calls
+        // to initServer
+        // use the original function from this point on.
+        BootstrapTable.prototype.initServer = _initServer;
+    }
+})(jQuery);

--- a/src/extensions/defer-url/extension.json
+++ b/src/extensions/defer-url/extension.json
@@ -1,0 +1,17 @@
+{
+  "name": "DeferURL",
+  "version": "1.0.0",
+  "description": "Plugin to defer server side processing.",
+  "url": "https://github.com/wenzhixin/bootstrap-table/tree/master/src/extensions/defer-url",
+  "example": "http://issues.wenzhixin.net.cn/bootstrap-table/#extensions/defer-url.html",
+
+  "plugins": [{
+    "name": "bootstrap-table-defer-url",
+    "url": "https://github.com/wenzhixin/bootstrap-table/tree/master/src/extensions/defer-url"
+  }],
+
+  "author": {
+    "name": "rubensa",
+    "image": "https://avatars1.githubusercontent.com/u/1469340"
+  }
+}


### PR DESCRIPTION
When using server-side processing, the default mode of operation for
bootstrap-table is to simply throw away any data that currently exists
in the table and make a request to the server to get the first page of
data to display. This is fine for an empty table, but if you already
have the first page of data displayed in the plain HTML, it is a waste
of resources. As such, you can use data-defer-url instead of data-url to
allow you to instruct bootstrap-table to not make that initial request,
rather it will use the data already on the page.
