### PR TITLE
修复多行表头在 IE 中缺少左边框问题 (Multi head in IE , some cells have no left border)

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -825,7 +825,8 @@
             Utils.sprintf(' rowspan="%s"', column.rowspan),
             Utils.sprintf(' colspan="%s"', column.colspan),
             Utils.sprintf(' data-field="%s"', column.field),
-            j === 0 && column.fieldIndex ? ' data-not-first-th' : '',
+            // If `column` is not the first element of `this.options.columns[0]`, then className 'data-not-first-th' should be added.
+            j === 0 && i > 0 ? ' data-not-first-th' : '',
             '>')
 
           html.push(Utils.sprintf('<div class="th-inner %s">', this.options.sortable && column.sortable


### PR DESCRIPTION
Multi head in **IE** , some cells have no left border, at this test case([https://codepen.io/shawchen08/pen/MBKjzO](https://codepen.io/shawchen08/pen/MBKjzO)) , the "Info 2" cell has no   left border.