### PR TITLE
Support exporting table footer

### DIFF
--- a/src/extensions/export/bootstrap-table-export.js
+++ b/src/extensions/export/bootstrap-table-export.js
@@ -99,13 +99,15 @@
                                 var $footerRow = that.$tableFooter.find("tr").first();
 
                                 var footerData = { };
-                                var footerText = [];
+                                var footerHtml = [];
 
                                 $.each($footerRow.children(), function (index, footerCell) {
-                                    var footerCellText = $(footerCell).children(".th-inner").first().text();
-                                    footerData[that.columns[index].field] = footerCellText;
+                                    
+                                    var footerCellHtml = $(footerCell).children(".th-inner").first().html();
+                                    footerData[that.columns[index].field] = footerCellHtml == '&nbsp;' ? null : footerCellHtml;
+
                                     // grab footer cell text into cell index-based array
-                                    footerText.push(footerCellText);
+                                    footerHtml.push(footerCellHtml);
                                 });
 
                                 that.append(footerData);
@@ -113,7 +115,8 @@
                                 var $lastTableRow = that.$body.children().last();
 
                                 $.each($lastTableRow.children(), function (index, lastTableRowCell) {
-                                    $(lastTableRowCell).text(footerText[index]);
+
+                                    $(lastTableRowCell).html(footerHtml[index]);
                                 });
                             }
                             

--- a/src/extensions/export/bootstrap-table-export.js
+++ b/src/extensions/export/bootstrap-table-export.js
@@ -110,9 +110,9 @@
 
                                 that.append(footerData);
 
-                                var lastTableRow = that.$body.children().last();
+                                var $lastTableRow = that.$body.children().last();
 
-                                $.each(lastTableRow.children(), function (index, lastTableRowCell) {
+                                $.each($lastTableRow.children(), function (index, lastTableRowCell) {
                                     $(lastTableRowCell).text(footerText[index]);
                                 });
                             }

--- a/src/extensions/export/bootstrap-table-export.js
+++ b/src/extensions/export/bootstrap-table-export.js
@@ -96,10 +96,10 @@
                             
                             if (!!that.options.exportFooter) {
                                 var data = that.getData();
-                                $footerRow = that.$tableFooter.find("tr").first();
+                                var $footerRow = that.$tableFooter.find("tr").first();
 
-                                footerData = { };
-                                footerText = [];
+                                var footerData = { };
+                                var footerText = [];
 
                                 $.each($footerRow.children(), function (index, footerCell) {
                                     var footerCellText = $(footerCell).children(".th-inner").first().text();
@@ -110,7 +110,7 @@
 
                                 that.append(footerData);
 
-                                $lastTableRow = that.$body.children().last();
+                                var $lastTableRow = that.$body.children().last();
 
                                 $.each($lastTableRow.children(), function (index, lastTableRowCell) {
                                     $(lastTableRowCell).text(footerText[index]);

--- a/src/extensions/export/bootstrap-table-export.js
+++ b/src/extensions/export/bootstrap-table-export.js
@@ -96,10 +96,10 @@
                             
                             if (!!that.options.exportFooter) {
                                 var data = that.getData();
-                                var $footerRow = that.$tableFooter.find("tr").first();
+                                $footerRow = that.$tableFooter.find("tr").first();
 
-                                var footerData = { };
-                                var footerText = [];
+                                footerData = { };
+                                footerText = [];
 
                                 $.each($footerRow.children(), function (index, footerCell) {
                                     var footerCellText = $(footerCell).children(".th-inner").first().text();
@@ -110,7 +110,7 @@
 
                                 that.append(footerData);
 
-                                var $lastTableRow = that.$body.children().last();
+                                $lastTableRow = that.$body.children().last();
 
                                 $.each($lastTableRow.children(), function (index, lastTableRowCell) {
                                     $(lastTableRowCell).text(footerText[index]);

--- a/src/extensions/export/bootstrap-table-export.js
+++ b/src/extensions/export/bootstrap-table-export.js
@@ -93,10 +93,38 @@
                 $menu.find('li').click(function () {
                     var type = $(this).data('type'),
                         doExport = function () {
+                            
+                            if (!!that.options.exportFooter) {
+                                var data = that.getData();
+                                var $footerRow = that.$tableFooter.find("tr").first();
+
+                                var footerData = { };
+                                var footerText = [];
+
+                                $.each($footerRow.children(), function (index, footerCell) {
+                                    var footerCellText = $(footerCell).children(".th-inner").first().text();
+                                    footerData[that.columns[index].field] = footerCellText;
+                                    // grab footer cell text into cell index-based array
+                                    footerText.push(footerCellText);
+                                });
+
+                                that.append(footerData);
+
+                                var lastTableRow = that.$body.children().last();
+
+                                $.each(lastTableRow.children(), function (index, lastTableRowCell) {
+                                    $(lastTableRowCell).text(footerText[index]);
+                                });
+                            }
+                            
                             that.$el.tableExport($.extend({}, that.options.exportOptions, {
                                 type: type,
                                 escape: false
                             }));
+                            
+                            if (!!that.options.exportFooter) {
+                                that.load(data);
+                            }
                         };
 
                     if (that.options.exportDataType === 'all' && that.options.pagination) {


### PR DESCRIPTION
Closes issue #1371

Use `data-export-footer="true"` or `exportFooter=true` to use this feature.

See fiddle: http://jsfiddle.net/dzmzoro9/7/