### PR TITLE
Html strip on search

### DIFF
--- a/dist/bootstrap-table.js
+++ b/dist/bootstrap-table.js
@@ -1277,6 +1277,9 @@
                         value = item[key];
                     }
 
+                    value = value.replace(/<[^>]*>/gi, '');
+                    console.log(value);
+
                     if (typeof value === 'string' || typeof value === 'number') {
                         if (that.options.strictSearch) {
                             if ((value + '').toLowerCase() === s) {

--- a/dist/bootstrap-table.js
+++ b/dist/bootstrap-table.js
@@ -363,6 +363,7 @@
             detailOpen: 'glyphicon-plus icon-plus',
             detailClose: 'glyphicon-minus icon-minus'
         },
+        searchHtmlStrip: false,
 
         customSearch: $.noop,
 
@@ -1277,8 +1278,10 @@
                         value = item[key];
                     }
 
-                    value = value.replace(/<[^>]*>/gi, '');
-                    console.log(value);
+                    if(that.options.searchHtmlStrip){
+                        value = value.replace(/<[^>]*>/gi, '');    
+                    }
+                    
 
                     if (typeof value === 'string' || typeof value === 'number') {
                         if (that.options.strictSearch) {


### PR DESCRIPTION
Sometimes I have to use `formatter` in order to create buttons or links in the table.
And when I search, the keyword searches even html tags.

For example, there is a button created by `formatter` and it will be
`<button type="button" data-index="122">Hello</button>`.
In this case, if you search `122`, you will be able to search which I don't want.
I want to search only by `Hello` because users will see only `Hello`.

So I added condition in `BootstrapTable.prototype.initSearch` with a boolean option called `searchHtmlStrip`

Here is jsFiddle
1. [Current bootstrap-table](https://jsfiddle.net/hadeath03/zggoj3ka/1/)
2. [Forked version bootstrap-table](https://jsfiddle.net/hadeath03/gLztzxLq/1/)

(This is my first time to do pull request, let me know if I miss something.)