### PR TITLE
Plugin to enable the multiple selection row v2

### DIFF
--- a/src/extensions/multiple-selection-row-v2/README.md
+++ b/src/extensions/multiple-selection-row-v2/README.md
@@ -1,0 +1,22 @@
+# Table Multiple Selection Row v2
+
+Use Plugin: [bootstrap-table-multiple-selection-row-2](https://github.com/wenzhixin/bootstrap-table/tree/master/src/extensions/multiple-selection-row-v2)
+
+jsFiddle example: [multiple-selection-row-2](https://jsfiddle.net/Bighamster/4rw6679x/)
+
+Example: [multiple-selection-row-2](http://issues.wenzhixin.net.cn/bootstrap-table/#extensions/multiple-selection-row-v2.html)
+
+## Usage
+
+```html
+<link rel="stylesheet" type="text/css" href="extensions/multiple-selection-row-v2/bootstrap-table-multiple-selection-row-v2.css">
+<script src="extensions/multiple-selection-row-v2/bootstrap-table-multiple-selection-row-v2.js"></script>
+```
+
+## Options
+
+### multipleSelectRow
+
+* type: Boolean
+* description: Set true to enable the multiple selection row.
+* default: `false`

--- a/src/extensions/multiple-selection-row-v2/bootstrap-table-multiple-selection-row-v2.css
+++ b/src/extensions/multiple-selection-row-v2/bootstrap-table-multiple-selection-row-v2.css
@@ -1,0 +1,8 @@
+.selected td {
+  color: white !important;
+  background-color: #08C !important;
+}
+
+.selected td a {
+  color: white !important;
+}

--- a/src/extensions/multiple-selection-row-v2/bootstrap-table-multiple-selection-row-v2.js
+++ b/src/extensions/multiple-selection-row-v2/bootstrap-table-multiple-selection-row-v2.js
@@ -1,0 +1,90 @@
+/**
+ * @author: Bighamster
+ * @webSite: https://github.com/Bighamster
+ * @version: v1.0.0
+ */
+!function($) {
+
+  'use strict';
+
+  $.extend($.fn.bootstrapTable.defaults, {
+    formatSelectedRows: function (totalRows) { return totalRows == 0 ? '' : (" "+totalRows+" row"+(totalRows > 1 ? 's' : '')+" selected"); }
+  });
+
+  var BootstrapTable  = $.fn.bootstrapTable.Constructor,
+            _initBody = BootstrapTable.prototype.initBody;
+
+  BootstrapTable.prototype.initBody = function () {
+
+  _initBody.apply(this, Array.prototype.slice.apply(arguments));
+
+  if( this.options.multipleSelectRow ) {
+
+    var that = this;
+
+    that.$body.find('> tr[data-index] > td').off('mousedown').on('mousedown', function(e) {
+      that.options.multipleSelectRowCtrlKey  = e.ctrlKey || e.metaKey;
+      that.options.multipleSelectRowShiftKey = e.shiftKey;
+    });
+
+    that.$selectItem.off('click').on('click', function(e) {
+
+      e.stopImmediatePropagation();
+
+      var $this = $(this),
+          checked = $this.prop('checked'),
+          index = $this.data('index'),
+          row = that.data[index];
+
+      if( $(this).is(':radio') ) {
+        $.each(that.options.data, function (i, row) {
+          row[that.header.stateField] = false;
+        });
+      }
+
+      row[that.header.stateField] = checked;
+
+      if( that.options.multipleSelectRowShiftKey && that.options.multipleSelectRowLastSelectedIndex >= 0 ) {
+
+        var indexes = [that.options.multipleSelectRowLastSelectedIndex, index].sort();
+
+        for(var i = indexes[0] + 1; i < indexes[1]; i++) {
+          that.data[i][that.header.stateField] = true;
+          that.$selectItem.filter('[data-index="'+i+'"]').prop('checked', true);
+        }
+      }
+      else {
+        if( that.options.multipleSelectRowCtrlKey ) {
+         // do nothing
+        }
+        else {
+          that.$selectItem.not(this).each(function () { that.data[$(this).data('index')][that.header.stateField] = false; });
+          that.$selectItem.filter(':checked').not(this).prop('checked', false);
+        }
+      }
+
+      that.updateSelected();
+      that.trigger(checked ? 'check' : 'uncheck', row, $this);
+      that.options.multipleSelectRowCtrlKey = false;
+      that.options.multipleSelectRowShiftKey = false;
+      that.options.multipleSelectRowLastSelectedIndex = checked ? index : null;
+    });
+
+    // Show selected items (qty) if pagination is true
+    that.$tableBody.off('check.bs.table uncheck.bs.table').on('check.bs.table uncheck.bs.table', function() {
+
+      var $pagination_info = $('.pagination-info');
+
+      if( $pagination_info.length ) {
+        var $selection_info = $('.selection-info');
+
+        if( $selection_info.length == 0 ) {
+          $selection_info = $("<span class='selection-info'></span>").insertAfter($pagination_info);
+        }
+
+        $selection_info.text( that.options.formatSelectedRows( that.getSelections().length ) );
+      }
+    });
+  }
+ };
+}(jQuery);

--- a/src/extensions/multiple-selection-row-v2/extension.json
+++ b/src/extensions/multiple-selection-row-v2/extension.json
@@ -1,0 +1,17 @@
+{
+  "name": "Multiple Selection Row v2",
+  "version": "1.0.0",
+  "description": "Plugin to enable the multiple selection row. You can use the ctrl+click to select one row or use shift+click to select a range of rows.",
+  "url": "https://github.com/wenzhixin/bootstrap-table/tree/master/src/extensions/multiple-selection-row-v2",
+  "example": "http://issues.wenzhixin.net.cn/bootstrap-table/#extensions/bootstrap-table-multiple-selection-row-v2.html",
+
+  "plugins": [{
+    "name": "bootstrap-table-multiple-selection-row-v2",
+    "url": "https://github.com/wenzhixin/bootstrap-table/tree/master/src/extensions/multiple-selection-row-v2"
+  }],
+
+  "author": {
+    "name": "Bighamster",
+    "image": "https://avatars1.githubusercontent.com/u/524100?s=400&u=f0458bb37e37f7fefa9a44bc6eead3b850f7d9ef&v=4"
+  }
+}


### PR DESCRIPTION
Plugin to enable the multiple selection row. You can use the ctrl+click to select one row or use shift+click to select a range of rows.

jsFiddle example: [multiple selection row v2](https://jsfiddle.net/Bighamster/4rw6679x/)