### PR TITLE
Limit fullscreen CSS rule scope

### DIFF
--- a/src/bootstrap-table.css
+++ b/src/bootstrap-table.css
@@ -307,7 +307,7 @@ div.fixed-table-scroll-outer {
     clear: both;
 }
 
-.fullscreen {
+.bootstrap-table.fullscreen {
     position: fixed;
     top: 0;
     left: 0;


### PR DESCRIPTION
Only apply the fullscreen rule to bootstrap-table elements, not any other elements that also happen to have a fullscreen class.