### PR TITLE
fixed racecondition

### DIFF
--- a/src/extensions/select2-filter/bootstrap-table-select2-filter.js
+++ b/src/extensions/select2-filter/bootstrap-table-select2-filter.js
@@ -31,7 +31,8 @@
           $ele.val(value).trigger('change');
         }
         else {
-          $ele.val(value);
+          //$ele.val(value);
+          $ele.trigger('change');
         }
       });
     }


### PR DESCRIPTION
When filling in table-search-input-fields, i allways get missing letters while typing. Thats because of the line edited in this change.
You dont' wanna "resett" the field value. in the case that it is a select field, you wanna set the value, thats okay. But not on an input.
setting the value triggers change, so we'll trigger this manually.