### PR TITLE
Remove `fixed` option from resizable extension

### DIFF
--- a/src/extensions/resizable/README.md
+++ b/src/extensions/resizable/README.md
@@ -23,12 +23,6 @@ Dependence: [colResizable](https://github.com/alvaro-prieto/colResizable) v1.6
 * description: When set to true the table layout is updated while dragging column anchors. liveDrag enabled is more CPU consuming so it is not recommended for slow computers, specially when dealing with huge or extremely complicated tables.
 * default: `false`
 
-### fixed
-
-* type: Boolean
-* description: It is used to set how the resize method works. In fixed mode resizing a column does not alter total table width, which means that when a column is expanded the next one shrinks. If fixed is set to false then table can change its width and each column can shrink or expand independently.
-* default: `true`
-
 ### headerOnly
 
 * type: Boolean

--- a/src/extensions/resizable/bootstrap-table-resizable.js
+++ b/src/extensions/resizable/bootstrap-table-resizable.js
@@ -1,7 +1,7 @@
 /**
  * @author: Dennis Hernández
  * @webSite: http://djhvscf.github.io/Blog
- * @version: v1.0.0
+ * @version: v1.1.1
  */
 
 (function ($) {

--- a/src/extensions/resizable/bootstrap-table-resizable.js
+++ b/src/extensions/resizable/bootstrap-table-resizable.js
@@ -14,7 +14,6 @@
         //Creates the plugin
         that.$el.colResizable({
             liveDrag: that.options.liveDrag,
-            fixed: that.options.fixed,
             headerOnly: that.options.headerOnly,
             minWidth: that.options.minWidth,
             hoverCursor: that.options.hoverCursor,
@@ -28,7 +27,6 @@
     $.extend($.fn.bootstrapTable.defaults, {
         resizable: false,
         liveDrag: false,
-        fixed: true,
         headerOnly: false,
         minWidth: 15,
         hoverCursor: 'e-resize',

--- a/src/extensions/resizable/extension.json
+++ b/src/extensions/resizable/extension.json
@@ -1,6 +1,6 @@
 {
   "name": "Resizable",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Plugin to support the resizable feature.",
   "url": "https://github.com/wenzhixin/bootstrap-table/tree/master/src/extensions/resizable",
   "example": "http://issues.wenzhixin.net.cn/bootstrap-table/#extensions/resizable.html",


### PR DESCRIPTION
According to [colResizable documentation](http://www.bacubacu.com/colresizable/#attributes) the `fixed` option is deprecated. `resizeMode` is the one that should be used.