### PR TITLE
Make pageList "All" option locale independant

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1382,7 +1382,7 @@
 
                 pageList = [];
                 $.each(list, function (i, value) {
-                    pageList.push((value.toUpperCase() === that.options.formatAllRows().toUpperCase() || value.toUpperCase() === "ALL") ?
+                    pageList.push((value.toUpperCase() === that.options.formatAllRows().toUpperCase() || value.toUpperCase() === "UNLIMITED") ?
                         that.options.formatAllRows() : +value);
                 });
             }

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1382,7 +1382,7 @@
 
                 pageList = [];
                 $.each(list, function (i, value) {
-                    pageList.push(value.toUpperCase() === that.options.formatAllRows().toUpperCase() ?
+                    pageList.push((value.toUpperCase() === that.options.formatAllRows().toUpperCase() || value.toUpperCase() === "ALL") ?
                         that.options.formatAllRows() : +value);
                 });
             }


### PR DESCRIPTION
With current implementation, using the "All" option in the pageList requires declaring it in the table options with the same locale as the one used at runtime. This is an issue when the local is chosen dynamically depending on client configuration.

For instance, if locale is fr-FR, pageList = [ 10, 25, all ] will show [10, 25, NaN] in the page list, and pageList = [ 10, 25, tous ] will show a proper list. But pageList = [ 10, 25, tous ] will display [10, 25, NaN] if locale is en-US.

This change allows to have the option in every locale with the "unlimited" keyword. pageList = [ 10, 25, unlimited] will show [10,25,Tous] with fr-FR, [10,25,All] with en-US, and so on.

The behavior when using the localized "All" string remains unchanged.