### PR TITLE
修改treegrid parent id不能为字符串，增加rootParentId，指定根节点pid值。

### DIFF
--- a/src/extensions/treegrid/bootstrap-table-treegrid.js
+++ b/src/extensions/treegrid/bootstrap-table-treegrid.js
@@ -8,6 +8,7 @@
         treeShowField: null,
         idField: 'id',
         parentIdField: 'pid',
+		rootParentId: null,
         onGetNodes: function (row, data) {
             var that = this;
             var nodes = [];
@@ -20,7 +21,9 @@
         },
         onCheckRoot: function (row, data) {
             var that = this;
-            return !row[that.options.parentIdField];
+            return that.options.rootParentId == row[that.options.parentIdField]
+				|| null == row[that.options.parentIdField]
+				|| undefined == row[that.options.parentIdField];
         }
     });
 


### PR DESCRIPTION
用法：
options: {
...,
rootParentId: rootPID,
...
}
如不指定，这默认将pid值为null或undefined的节点做为根节点。