### PR TITLE
making formatter api like cellStyle and improve documentation

### DIFF
--- a/docs/_i18n/en/documentation/column-options.md
+++ b/docs/_i18n/en/documentation/column-options.md
@@ -164,7 +164,18 @@ The column options is defined in `jQuery.fn.bootstrapTable.columnDefaults`.
         The cell formatter function, take three parameters: <br>
         value: the field value. <br>
         row: the row record data.<br>
-        index: the row index.</td>
+        index: the row index.<br>
+        field: the row field.<br>
+        Example usage:<br>
+<pre>
+function formatter(value, row, index, field) {
+  if (value === 'foo') {
+    return '<strong>' + value + '</strong>';
+  }
+  return value;
+}
+</pre>
+        </td>
     </tr>
     <tr>
         <td>footerFormatter</td>

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1736,7 +1736,7 @@
             }
 
             value = calculateObjectValue(column,
-                that.header.formatters[j], [value_, item, i], value_);
+                that.header.formatters[j], [value_, item, i, field], value_);
 
             if (item['_' + field + '_data'] && !$.isEmptyObject(item['_' + field + '_data'])) {
                 $.each(item['_' + field + '_data'], function(k, v) {


### PR DESCRIPTION
i'm trying create a generic formatter overwriting `$.fn.bootstrapTable.columnDefaults` variable.
I've implemented a **cellStyle** and works great but _formatter callback doesn't have a **field** argument_. 

# Examples
### Case 01 (Theoretically The-Right-Way)
http://jsfiddle.net/03gg8hre/
- the User can resize, switch and move columns.
- get data with URL
- i'm listening resize, switch and move columns event to save as user preferences to keep the table how it has left. 

**The problem**: hard difficult to keep `columns` variable synchronized with content. Example: http://jsfiddle.net/zc0kz0b0/

### Case 02 (Workaround)
http://jsfiddle.net/pn3b0k8c/
redefining **$.fn.bootstrapTable.columnDefaults** i can make a generic default without problems with _unsynchronized_ column header with text



> This PR pass field as 4th parameter