### PR TITLE
Allow fromHTML tables to sort using a custom sort value

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -707,7 +707,7 @@
 
                 var field = that.columns[x].field;
 
-                row[field] = $(this).html();
+                row[field] = ($(this).data('value') || $(this).html());
                 // save td's id, class and data-* attributes
                 row['_' + field + '_id'] = $(this).attr('id');
                 row['_' + field + '_class'] = $(this).attr('class');


### PR DESCRIPTION
* set data-value on the <td> to the custom sort value it use that instead of $td.html()

This is for use cases where the value to be sorted is different from the display html. For example, rankings:

1st, 2nd, 3rd [...]10th, 11th, 12th, ordered by text becomes shows: 10th, 11th, 12th, 1st, 2nd, 3rd [...] which is unexpected and not how it should be.

This solves it by setting a data-value attribute on the <td> in the html, in this case, the data-value will just be a number for the ranking without the ordinal text.

Thank you!

PS. I did not commit build artifacts because apparently, the build regenerates a lot of dist files, and generates some new ones...