### PR TITLE
keep timeout per column, not globally

### DIFF
--- a/src/extensions/filter-control/bootstrap-table-filter-control.js
+++ b/src/extensions/filter-control/bootstrap-table-filter-control.js
@@ -318,7 +318,7 @@
                     return;
                 }
 
-                clearTimeout(event.currentTarget.timeoutId);
+                clearTimeout(event.currentTarget.timeoutId || 0);
                 event.currentTarget.timeoutId = setTimeout(function () {
                     that.onColumnSearch(event);
                 }, that.options.searchTimeOut);
@@ -333,7 +333,7 @@
                     return;
                 }
                 
-                clearTimeout(event.currentTarget.timeoutId);
+                clearTimeout(event.currentTarget.timeoutId || 0);
                 event.currentTarget.timeoutId = setTimeout(function () {
                     that.onColumnSearch(event);
                 }, that.options.searchTimeOut);
@@ -351,7 +351,7 @@
                     var newValue = $input.val();
 
                     if (newValue === "") {
-                        clearTimeout(event.currentTarget.timeoutId);
+                        clearTimeout(event.currentTarget.timeoutId || 0);
                         event.currentTarget.timeoutId = setTimeout(function () {
                             that.onColumnSearch(event);
                         }, that.options.searchTimeOut);

--- a/src/extensions/filter-control/bootstrap-table-filter-control.js
+++ b/src/extensions/filter-control/bootstrap-table-filter-control.js
@@ -317,15 +317,15 @@
 
         if (addedFilterControl) {
             header.off('keyup', 'input').on('keyup', 'input', function (event) {
-                clearTimeout(timeoutId);
-                timeoutId = setTimeout(function () {
+                clearTimeout(event.currentTarget.timeoutId);
+                event.currentTarget.timeoutId = setTimeout(function () {
                     that.onColumnSearch(event);
                 }, that.options.searchTimeOut);
             });
 
             header.off('change', 'select').on('change', 'select', function (event) {
-                clearTimeout(timeoutId);
-                timeoutId = setTimeout(function () {
+                clearTimeout(event.currentTarget.timeoutId);
+                event.currentTarget.timeoutId = setTimeout(function () {
                     that.onColumnSearch(event);
                 }, that.options.searchTimeOut);
             });
@@ -342,8 +342,8 @@
                     var newValue = $input.val();
 
                     if (newValue === "") {
-                        clearTimeout(timeoutId);
-                        timeoutId = setTimeout(function () {
+                        clearTimeout(event.currentTarget.timeoutId);
+                        event.currentTarget.timeoutId = setTimeout(function () {
                             that.onColumnSearch(event);
                         }, that.options.searchTimeOut);
                     }


### PR DESCRIPTION
Fixes issue where leaving a filter field too quickly (by using tab to move to the next field) would ignore the value just entered.

In the below jsfiddles, click the first filter field, then type 'An<tab>' quickly.
Broken - https://jsfiddle.net/L31grfa4/1/
Fixed - https://jsfiddle.net/z3xhenj9/2/