### PR TITLE
 bootstrap-table-group-by header formatter

### DIFF
--- a/site/docs/extensions/group-by-v2.md
+++ b/site/docs/extensions/group-by-v2.md
@@ -36,3 +36,17 @@ You must include the bootstrap-table-group-by.css file in order to get the appro
    Set the fields name that you want to group the data.
 
 - **Default:** `''`
+
+### groupByFormatter
+
+- **type:** `Function`
+
+- **Detail:**
+
+   The group row formatter function, takes three parameters:
+
+   value: the group by value.
+   idx: the index of the group.
+   data: an array of rows in the group.
+
+- **Default:** `Undefined`

--- a/site/docs/extensions/group-by-v2.md
+++ b/site/docs/extensions/group-by-v2.md
@@ -10,10 +10,9 @@ Use Plugin: [bootstrap-table-group-by-v2](https://github.com/wenzhixin/bootstrap
 You must include the bootstrap-table-group-by.css file in order to get the appropriate style
 
 ## Usage
-
-{% highlight html %}
+```
 <script src="extensions/group-by-v2/bootstrap-table-group-by.js"></script>
-{% endhighlight %}
+```
 
 ## Options
 
@@ -45,8 +44,8 @@ You must include the bootstrap-table-group-by.css file in order to get the appro
 
    The group row formatter function, takes three parameters:
 
-   value: the group by value.
-   idx: the index of the group.
-   data: an array of rows in the group.
+   * `value`: the group by value.
+   * `idx`: the index of the group.
+   * `data`: an array of rows in the group.
 
 - **Default:** `Undefined`

--- a/src/extensions/group-by-v2/bootstrap-table-group-by.js
+++ b/src/extensions/group-by-v2/bootstrap-table-group-by.js
@@ -1,6 +1,6 @@
 /**
  * @author: Yura Knoxville
- * @version: v1.0.0
+ * @version: v1.1.0
  */
 
 (function ($) {
@@ -27,7 +27,6 @@
         });
         return flag ? str : '';
     };
-
     
     var groupBy = function (array , f) {
         var groups = {};
@@ -40,26 +39,18 @@
         return groups;
     };
 
-
-
     $.extend($.fn.bootstrapTable.defaults, {
         groupBy: false,
         groupByField: '',
         groupByFormatter: undefined
     });
 
-
     var BootstrapTable = $.fn.bootstrapTable.Constructor,
         _initSort = BootstrapTable.prototype.initSort,
         _initBody = BootstrapTable.prototype.initBody,
         _updateSelected = BootstrapTable.prototype.updateSelected;
 
-
-
-
     BootstrapTable.prototype.initSort = function () {
-
-
         _initSort.apply(this, Array.prototype.slice.apply(arguments));
 
         var that = this;
@@ -69,8 +60,7 @@
 
             if ((this.options.sortName != this.options.groupByField)) {
                 this.data.sort(function(a, b) {
-                    if (a[that.options.groupByField] == b[that.options.groupByField]) return String(a[that.options.sortName]).localeCompare(String(b[that.options.sortName])); //sortable by byron 16 april 2018
-                    return String(a[that.options.groupByField]).localeCompare(String(b[that.options.groupByField]));
+                    return a[that.options.groupByField].localeCompare(b[that.options.groupByField]);
                 });
             }
 
@@ -99,9 +89,6 @@
             });
         }
     }
-
-
-
 
     BootstrapTable.prototype.initBody = function () {
         initBodyCaller = true;
@@ -189,7 +176,6 @@
         this.updateSelected();
     };
 
-
     BootstrapTable.prototype.updateSelected = function () {
         if (!initBodyCaller) {
             _updateSelected.apply(this, Array.prototype.slice.apply(arguments));
@@ -205,7 +191,6 @@
         }
     };
 
-
     BootstrapTable.prototype.getGroupSelections = function (index) {
         var that = this;
 
@@ -214,16 +199,13 @@
         });
     };
 
-
     BootstrapTable.prototype.checkGroup = function (index) {
         this.checkGroup_(index, true);
     };
 
-
     BootstrapTable.prototype.uncheckGroup = function (index) {
         this.checkGroup_(index, false);
     };
