### PR TITLE
Footer cant adjust itself on fixed table layout.

### DIFF
--- a/dist/bootstrap-table.js
+++ b/dist/bootstrap-table.js
@@ -2272,9 +2272,10 @@
 
         this.$tableFooter.css({
             'margin-right': scrollWidth
-        }).find('table').css('width', elWidth)
-            .attr('class', this.$el.attr('class'));
-
+        }).find('table').css('width', elWidth);
+            //.attr('class', this.$el.attr('class'));
+            //cant adjust itself with table columns on fixed table layout.
+        
         $footerTd = this.$tableFooter.find('td');
 
         this.$body.find('>tr:first-child:not(.no-records-found) > *').each(function (i) {


### PR DESCRIPTION
Footer cant adjust itself when table layout is fixed and columns are customly sized;
Removing user-defined classes or all classes of table inside fixed footer container solved it.