### PR TITLE
Cookie on filter-control with strict search enabled

### DIFF
--- a/src/extensions/cookie/bootstrap-table-cookie.js
+++ b/src/extensions/cookie/bootstrap-table-cookie.js
@@ -179,8 +179,10 @@
 
                     applyCookieFilters = function (element, filteredCookies) {
                         $(filteredCookies).each(function (i, cookie) {
+                            if (cookie.text !== '') {
                                 $(element).val(cookie.text);
                                 cachedFilters[cookie.field] = cookie.text;
+                            }                                
                         });
                     };
 

--- a/src/extensions/cookie/bootstrap-table-cookie.js
+++ b/src/extensions/cookie/bootstrap-table-cookie.js
@@ -179,10 +179,8 @@
 
                     applyCookieFilters = function (element, filteredCookies) {
                         $(filteredCookies).each(function (i, cookie) {
-                            if (cookie.text !== '') {
                                 $(element).val(cookie.text);
                                 cachedFilters[cookie.field] = cookie.text;
-                            }                            
                         });
                     };
 

--- a/src/extensions/cookie/bootstrap-table-cookie.js
+++ b/src/extensions/cookie/bootstrap-table-cookie.js
@@ -179,8 +179,10 @@
 
                     applyCookieFilters = function (element, filteredCookies) {
                         $(filteredCookies).each(function (i, cookie) {
-                            $(element).val(cookie.text);
-                            cachedFilters[cookie.field] = cookie.text;
+                            if (cookie.text !== '') {
+                                $(element).val(cookie.text);
+                                cachedFilters[cookie.field] = cookie.text;
+                            }                            
                         });
                     };
 


### PR DESCRIPTION
When using cookie in combination with filter-control and strict search enabled on a column, selecting the empty value would store it as an empty value in cookie. When returning to the page and thus getting the cookie, it would result in no results in bootstrap-table because it would literally search for ''.

This fix will allow for usage of strict search with filter-control and cookie enabled, and will show default values as expected when resetting filter.