### PR TITLE
Keep timeout per column, not globally

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1004,22 +1004,28 @@
         }
     };
 
-    BootstrapTable.prototype.onSort = function (event) {
+    BootstrapTable.prototype.onSort = function (event, reSort) {
         var $this = event.type === "keypress" ? $(event.currentTarget) : $(event.currentTarget).parent(),
             $this_ = this.$header.find('th').eq($this.index());
 
+        if (reSort && (this.options.sortName === "null" || this.options.sortName === "undefined")) {
+            return;
+        }
+
         this.$header.add(this.$header_).find('span.order').remove();
 
-        if (this.options.sortName === $this.data('field')) {
-            this.options.sortOrder = this.options.sortOrder === 'asc' ? 'desc' : 'asc';
-        } else {
-            this.options.sortName = $this.data('field');
-            if (this.options.rememberOrder) {
-                this.options.sortOrder = $this.data('order') === 'asc' ? 'desc' : 'asc';
+        if (!reSort) {
+            if (this.options.sortName === $this.data('field')) {
+                this.options.sortOrder = this.options.sortOrder === 'asc' ? 'desc' : 'asc';
             } else {
-                this.options.sortOrder = this.options.columns[0].filter(function(option) {
-                    return option.field === $this.data('field');
-                })[0].order;
+                this.options.sortName = $this.data('field');
+                if (this.options.rememberOrder) {
+                    this.options.sortOrder = $this.data('order') === 'asc' ? 'desc' : 'asc';
+                } else {
+                    this.options.sortOrder = this.options.columns[0].filter(function(option) {
+                        return option.field === $this.data('field');
+                    })[0].order;
+                }
             }
         }
         this.trigger('sort', this.options.sortName, this.options.sortOrder);

--- a/src/extensions/filter-control/bootstrap-table-filter-control.js
+++ b/src/extensions/filter-control/bootstrap-table-filter-control.js
@@ -257,7 +257,7 @@
                 if (column.searchable && that.options.filterTemplate[nameControl]) {
                     addedFilterControl = true;
                     isVisible = 'visible';
-                    html.push(that.options.filterTemplate[nameControl](that, column.field, isVisible, column.filterControlPlaceholder ? column.filterControlPlaceholder : ""));
+                    html.push(that.options.filterTemplate[nameControl](that, column.field, isVisible, column.filterControlPlaceholder ? column.filterControlPlaceholder : "", "filter-control-" + i));
                 }
             }
 
@@ -317,15 +317,15 @@
 
         if (addedFilterControl) {
             header.off('keyup', 'input').on('keyup', 'input', function (event) {
-                clearTimeout(timeoutId);
-                timeoutId = setTimeout(function () {
+                clearTimeout(event.currentTarget.timeoutId);
+                event.currentTarget.timeoutId = setTimeout(function () {
                     that.onColumnSearch(event);
                 }, that.options.searchTimeOut);
             });
 
             header.off('change', 'select').on('change', 'select', function (event) {
-                clearTimeout(timeoutId);
-                timeoutId = setTimeout(function () {
+                clearTimeout(event.currentTarget.timeoutId);
+                event.currentTarget.timeoutId = setTimeout(function () {
                     that.onColumnSearch(event);
                 }, that.options.searchTimeOut);
             });
@@ -342,8 +342,8 @@
                     var newValue = $input.val();
 
                     if (newValue === "") {
-                        clearTimeout(timeoutId);
-                        timeoutId = setTimeout(function () {
+                        clearTimeout(event.currentTarget.timeoutId);
+                        event.currentTarget.timeoutId = setTimeout(function () {
                             that.onColumnSearch(event);
                         }, that.options.searchTimeOut);
                     }
@@ -355,7 +355,7 @@
                     if (column.filterControl !== undefined && column.filterControl.toLowerCase() === 'datepicker') {
                         header.find('.date-filter-control.bootstrap-table-filter-control-' + column.field).datepicker(column.filterDatepickerOptions)
                             .on('changeDate', function (e) {
-                                $(sprintf(".%s", e.currentTarget.classList.toString().split(" ").join("."))).val(e.currentTarget.value);
+                                $(sprintf("#%s", e.currentTarget.id)).val(e.currentTarget.value);
                                 //Fired the keyup event
                                 $(e.currentTarget).keyup();
                             });

--- a/src/extensions/filter-control/bootstrap-table-filter-control.js
+++ b/src/extensions/filter-control/bootstrap-table-filter-control.js
@@ -650,6 +650,11 @@
         this.options.pageNumber = 1;
         this.EnableControls(false);
         this.onSearch(event);
+        var sortable = $(event.currentTarget).parents("th").children(".sortable");
+        if (sortable[0] !== "null" && sortable[0] !== "undefined") {
+            event.currentTarget = sortable;
+            this.onSort(event, true);
+        }
         this.trigger('column-search', $field, text);
     };
 


### PR DESCRIPTION
First commit fixes issue where leaving a filter field too quickly (by using tab to move to the next field) would ignore the value just entered.
Second commit fixes #3063 