### PR TITLE
Install Grunt locally, rather than globally.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,3 @@ language: node_js
 
 node_js:
     - "0.10"
-
-before_install:
-    - npm install grunt-cli -g

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Look at the [Change Log](https://github.com/wenzhixin/bootstrap-table/blob/maste
 To build bootstrap-table locally please run:
 
 ```
-grunt build
+npm run grunt
 ```
 
 Result will appear in `dist` directory.

--- a/docs/_i18n/en/getting-started/grunt.md
+++ b/docs/_i18n/en/getting-started/grunt.md
@@ -10,26 +10,17 @@ To install Grunt, you must **first** [download and install node.js](http://nodej
 
 Then, from the command line:
 
-1. Install `grunt-cli` globally with `npm install -g grunt-cli`.
-2. Navigate to the root `/bootstrap-table/` directory, then run `npm install`. npm will look at the `package.json` file and automatically install the necessary local dependencies listed there.
+1. Navigate to the root `/bootstrap-table/` directory, then run `npm install`. npm will look at the `package.json` file and automatically install the necessary local dependencies listed there.
 
 When completed, you'll be able to run the various Grunt commands provided from the command line.
 
 ## Available Grunt commands
 
-### `grunt dist` (Just compile CSS and JavaScript)
-
-Regenerates the `/dist/` directory with compiled and minified CSS and JavaScript files. As a Bootstrap user, this is normally the command you want.
-
-### `grunt test` (Run tests)
-
-Runs [JSHint](http://jshint.com/) to test our code.
-
-### `grunt docs` (Build & test the docs assets)
+### `npm run grunt docs` (Build & test the docs assets)
 
 Builds and tests CSS, JavaScript, and other assets which are used when running the documentation locally via `jekyll serve`.
 
-### `grunt` (Build absolutely everything and run tests)
+### `npm run grunt` (Build absolutely everything and run tests)
 
 Compiles and minifies CSS and JavaScript, builds the documentation website, runs the HTML5 validator against the docs, regenerates the Customizer assets, and more. Requires [Jekyll](http://jekyllrb.com/docs/installation/).
 

--- a/docs/_i18n/es/getting-started/grunt.md
+++ b/docs/_i18n/es/getting-started/grunt.md
@@ -10,26 +10,17 @@ Para instalar Grunt, se debe **primero** [descargar e instalar node.js](http://n
 
 Entonces, en la linea de comandos:
 
-1. Instalar `grunt-cli` globalmente con `npm install -g grunt-cli`.
-2. Navegue hasta la ruta del folder `/bootstrap-table/`, entonces ejecute `npm install`. npm buscará el archivo `package.json` y automaticamente instalará las dependencias locales necesarias listadas aquí.
+1. Navegue hasta la ruta del folder `/bootstrap-table/`, entonces ejecute `npm install`. npm buscará el archivo `package.json` y automaticamente instalará las dependencias locales necesarias listadas aquí.
 
 Cuando esté completo, ya se podrá ejecutar varios comandos de Grunt en la linea de comandos.
 
 ## Available Grunt commands
 
-### `grunt dist` (Just compile CSS and JavaScript)
-
-Regenerando el folder `/dist/` con el CSS y JavaScript compilado. Como un usuario de Bootstrap, este es el comando.
-
-### `grunt test` (Run tests)
-
-Ejecute [JSHint](http://jshint.com/) para probar nuestras pruebas.
-
-### `grunt docs` (Compila y prueba la documentación)
+### `npm run grunt docs` (Compila y prueba la documentación)
 
 Compila y purueba el CSS, JavaScript, y otros artchivos cuando se esta ejecutando la documentación localmente con `jekyll serve`.
 
-### `grunt` (Compila absolutamente todo y ejecuta pruebas)
+### `npm run grunt` (Compila absolutamente todo y ejecuta pruebas)
 
 Compila y minifica el CSS y JavaScript, compila la documentación, ejecuta el validador de HTML5 contra la documentación, regenera los archivos customizables, y más. Se requiere [Jekyll](http://jekyllrb.com/docs/installation/).
 

--- a/docs/_i18n/zh-cn/getting-started/grunt.md
+++ b/docs/_i18n/zh-cn/getting-started/grunt.md
@@ -10,26 +10,17 @@ Bootstrap table 使用 [Grunt](http://gruntjs.com/) 来作为编译系统，可�
 
 然后，我们使用命令行：
 
-1. 安装全局的 `grunt-cli`，使用 `npm install -g grunt-cli` 命令即可。
-2. 进入到 `/bootstrap-table/` 的根目录，然后运行 `npm install`。npm 将通过查找 `package.json` 文件并自动安装这里所需要的依赖。
+1. 进入到 `/bootstrap-table/` 的根目录，然后运行 `npm install`。npm 将通过查找 `package.json` 文件并自动安装这里所需要的依赖。
 
 完成之后，你就可以运行一下的命令来编译的代码了。
 
 ## 可以用的 Grunt 命令
 
-### `grunt dist` (编译 CSS 和 JavaScript)
-
-这里我们会生成 `/dist/` 文件夹。 As a Bootstrap user, this is normally the command you want.
-
-### `grunt test` (运行 tests)
-
-运行 [JSHint](http://jshint.com/) 来测试我们的代码。
-
-### `grunt docs` (编译和测试文档)
+### `npm run grunt docs` (编译和测试文档)
 
 编译和测试 CSS，JavaScript，本地我们可以通过 `jekyll serve` 来运行我们的文档。
 
-### `grunt` (编译所有并运行测试)
+### `npm run grunt` (编译所有并运行测试)
 
 压缩和扰乱 CSS 和 JavaScript，测试，编译文档等等。依赖 [Jekyll](http://jekyllrb.com/docs/installation/)。
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "devDependencies": {
     "cz-conventional-changelog": "^1.1.5",
     "grunt": "^0.4.5",
+    "grunt-cli": "^1.2.0",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-concat": "^0.5.1",
     "grunt-contrib-copy": "^0.8.0",
@@ -16,6 +17,9 @@
     "grunt-contrib-jshint": "^0.10.0",
     "grunt-contrib-uglify": "^0.8.0",
     "grunt-release": "^0.13.0"
+  },
+  "scripts": {
+    "grunt": "grunt"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This is considered best practice, see
https://github.com/gruntjs/grunt-cli#installing-grunt-cli-locally.