### PR TITLE
fix bug in pagination

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1602,6 +1602,7 @@
         }
         this.options.pageNumber = +$(event.currentTarget).text();
         this.updatePagination(event);
+        $('li.page-number.active a').attr("href","javascript:void(0);");
         return false;
     };
 


### PR DESCRIPTION
bug detail:
when click active page number, it jump to document.baseURI+"#"
fixed:
change active page number's href to javascript:void(0);