### PR TITLE
Update bootstrap-table-export.js

### DIFF
--- a/src/extensions/export/bootstrap-table-export.js
+++ b/src/extensions/export/bootstrap-table-export.js
@@ -67,7 +67,7 @@
                         '</button>',
                         '<ul class="dropdown-menu" role="menu">',
                         '</ul>',
-                    '</div>'].join('')).appendTo($btnGroup);
+                    '</div>'].join('')).appendTo($btnGroup[0]);
 
                 var $menu = $export.find('.dropdown-menu'),
                     exportTypes = this.options.exportTypes;


### PR DESCRIPTION
solving problem of multiple export button will be displayed when using export extension with advancedSearch (bootstrap-table-toolbar) extension...

this show the bug.
![screen shot 2018-03-17 at 11 47 58 pm](https://user-images.githubusercontent.com/16401732/37560256-aaaff108-2a3d-11e8-88d8-d50f2a28f119.png)

solve it by adding the export button to index 0 of btnGroup
$btnGroup[0] instead of $btnGroup
