### PR TITLE
Fix cookie extension onPage*** hook return values

### DIFF
--- a/src/extensions/cookie/bootstrap-table-cookie.js
+++ b/src/extensions/cookie/bootstrap-table-cookie.js
@@ -359,31 +359,37 @@
     BootstrapTable.prototype.onPageNumber = function () {
         _onPageNumber.apply(this, Array.prototype.slice.apply(arguments));
         setCookie(this, cookieIds.pageNumber, this.options.pageNumber);
+        return false;
     };
 
     BootstrapTable.prototype.onPageListChange = function () {
         _onPageListChange.apply(this, Array.prototype.slice.apply(arguments));
         setCookie(this, cookieIds.pageList, this.options.pageSize);
+        return false;
     };
 
     BootstrapTable.prototype.onPageFirst = function () {
         _onPageFirst.apply(this, Array.prototype.slice.apply(arguments));
         setCookie(this, cookieIds.pageNumber, this.options.pageNumber);
+        return false;
     };
 
     BootstrapTable.prototype.onPagePre = function () {
         _onPagePre.apply(this, Array.prototype.slice.apply(arguments));
         setCookie(this, cookieIds.pageNumber, this.options.pageNumber);
+        return false;
     };
 
     BootstrapTable.prototype.onPageNext = function () {
         _onPageNext.apply(this, Array.prototype.slice.apply(arguments));
         setCookie(this, cookieIds.pageNumber, this.options.pageNumber);
+        return false;
     };
 
     BootstrapTable.prototype.onPageLast = function () {
         _onPageLast.apply(this, Array.prototype.slice.apply(arguments));
         setCookie(this, cookieIds.pageNumber, this.options.pageNumber);
+        return false;
     };
 
     BootstrapTable.prototype.toggleColumn = function () {


### PR DESCRIPTION
The cookie extension hooks some of the bootstrap table methods to implement saving the state. Unfortunately the `onPage***` hooks don't propagate the return values of the original hooked methods.

The original methods `return false` to ask jQuery to call `event.preventDefault()` and `event.stopPropagation()`. Without this clicking the pagination control caused my webpage to scroll to the top.

Additional info:
- The original `onPage***` methods of bootstrap table returning false: https://github.com/wenzhixin/bootstrap-table/blob/4228fa6049926fbba5f5315f7102300fc7837459/src/bootstrap-table.js#L1555
- The jQuery dispatch method that handles the `false` return value specially: https://github.com/jquery/jquery/blob/4d6b4536b2e0148d4b228884a0b356e73dd8beec/src/event.js#L341