### PR TITLE
 在Bootstrap 4下，Sticky header 的 thead总是浅色背景

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -43,7 +43,7 @@
       icons: {
         paginationSwitchDown: 'fa-toggle-down',
         paginationSwitchUp: 'fa-toggle-up',
-        refresh: 'fa-refresh',
+        refresh: 'fa-sync',
         toggleOff: 'fa-toggle-off',
         toggleOn: 'fa-toggle-on',
         columns: 'fa-th-list',

--- a/src/extensions/sticky-header/bootstrap-table-sticky-header.js
+++ b/src/extensions/sticky-header/bootstrap-table-sticky-header.js
@@ -95,7 +95,7 @@
                 // create scrollable container for header
                 var scrollable_div = $('<div style="position:absolute;width:100%;overflow-x:hidden;" />');
                 // append cloned header to dom
-                $("#"+sticky_header_container_id).html(scrollable_div.append(that.$stickyHeader));
+                $("#"+sticky_header_container_id).html(scrollable_div.append($('<table>').addClass('table').append(that.$stickyHeader)));
                 // match clone and source header positions when left-right scroll
                 match_position_x(event);
             } else {


### PR DESCRIPTION
在Bootstrap 4下存在兼容性问题，指定"thead-dark"时，sticky-header的背景色是浅色的。
现在兼容了。
另外改成兼容Font Awesome 5