### PR TITLE
Changed pull- to float- because pull was removed from Bootstrap 4

### DIFF
--- a/src/bootstrap-table.css
+++ b/src/bootstrap-table.css
@@ -280,7 +280,7 @@
     padding: 0 !important;
 }
 
-.bootstrap-table .pull-right .dropdown-menu {
+.bootstrap-table .float-right .dropdown-menu {
     right: 0;
     left: auto;
 }

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -29,7 +29,7 @@
       },
       classes: {
         buttons: 'default',
-        pull: 'pull'
+        pull: 'float'
       },
       html: {
         toobarDropdow: ['<ul class="dropdown-menu" role="menu">', '</ul>'],


### PR DESCRIPTION
`pull-left` and `pull-right` have been removed from Bootstrap 4 in favor of `float-left` and `float-right`. This requires a minor change to css and js source files.

[https://getbootstrap.com/docs/4.0/migration/#utilities](https://getbootstrap.com/docs/4.0/migration/#utilities)

> Added .float-{sm,md,lg,xl}-{left,right,none} classes for responsive floats and removed .pull-left and .pull-right since they’re redundant to .float-left and .float-right.