### PR TITLE
Fix cookie-expiration feature

### DIFF
--- a/src/extensions/cookie/bootstrap-table-cookie.js
+++ b/src/extensions/cookie/bootstrap-table-cookie.js
@@ -68,19 +68,18 @@
         switch(that.options.cookieStorage) {
             case 'cookieStorage':
                 document.cookie = [
-                        cookieName, '=', cookieValue,
-                        '; expires=' + that.options.cookieExpire,
-                        that.options.cookiePath ? '; path=' + that.options.cookiePath : '',
-                        that.options.cookieDomain ? '; domain=' + that.options.cookieDomain : '',
-                        that.options.cookieSecure ? '; secure' : ''
-                    ].join('');
-            break;
+                    cookieName, '=', cookieValue,
+                    '; expires=' + calculateExpiration(that.options.cookieExpire),
+                    that.options.cookiePath ? '; path=' + that.options.cookiePath : '',
+                    that.options.cookieDomain ? '; domain=' + that.options.cookieDomain : '',
+                    that.options.cookieSecure ? '; secure' : ''
+                ].join('');
             case 'localStorage':
                 localStorage.setItem(cookieName, cookieValue);
-            break;
+                break;
             case 'sessionStorage':
                 sessionStorage.setItem(cookieName, cookieValue);
-            break;
+                break;
             default:
                 return false;
         }
@@ -113,22 +112,22 @@
 
     var deleteCookie = function (that, tableName, cookieName) {
         cookieName = tableName + '.' + cookieName;
-        
+
         switch(that.options.cookieStorage) {
             case 'cookieStorage':
                 document.cookie = [
-                        encodeURIComponent(cookieName), '=',
-                        '; expires=Thu, 01 Jan 1970 00:00:00 GMT',
-                        that.options.cookiePath ? '; path=' + that.options.cookiePath : '',
-                        that.options.cookieDomain ? '; domain=' + that.options.cookieDomain : '',
-                    ].join('');
+                    encodeURIComponent(cookieName), '=',
+                    '; expires=Thu, 01 Jan 1970 00:00:00 GMT',
+                    that.options.cookiePath ? '; path=' + that.options.cookiePath : '',
+                    that.options.cookieDomain ? '; domain=' + that.options.cookieDomain : '',
+                ].join('');
                 break;
             case 'localStorage':
                 localStorage.removeItem(cookieName);
-            break;
+                break;
             case 'sessionStorage':
                 sessionStorage.removeItem(cookieName);
-            break;
+                break;
 
         }
         return true;
@@ -136,7 +135,7 @@
 
     var calculateExpiration = function(cookieExpire) {
         var time = cookieExpire.replace(/[0-9]*/, ''); //s,mi,h,d,m,y
-        cookieExpire = cookieExpire.replace(/[A-Za-z]{1,2}}/, ''); //number
+        cookieExpire = cookieExpire.replace(/[A-Za-z]{1,2}/, ''); //number
 
         switch (time.toLowerCase()) {
             case 's':
@@ -161,8 +160,12 @@
                 cookieExpire = undefined;
                 break;
         }
-
-        return cookieExpire === undefined ? '' : '; max-age=' + cookieExpire;
+        if(!cookieExpire){
+            return '';
+        }
+        var d = new Date();
+        d.setTime(d.getTime() + cookieExpire*1000);
+        return d.toGMTString();
     };
 
     var initCookieFilters = function (bootstrapTable) {
@@ -247,7 +250,7 @@
         this.options.cookiesEnabled = typeof this.options.cookiesEnabled === 'string' ?
             this.options.cookiesEnabled.replace('[', '').replace(']', '')
                 .replace(/ /g, '').toLowerCase().split(',') :
-                this.options.cookiesEnabled;
+            this.options.cookiesEnabled;
 
         if (this.options.filterControl) {
             var that = this;
@@ -392,7 +395,7 @@
         _onSearch.apply(this, target);
 
         if ($(target[0].currentTarget).parent().hasClass('search')) {
-          setCookie(this, cookieIds.searchText, this.searchText);
+            setCookie(this, cookieIds.searchText, this.searchText);
         }
     };
 

--- a/src/extensions/cookie/bootstrap-table-cookie.js
+++ b/src/extensions/cookie/bootstrap-table-cookie.js
@@ -160,11 +160,11 @@
                 cookieExpire = undefined;
                 break;
         }
-        if(!cookieExpire){
+        if (!cookieExpire) {
             return '';
         }
         var d = new Date();
-        d.setTime(d.getTime() + cookieExpire*1000);
+        d.setTime(d.getTime() + cookieExpire * 1000);
         return d.toGMTString();
     };
 


### PR DESCRIPTION
Unfortuanally in commit [dce77b0aabfbe2894c8533f529e7d8a043ab77fb](https://github.com/wenzhixin/bootstrap-table/commit/dce77b0aabfbe2894c8533f529e7d8a043ab77fb#diff-9dc33f6bff50c3fdd9646828c7d37dd4) was broke cookie-expiration feature. This led to fact that only session sort cookies creates with cookie extension.
Thus, `cookieExpire` option is not working at all.
This pull request fixes that bug. `expires` prefered to `max-age` because some old browsers can only work with `expires`. 
