### PR TITLE
add align option for mergeCells

### DIFF
--- a/dist/bootstrap-table.js
+++ b/dist/bootstrap-table.js
@@ -2547,6 +2547,7 @@
             col = $.inArray(options.field, this.getVisibleFields()),
             rowspan = options.rowspan || 1,
             colspan = options.colspan || 1,
+            align = options.align,
             i, j,
             $tr = this.$body.find('>tr'),
             $td;
@@ -2567,7 +2568,7 @@
             }
         }
 
-        $td.attr('rowspan', rowspan).attr('colspan', colspan).show();
+        $td.attr('rowspan', rowspan).attr('colspan', colspan).attr('align', align).show();
     };
 
     BootstrapTable.prototype.updateCell = function (params) {


### PR DESCRIPTION
no option for align so i made align option available for merging cells. When aplied to 'post-body.bs.table'. i can have mergeCells with differents align from columns header style i made..

![2017-02-10_100256](https://cloud.githubusercontent.com/assets/1222779/22812749/2ae57a88-ef79-11e6-9bbc-f707ee5bcdef.png)


there you can see just for last row i made align center + mergeCells it

hopefully this will usefull, thanks.