### PR TITLE
Fix loading of defaults columns options in table-filter-control

### DIFF
--- a/src/extensions/filter-control/bootstrap-table-filter-control.js
+++ b/src/extensions/filter-control/bootstrap-table-filter-control.js
@@ -446,7 +446,7 @@
         valuesFilterControl: []
     });
 
-    $.extend($.fn.bootstrapTable.COLUMN_DEFAULTS, {
+    $.extend($.fn.bootstrapTable.columnDefaults, {
         filterControl: undefined,
         filterData: undefined,
         filterDatepickerOptions: undefined,


### PR DESCRIPTION
Defaults columns options are already defined in the code but never set.