### PR TITLE
点击table的列数据，列的数据的背景色变化

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1865,18 +1865,23 @@
             that.trigger(e.type === 'click' ? 'click-cell' : 'dbl-click-cell', field, value, item, $td);
             that.trigger(e.type === 'click' ? 'click-row' : 'dbl-click-row', item, $tr, field);
 
+            // if click to select then row which is clicking background is changing
+            if(e.type === 'click'){
+                if(that.options.singleSelect){
+                    that.$selectItem.closest('tr').find('td').css({'background-color':'white'});
+                }
+                if($(this).closest('tr').hasClass('selected')){ //judge the node is or not contain selected class
+                    $(this).closest('tr').find('td').css({'background':'white'});
+                }else{
+                    $(this).closest('tr').find('td').css({'background':that.options.clickToSelectColor});
+                }
+            }
+            
             // if click to select - then trigger the checkbox/radio click
             if (e.type === 'click' && that.options.clickToSelect && column.clickToSelect) {
                 var $selectItem = $tr.find(sprintf('[name="%s"]', that.options.selectItemName));
                 if ($selectItem.length) {
                     $selectItem[0].click(); // #144: .trigger('click') bug
-                }
-            }
-            // if click to select then row which is clicking background is changing
-            if(e.type === 'click'){
-                $(this).closest('tr').find('td').css({'background':that.options.clickToSelectColor});
-                if(that.options.singleSelect){
-                    that.$selectItem.closest('tr').find('td').css({'background-color':'white'});
                 }
             }
         });

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -333,6 +333,7 @@
         },
         trimOnSearch: true,
         clickToSelect: false,
+        clickToSelectColor: '#7ccc7c',
         singleSelect: false,
         toolbar: undefined,
         toolbarAlign: 'left',
@@ -1869,6 +1870,13 @@
                 var $selectItem = $tr.find(sprintf('[name="%s"]', that.options.selectItemName));
                 if ($selectItem.length) {
                     $selectItem[0].click(); // #144: .trigger('click') bug
+                }
+            }
+            // if click to select then row which is clicking background is changing
+            if(e.type === 'click'){
+                $(this).closest('tr').find('td').css({'background':that.options.clickToSelectColor});
+                if(that.options.singleSelect){
+                    that.$selectItem.closest('tr').find('td').css({'background-color':'white'});
                 }
             }
         });


### PR DESCRIPTION
针对问题： 使用table的时候，单击（clickToSelect、singleSelect）点击表格行，行颜色样式没有改变，不能够达到醒目的效果，进行调整，发现一个小的问题，进行修复