### PR TITLE
Update bootstrap-table.css

### DIFF
--- a/src/bootstrap-table.css
+++ b/src/bootstrap-table.css
@@ -124,6 +124,10 @@
     border-left: none;
 }
 
+.fixed-table-container thead tr:nth-child(2) th:first-child {
+    border-left: 1px solid #ddd;
+}
+
 /* the same color with .active */
 .fixed-table-container tbody .selected td {
     background-color: #f5f5f5;


### PR DESCRIPTION
fixes the missing left border of grouped header's second row's first td element. it was (probably) an issue when those headers created dynamically.

example: http://issues.wenzhixin.net.cn/bootstrap-table/welcome.html