### PR TITLE
Add support for dropdown fields in advanced search form (toolbar extension)

### DIFF
--- a/src/extensions/toolbar/bootstrap-table-toolbar.js
+++ b/src/extensions/toolbar/bootstrap-table-toolbar.js
@@ -36,7 +36,7 @@
 
             $('#avdSearchModalContent' + "_" + that.options.idTable).append(vFormAvd.join(''));
 
-            $('#' + that.options.idForm).off('keyup blur', 'input').on('keyup blur', 'input', function (event) {
+            $('#' + that.options.idForm).off('keyup blur change', 'input,select').on('keyup blur change', 'input,select', function (event) {
                 clearTimeout(timeoutId);
                 timeoutId = setTimeout(function () {
                     that.onColumnAdvancedSearch(event);
@@ -62,7 +62,16 @@
                 htmlForm.push('<div class="form-group">');
                 htmlForm.push(sprintf('<label class="col-sm-4 control-label">%s</label>', vObjCol.title));
                 htmlForm.push('<div class="col-sm-6">');
-                htmlForm.push(sprintf('<input type="text" class="form-control input-md" name="%s" placeholder="%s" id="%s">', vObjCol.field, vObjCol.title, vObjCol.field));
+                if (vObjCol.collection_select && vObjCol.collection_select_options) {
+                    htmlForm.push(sprintf('<select class="form-control input-md" name="%s" id="%s">', vObjCol.field, vObjCol.field));
+                    htmlForm.push('<option value=""></option>');
+                    collection_select_options.split(',').forEach(function(el){
+                        htmlForm.push('<option value="' + el + '">' + el + '</option>');
+                    });
+                    htmlForm.push('</select>');
+                } else {
+                    htmlForm.push(sprintf('<input type="text" class="form-control input-md" name="%s" placeholder="%s" id="%s">', vObjCol.field, vObjCol.title, vObjCol.field));
+                }
                 htmlForm.push('</div>');
                 htmlForm.push('</div>');
             }


### PR DESCRIPTION
Currently the [advanced search toolbar extension](http://issues.wenzhixin.net.cn/bootstrap-table/#extensions/toolbar.html) only supports text fields for the advanced search process, but sometimes it would be beneficial to have dropdown (`<select>`) fields with set options. I suggest adding two new [column options](http://bootstrap-table.wenzhixin.net.cn/documentation/#column-options) to achieve this:

- `collection_select`
- `collection_select_options`

Let me know if this sounds like an update that could be included and I will add revisions to the docs as part of this Pull Request

-----

PS: The CONTRIBUTING.md says
> Please do not open issues or pull requests regarding the code in bootstrap-table-examples and extensions plugin dependence...

But I couldn't find the respective repository for the toolbar advanced search. Sorry if this is incorrect!