### PR TITLE
Allow different x-editable configuration per table row

### DIFF
--- a/src/extensions/editable/README.md
+++ b/src/extensions/editable/README.md
@@ -20,8 +20,10 @@ Use Plugin: [x-editable](https://github.com/vitalets/x-editable)
 
 ### editable
 
-* type: Object
+* type: Object or Function
 * description: Configuration of x-editable. Full list of options: http://vitalets.github.io/x-editable/docs.html#editable
+* If it is type of Function, it is called with params: index, row, element for
+  each row of the table. It should return Object of the x-editable configuration.
 * default: `undefined`
 
 All options can be defined via `data-editable-*` HTML attributes. Table wide options are used for every column but can be overridden:

--- a/src/extensions/editable/bootstrap-table-editable.js
+++ b/src/extensions/editable/bootstrap-table-editable.js
@@ -111,6 +111,20 @@
                 return;
             }
 
+            var data = that.getData();
+
+            that.$body.find('a[data-name="' + column.field + '"]').each(function(i, element){
+                var $element = $(element);
+                var $tr = $element.closest('tr');
+                var index = $tr.data('index');
+                var row = data[index];
+
+                var editableOpts = $.fn.bootstrapTable.utils.calculateObjectValue(column, column.editable, [index, row, $element], {});
+
+                $element.editable(editableOpts);
+            });
+
+
             that.$body.find('a[data-name="' + column.field + '"]').editable(column.editable)
                 .off('save').on('save', function(e, params) {
                     var data = that.getData(),


### PR DESCRIPTION
In my use case I need different x-editable elements for each row in one column in dependency on datatype on that row. 

This pull request allow `editable` option to be a function that can generate different configuration for x-editable.