### PR TITLE
Fix #3696: can't search data with formatter

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1295,16 +1295,16 @@
                   value = value[props[i]]
                 }
               }
-
-              // Fix #142: respect searchForamtter boolean
-              if (column && column.searchFormatter) {
-                value = Utils.calculateObjectValue(column,
-                  this.header.formatters[j], [value, item, i], value)
-              }
             } else {
               value = item[key]
             }
 
+            // Fix #142: respect searchForamtter boolean
+            if (column && column.searchFormatter) {
+              value = Utils.calculateObjectValue(column,
+                this.header.formatters[j], [value, item, i], value)
+            }
+            
             if (typeof value === 'string' || typeof value === 'number') {
               if (this.options.strictSearch) {
                 if ((`${value}`).toLowerCase() === s) {


### PR DESCRIPTION
The 'searchFormatter' option was ignored when column.field was an array index.