### PR TITLE
updateByUniqueId plus add

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -2536,7 +2536,8 @@
     BootstrapTable.prototype.updateByUniqueId = function (params) {
         var that = this;
         var allParams = $.isArray(params) ? params : [ params ];
-
+        var data = [];
+        
         $.each(allParams, function(i, params) {
             var rowId;
 
@@ -2547,11 +2548,12 @@
             rowId = $.inArray(that.getRowByUniqueId(params.id), that.options.data);
 
             if (rowId === -1) {
-                return;
+                data.push(params.row);
             }
             $.extend(that.options.data[rowId], params.row);
         });
-
+        
+        if (data.length) this.initData(data, 'append');
         this.initSearch();
         this.initPagination();
         this.initSort();


### PR DESCRIPTION
during updateByUniqueId, when data have some new entries,  in order to avoid multiple init steps, just go ahead append the data.