### PR TITLE
Feature - Support enable/disable expanding by row

### DIFF
--- a/docs/_i18n/en/documentation/table-options.md
+++ b/docs/_i18n/en/documentation/table-options.md
@@ -448,6 +448,13 @@ The table options are defined in `jQuery.fn.bootstrapTable.defaults`.
         <td>Format your detail view when <code>detailView</code> is set to <code>true</code>. Return a String and it will be appended into the detail view cell, optionally render the element directly using the third parameter which is a jQuery element of the target cell.</td>
     </tr>
     <tr>
+        <td>detailFilter</td>
+        <td>data-detail-filter</td>
+        <td>Function</td>
+        <td>function(index, row) {<br>return true;<br>}</td>
+        <td>Enable expansion per row when <code>detailView</code> is set to <code>true</code>. Return `true` and the row will be enabled for expansion, return `false` and expansion for the row will be disabled. Default function returns `true` to enable expansion for all rows.</td>
+    </tr>
+    <tr>
         <td>searchAlign</td>
         <td>data-search-align</td>
         <td>String</td>

--- a/docs/_i18n/en/documentation/table-options.md
+++ b/docs/_i18n/en/documentation/table-options.md
@@ -452,7 +452,7 @@ The table options are defined in `jQuery.fn.bootstrapTable.defaults`.
         <td>data-detail-filter</td>
         <td>Function</td>
         <td>function(index, row) {<br>return true;<br>}</td>
-        <td>Enable expansion per row when <code>detailView</code> is set to <code>true</code>. Return `true` and the row will be enabled for expansion, return `false` and expansion for the row will be disabled. Default function returns `true` to enable expansion for all rows.</td>
+        <td>Enable expansion per row when <code>detailView</code> is set to <code>true</code>. Return <code>true</code> and the row will be enabled for expansion, return <code>false</code> and expansion for the row will be disabled. Default function returns <code>true</code> to enable expansion for all rows.</td>
     </tr>
     <tr>
         <td>searchAlign</td>

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -340,6 +340,9 @@
         detailFormatter: function (index, row) {
             return '';
         },
+        detailFilter: function (index, item) {
+            return true;
+        },
         trimOnSearch: true,
         clickToSelect: false,
         singleSelect: false,
@@ -1658,11 +1661,15 @@
         }
 
         if (!this.options.cardView && this.options.detailView) {
-            html.push('<td>',
-                '<a class="detail-icon" href="#">',
+            html.push('<td>');
+
+            if (calculateObjectValue(null, this.options.detailFilter, [i, item])) {
+                html.push('<a class="detail-icon" href="javascript:">',
                 sprintf('<i class="%s %s"></i>', this.options.iconsPrefix, this.options.icons.detailOpen),
-                '</a>',
-                '</td>');
+                '</a>');
+            }
+
+            html.push('</td>');
         }
 
         $.each(this.header.fields, function(j, field) {

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -340,7 +340,7 @@
         detailFormatter: function (index, row) {
             return '';
         },
-        detailFilter: function (index, item) {
+        detailFilter: function (index, row) {
             return true;
         },
         trimOnSearch: true,


### PR DESCRIPTION
There is no current support for enabling/disabling expansion of a row on a per-row basis.

This PR adds support for this.

Option `data-detail-filter="detailFilterFunction"` or `options.detailFilter=detailFilterFunction` is used to provide a function name (or function) to call. This function is provided with the row index and row data as parameters:

`function detailFilterFunction(index, row) {
}`

The default detailFilter option function returns true to keep the existing functionality to enable expanding all rows if this option is not configured.

See fiddle for example: http://jsfiddle.net/ng0uuqy2/4/