### PR TITLE
Fix error when with numbers in accent neutralise

### DIFF
--- a/src/extensions/accent-neutralise/bootstrap-table-accent-neutralise.js
+++ b/src/extensions/accent-neutralise/bootstrap-table-accent-neutralise.js
@@ -158,7 +158,7 @@
                     }
 
                     var index = $.inArray(key, that.header.fields);
-                    if (index !== -1 && that.header.searchables[index] && (typeof value === 'string' || typeof value === 'number')) {
+                    if (index !== -1 && that.header.searchables[index] && typeof value === 'string') {
                         if (that.options.searchAccentNeutralise) {
                             value = removeDiacritics(value);
                             s = removeDiacritics(s);


### PR DESCRIPTION
When you enable accent neutralise in a table and you have one column with numbers as data, [this line](https://github.com/wenzhixin/bootstrap-table/blob/4b6fd6b375b3678135cb8d3f20cca0793a32d9e1/src/extensions/accent-neutralise/bootstrap-table-accent-neutralise.js#L111) throws an error because the "str" var is a number, and the number type dont have a replace function.

Also, there is no reason to try to "remove" accents from numbers.