-
 
     BootstrapTable.prototype.checkGroup_ = function (index, checked) {
         var rows;
@@ -236,7 +218,6 @@
         }
 
         this.$selectItem.filter(filter).prop('checked', checked);
-
 
         this.updateRows();
         this.updateSelected();

--- a/src/extensions/group-by-v2/bootstrap-table-group-by.js
+++ b/src/extensions/group-by-v2/bootstrap-table-group-by.js
@@ -3,7 +3,7 @@
  * @version: v1.0.0
  */
 
-!function ($) {
+(function ($) {
 
     'use strict';
 
@@ -28,6 +28,7 @@
         return flag ? str : '';
     };
 
+    
     var groupBy = function (array , f) {
         var groups = {};
         array.forEach(function(o) {
@@ -39,17 +40,26 @@
         return groups;
     };
 
+
+
     $.extend($.fn.bootstrapTable.defaults, {
         groupBy: false,
-        groupByField: ''
+        groupByField: '',
+        groupByFormatter: undefined
     });
+
 
     var BootstrapTable = $.fn.bootstrapTable.Constructor,
         _initSort = BootstrapTable.prototype.initSort,
         _initBody = BootstrapTable.prototype.initBody,
         _updateSelected = BootstrapTable.prototype.updateSelected;
 
+
+
+
     BootstrapTable.prototype.initSort = function () {
+
+
         _initSort.apply(this, Array.prototype.slice.apply(arguments));
 
         var that = this;
@@ -59,7 +69,8 @@
 
             if ((this.options.sortName != this.options.groupByField)) {
                 this.data.sort(function(a, b) {
-                    return a[that.options.groupByField].localeCompare(b[that.options.groupByField]);
+                    if (a[that.options.groupByField] == b[that.options.groupByField]) return String(a[that.options.sortName]).localeCompare(String(b[that.options.sortName])); //sortable by byron 16 april 2018
+                    return String(a[that.options.groupByField]).localeCompare(String(b[that.options.groupByField]));
                 });
             }
 
@@ -72,7 +83,8 @@
             $.each(groups, function(key, value) {
                 tableGroups.push({
                     id: index,
-                    name: key
+                    name: key,
+                    data: value
                 });
 
                 value.forEach(function(item) {
@@ -87,6 +99,9 @@
             });
         }
     }
+
+
+
 
     BootstrapTable.prototype.initBody = function () {
         initBodyCaller = true;
@@ -127,10 +142,13 @@
                         '</td>'
                     );
                 }
-
+                var formattedValue = item.name;
+                if (typeof(that.options.groupByFormatter) == "function") {
+                    formattedValue = that.options.groupByFormatter(item.name, item.id, item.data);
+                }
                 html.push('<td',
                     sprintf(' colspan="%s"', visibleColumns),
-                    '>', item.name, '</td>'
+                    '>', formattedValue, '</td>'
                 );
 
                 html.push('</tr>');
@@ -171,6 +189,7 @@
         this.updateSelected();
     };
 
+
     BootstrapTable.prototype.updateSelected = function () {
         if (!initBodyCaller) {
             _updateSelected.apply(this, Array.prototype.slice.apply(arguments));
@@ -186,6 +205,7 @@
         }
     };
 
+
     BootstrapTable.prototype.getGroupSelections = function (index) {
         var that = this;
 
@@ -194,13 +214,16 @@
         });
     };
 
+
     BootstrapTable.prototype.checkGroup = function (index) {
         this.checkGroup_(index, true);
     };
 
+
     BootstrapTable.prototype.uncheckGroup = function (index) {
         this.checkGroup_(index, false);
     };
+
 
     BootstrapTable.prototype.checkGroup_ = function (index, checked) {
         var rows;
@@ -223,4 +246,4 @@
         this.trigger(checked ? 'check-all' : 'uncheck-all', rows);
     };
 
-}(jQuery);
+})(jQuery);


### PR DESCRIPTION
An additional option for bootstrap-table-group-by to allow formatting of group headers.
Option is in the form of a function with the signature groupByFormatter(value, idx, data) where:
value: is the original header text
idx: is the index of the group
data: is an array of the row objects for this group
return: a string to be used as the group header html

This is useful when you require the group header to be formatted differently from the field value.