### PR TITLE
Allow for clear functionality without generating a button

### DIFF
--- a/dist/extensions/filter-control/bootstrap-table-filter-control.js
+++ b/dist/extensions/filter-control/bootstrap-table-filter-control.js
@@ -428,6 +428,7 @@
             return false;
         },
         filterShowClear: false,
+        filterGenerateClear: true,
         alignmentSelectControlOptions: undefined,
         filterTemplate: {
             input: function (that, field, isVisible, placeholder) {
@@ -520,18 +521,25 @@
         _initToolbar.apply(this, Array.prototype.slice.apply(arguments));
 
         if (this.options.filterControl && this.options.filterShowClear) {
-            var $btnGroup = this.$toolbar.find('>.btn-group'),
-                $btnClear = $btnGroup.find('.filter-show-clear');
+            if(this.options.filterGenerateClear) {
+                var $btnGroup = this.$toolbar.find('>.btn-group'),
+                    $btnClear = $btnGroup.find('.filter-show-clear');
 
-            if (!$btnClear.length) {
-                $btnClear = $([
-                    '<button class="btn btn-default filter-show-clear" ',
-                    sprintf('type="button" title="%s">', this.options.formatClearFilters()),
-                    sprintf('<i class="%s %s"></i> ', this.options.iconsPrefix, this.options.icons.clear),
-                    '</button>'
-                ].join('')).appendTo($btnGroup);
+                if (!$btnClear.length) {
+                    $btnClear = $([
+                        '<button class="btn btn-default filter-show-clear" ',
+                        sprintf('type="button" title="%s">', this.options.formatClearFilters()),
+                        sprintf('<i class="%s %s"></i> ', this.options.iconsPrefix, this.options.icons.clear),
+                        '</button>'
+                    ].join('')).appendTo($btnGroup);
 
-                $btnClear.off('click').on('click', $.proxy(this.clearFilterControl, this));
+                    $btnClear.off('click').on('click', $.proxy(this.clearFilterControl, this));
+                }
+            } else {
+                var $btnClear = $('.filter-clear');
+                if($btnClear.length) {
+                    $btnClear.off('click').on('click', $.proxy(this.clearFilterControl, this));
+                }
             }
         }
     };

--- a/src/extensions/filter-control/README.md
+++ b/src/extensions/filter-control/README.md
@@ -24,6 +24,11 @@ Dependence if you use the datepicker option: [bootstrap-datepicker](https://gith
 * description: Set true to add a button to clear all the controls added by this plugin.
 * default: `false`
 
+### filterGenerateClear
+* type: Boolean
+* description: If `filterShowClear` is `true` then this flag can be used to suppress the generation of a clear button. When set to `false` the clear functionality will be bound to DOM elements with class `.filter-clear` 
+* default: `true`
+
 ### alignmentSelectControlOptions
 
 * type: String


### PR DESCRIPTION
This PR implements #3469 and addresses my desire to be able to generate static buttons to clear filters.