### PR TITLE
Fix cardview click event

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1906,8 +1906,10 @@
       this.$body.find('> tr[data-index] > td').off('click dblclick').on('click dblclick', ({currentTarget, type, target}) => {
         const $td = $(currentTarget)
         const $tr = $td.parent()
+        const $cardviewArr = $(target).parents('.card-views').children()
+        const $cardviewTarget = $(target).parents('.card-view')
         const item = this.data[$tr.data('index')]
-        const index = $td[0].cellIndex
+        const index = this.options.cardView ? $cardviewArr.index($cardviewTarget) : $td[0].cellIndex
         const fields = this.getVisibleFields()
         const field = fields[this.options.detailView && !this.options.cardView ? index - 1 : index]
         const column = this.columns[this.fieldsColumnsIndex[field]]


### PR DESCRIPTION
This fix the #3780 

``` javascript
const $cardviewArr = $(target).parents('.card-views').children()
const $cardviewTarget = $(target).parents('.card-view')
const index = this.options.cardView ? $cardviewArr.index($cardviewTarget) : $td[0].cellIndex
```
I only modified these lines.

A [not working jsFiddle](http://jsfiddle.net/jm02oaLk/13/)
1. Click cardview toggle
2. Click hyperlink
3. Read the **field = xyz** in `#fake_console`, you can see the wrong field string.

[My patch is working jsFiddle](http://jsfiddle.net/onb487u3/)
Read the field = xyz part, this time, it shows the correct field string

