### PR TITLE
Support editable obj.field1.field2

### DIFF
--- a/src/extensions/editable/bootstrap-table-editable.js
+++ b/src/extensions/editable/bootstrap-table-editable.js
@@ -119,7 +119,11 @@
                         oldValue = row[column.field];
 
                     $(this).data('value', params.submitValue);
-                    row[column.field] = params.submitValue;
+                    if (column.field.indexOf('.') < 0) {
+                        row[column.field] = params.submitValue;
+                    } else {
+                        eval('row.' + column.field + '=' + params.submitValue);
+                    }
                     that.trigger('editable-save', column.field, row, oldValue, $(this));
                     that.resetFooter();
                 });

--- a/src/extensions/editable/bootstrap-table-editable.js
+++ b/src/extensions/editable/bootstrap-table-editable.js
@@ -122,7 +122,7 @@
                     if (column.field.indexOf('.') < 0) {
                         row[column.field] = params.submitValue;
                     } else {
-                        eval('row.' + column.field + '=' + params.submitValue);
+                        eval('row.' + column.field + '="' + params.submitValue.replace(/"/g, '\\"') + '"');
                     }
                     that.trigger('editable-save', column.field, row, oldValue, $(this));
                     that.resetFooter();


### PR DESCRIPTION
```
obj = { field1: { field2: 2 } };
```
When I use editable to edit field2, `obj` will and a field" `field1.field2: 2`".
This pull request fixed it.