### PR TITLE
insertRow method doesn't works if the table has active filters

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -2511,7 +2511,7 @@
         if (!params.hasOwnProperty('index') || !params.hasOwnProperty('row')) {
             return;
         }
-        this.data.splice(params.index, 0, params.row);
+        this.options.data.splice(params.index, 0, params.row);
         this.initSearch();
         this.initPagination();
         this.initSort();


### PR DESCRIPTION
The insertRow method doesn't works if the table has active filters, even when the new row matches the enabled filter.
The issue can be reproduced here:
[https://jsfiddle.net/jps1984/0v3enkwe](https://jsfiddle.net/jps1984/0v3enkwe)