### PR TITLE
Added the possibility to use rowStyles when using tree grid.

### DIFF
--- a/src/extensions/treegrid/bootstrap-table-treegrid.js
+++ b/src/extensions/treegrid/bootstrap-table-treegrid.js
@@ -1,6 +1,6 @@
 /**
  * @author: YL
- * @version: v1.0.0
+ * @version: v1.1.0
  */
 !function ($) {
     'use strict';
@@ -8,6 +8,7 @@
         treeShowField: null,
         idField: 'id',
         parentIdField: 'pid',
+        afterTreeRowStyle: function (row) { },
         onGetNodes: function (row, data) {
             var that = this;
             var nodes = [];
@@ -62,7 +63,7 @@
                 var id = item[that.options.idField] ? item[that.options.idField] : 0;
                 var pid = item[that.options.parentIdField] ? item[that.options.parentIdField] : 0;
                 return {
-                    classes: 'treegrid-' + id + ' treegrid-parent-' + pid
+                    classes: 'treegrid-' + id + ' treegrid-parent-' + pid + ' ' + that.options.afterTreeRowStyle(item).classes
                 };
             };
             initTr.apply(that, [node, $.inArray(node, data), data, parentDom]);
@@ -82,7 +83,7 @@
                 that.options.rowStyle = function (item, idx) {
                     var x = item[that.options.idField] ? item[that.options.idField] : 0;
                     return {
-                        classes: 'treegrid-' + x
+                        classes: 'treegrid-' + x + ' ' + that.options.afterTreeRowStyle(item).classes
                     };
                 };
                 initTr.apply(that, [item, idx, data, parentDom]);


### PR DESCRIPTION
Bootstrap-table has the rowStyle property in order for us to set classes for an entire row.
For example:

```
rowStyle: (row, index) => {
	if (row.foo != undefined) {
		return { classes: 'success' };
	} else {
		return { classes: 'danger' };
	}
}
```

When using the plugin tree-grid we can see that it overrides our customized rowStyle function:

```
that.options.rowStyle = function (item, idx) {
	var x = item[that.options.idField] ? item[that.options.idField] : 0;
	return {
		classes: 'treegrid-' + x
	};
};
```
So after the tree is initialized, we lost our rowStyle. In order to workaround this I added a function named: `afterTreeRowStyle` that applies our customizations after the tree initialization.
