### PR TITLE
Allow custom footer values from server

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -298,6 +298,8 @@
         paginationLoop: true,
         sidePagination: 'client', // client or server
         totalRows: 0, // server side need to set
+        footerValues: [],
+        footerValuesField: null,
         pageNumber: 1,
         pageSize: 10,
         pageList: [10, 25, 50, 100],
@@ -2240,9 +2242,14 @@
 
             html.push('<td', class_, sprintf(' style="%s"', falign + valign + csses.concat().join('; ')), '>');
             html.push('<div class="th-inner">');
-
-            html.push(calculateObjectValue(column, column.footerFormatter, [data], '&nbsp;') || '&nbsp;');
-
+            
+            if(that.options.footerValues && typeof that.options.footerValues[column.field] != 'undefined') {
+                html.push(calculateObjectValue(column, column.footerFormatter, [that.options.footerValues[column.field]], '&nbsp;') || '&nbsp;');
+            }
+            else {
+                html.push(calculateObjectValue(column, column.footerFormatter, [data], '&nbsp;') || '&nbsp;');
+            }
+            
             html.push('</div>');
             html.push('<div class="fht-cell"></div>');
             html.push('</div>');
@@ -2403,6 +2410,10 @@
         // #431: support pagination
         if (this.options.sidePagination === 'server') {
             this.options.totalRows = data[this.options.totalField];
+            if(this.options.footerValuesField) {
+               this.options.footerValues = data[this.options.footerValuesField]
+            }
+            
             fixedScroll = data.fixedScroll;
             data = data[this.options.dataField];
         } else if (!$.isArray(data)) { // support fixedScroll

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -298,8 +298,8 @@
         paginationLoop: true,
         sidePagination: 'client', // client or server
         totalRows: 0, // server side need to set
-        footerValues: null,
-        footerValuesField: null,
+        footerValues: false,
+        footerValuesField: false,
         pageNumber: 1,
         pageSize: 10,
         pageList: [10, 25, 50, 100],
@@ -2243,7 +2243,7 @@
             html.push('<td', class_, sprintf(' style="%s"', falign + valign + csses.concat().join('; ')), '>');
             html.push('<div class="th-inner">');
             
-            if(that.options.footerValues && typeof that.options.footerValues[column.field] != 'undefined') {
+            if(that.options.sidePagination === 'server' && that.options.footerValues) {
                 html.push(calculateObjectValue(column, column.footerFormatter, [that.options.footerValues[column.field]], '&nbsp;') || '&nbsp;');
             }
             else {

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -298,7 +298,7 @@
         paginationLoop: true,
         sidePagination: 'client', // client or server
         totalRows: 0, // server side need to set
-        footerValues: [],
+        footerValues: null,
         footerValuesField: null,
         pageNumber: 1,
         pageSize: 10,


### PR DESCRIPTION
Also mentioned here https://github.com/wenzhixin/bootstrap-table/issues/3046

Assuming this is the current expected response when using server side pagination
https://github.com/wenzhixin/bootstrap-table-examples/blob/master/json/data2.json
This change will allow support support for a third field defined by this.options.footerValuesField that will be used for the footer.  

For example, if you need to display the "true" total of _all records on all pages_ in the footer, you would need to make additional ajax calls to set that, since currently the only data sent to the footer is what already exists in the table.

So if the server returns a response like so:

```
{ 
"total": 200, 
"rows": [ 
    ['col1':50, 'col2':25], 
    ['col1':50, 'col2':25], 
    ['col1':50, 'col2':25], 
    ['col1':50, 'col2':25], 
    ['col1':50, 'col2':25], 
    ['col1':50, 'col2':25], 
    ['col1':50, 'col2':25], 
    ['col1':50, 'col2':25], 
    ['col1':50, 'col2':25], 
    ['col1':50, 'col2':25]
   ], 
"aggregations": ['col1' : 750000000, 'col2' : 64500000] 
}
```

With this change, you can make the values in the "aggregations" field display in the footer like so:

```
$('#my_table').bootstrapTable({
   ....
   footerValuesField: 'aggregations',
   ....
});
```


Example:

http://jsfiddle.net/4r6g4cfu/626/

There are supposed to be 800 rows of data and in this example I want to show the total of all rows (which is 319600). However that is impossible since only the values for one page have been retrieved from the server. The total for all rows would have to be calculated server-side, hence the need to check for another field from the server.