### PR TITLE
Provide typings - reopened after adding missing file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,7 @@
+interface JQuery {
+
+    bootstrapTable(options: object): JQuery;
+
+    bootstrapTable(method: string, ...parameters: any[]): JQuery | any;
+
+}

--- a/package.json
+++ b/package.json
@@ -41,8 +41,5 @@
       "path": "./node_modules/cz-conventional-changelog"
     }
   },
-  "types": "./index.d.ts",
-  "dependencies": {
-    "@types/jquery": "^2.0.46"
-  }
+  "types": "./index.d.ts"
 }


### PR DESCRIPTION
Provide simple typings to that this library out of the box is ready for typescript.
There is though a typings out there for this library under the definitelyTyped umbrella,
but it is extremely outdated and isn't correct. For instance, ts compiler will give an error for the line
$('#someId').bootstrapTable('method', {});
This pull requests adds a simple but ready type definition.