### PR TITLE
allow sorting by data-sort-value for fromHtml tables

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -203,6 +203,19 @@
         }
         return escape ? escapeHTML(value) : value;
     };
+    
+    var getItemSortValue = function (item, field, escape) {
+        var data;
+
+        if (item.hasOwnProperty('_' + field + '_data')) {
+            data = item['_' + field + '_data'];
+
+            if(data && (data.sortValue || data['sort-value'])){
+                return (data.sortValue || data['sort-value']);
+            }
+        }
+        return getItemField(item, field, escape);
+    };
 
     var isIEBrowser = function () {
         return !!(navigator.userAgent.indexOf("MSIE ") > 0 || !!navigator.userAgent.match(/Trident.*rv\:11\./));
@@ -921,7 +934,8 @@
             name = this.options.sortName,
             order = this.options.sortOrder === 'desc' ? -1 : 1,
             index = $.inArray(this.options.sortName, this.header.fields),
-            timeoutId = 0;
+            timeoutId = 0,
+            sortingFunc = getItemField;
 
         if (this.options.customSort !== $.noop) {
             this.options.customSort.apply(this, [this.options.sortName, this.options.sortOrder]);
@@ -934,13 +948,14 @@
                     row._position = i;
                 });
             }
-
+            
+            if (this.fromHtml) { sortingFunc = getItemSortValue; }
             this.data.sort(function (a, b) {
                 if (that.header.sortNames[index]) {
                     name = that.header.sortNames[index];
                 }
-                var aa = getItemField(a, name, that.options.escape),
-                    bb = getItemField(b, name, that.options.escape),
+                var aa = sortingFunc(a, name, that.options.escape),
+                    bb = sortingFunc(b, name, that.options.escape),
                     value = calculateObjectValue(that.header, that.header.sorters[index], [aa, bb]);
 
                 if (value !== undefined) {


### PR DESCRIPTION
* Set data-sort-value on the <td> to use that value to sort instead of html()

This is for use cases where the value to be sorted is different from the display html. For example, rankings:

1st, 2nd, 3rd [...]10th, 11th, 12th, ordered by text becomes shows: 10th, 11th, 12th, 1st, 2nd, 3rd [...] which is unexpected and not how it should be.

This solves it by setting a data-sort-value attribute on the column (td) in the html, in this case, the data-sort-value will just be a number for the ranking without the ordinal text.

Thank you!

PS. I did not commit build artifacts because apparently, the build regenerates a lot of dist files, and generates some new ones...