### PR TITLE
Master

### DIFF
--- a/dist/extensions/filter-control/bootstrap-table-filter-control.js
+++ b/dist/extensions/filter-control/bootstrap-table-filter-control.js
@@ -13,7 +13,7 @@
 
     var addOptionToSelectControl = function (selectControl, value, text) {
         value = $.trim(value);
-        selectControl = $(selectControl.get(selectControl.length - 1));
+        selectControl = $(selectControl.get(0));
         if (!existOptionInSelectControl(selectControl, value)) {
             selectControl.append($("<option></option>")
                 .attr("value", value)

--- a/dist/extensions/filter-control/bootstrap-table-filter-control.js
+++ b/dist/extensions/filter-control/bootstrap-table-filter-control.js
@@ -13,7 +13,7 @@
 
     var addOptionToSelectControl = function (selectControl, value, text) {
         value = $.trim(value);
-        selectControl = $(selectControl.get(0));
+        selectControl = $(selectControl.get(selectControl.length - 1));
         if (!existOptionInSelectControl(selectControl, value)) {
             selectControl.append($("<option></option>")
                 .attr("value", value)

--- a/src/extensions/filter-control/bootstrap-table-filter-control.js
+++ b/src/extensions/filter-control/bootstrap-table-filter-control.js
@@ -13,7 +13,7 @@
 
     var addOptionToSelectControl = function (selectControl, value, text) {
         value = $.trim(value);
-        selectControl = $(selectControl.get(selectControl.length - 1));
+        selectControl = $(selectControl.get(0));
         if (!existOptionInSelectControl(selectControl, value)) {
             selectControl.append($("<option></option>")
                 .attr("value", value)


### PR DESCRIPTION
Bugfix to the filter-control plugin.

It fixes following behavior: When there is a select control in one column and other columns get added/removed from the table, the items shown in the select control get duplicated.