### PR TITLE
cosmetic patch for collision on certain conditions

### DIFF
--- a/src/extensions/group-by-v2/bootstrap-table-group-by.css
+++ b/src/extensions/group-by-v2/bootstrap-table-group-by.css
@@ -5,3 +5,7 @@
 .bootstrap-table .table > tbody > tr.groupBy.expanded {
 
 }
+
+.bootstrap-table .table > tbody > tr.groupBy + tr.hidden + tr.detail-view {
+    display: none;
+}

--- a/src/extensions/group-by-v2/bootstrap-table-group-by.css
+++ b/src/extensions/group-by-v2/bootstrap-table-group-by.css
@@ -6,6 +6,6 @@
 
 }
 
-.bootstrap-table .table > tbody > tr.groupBy + tr.hidden + tr.detail-view {
+tr.hidden + tr.detail-view {
     display: none;
 }


### PR DESCRIPTION
the collision is faced when group-by-v2 plugin is used along w/ enabled detailView — if one expands one or more rows in a group into detailView mode & then clicks on tr.groupBy row to collapse this group, the source rows become hidden just as expected, but their detailView representations still stay visible & expanded

applied patch fixes the issue