### PR TITLE
theadClasses is not set by default

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -667,6 +667,9 @@
       if (!this.$header.length) {
         this.$header = $(`<thead class="${this.options.theadClasses}"></thead>`).appendTo(this.$el)
       }
+      else{
+        this.$header.addClass(this.options.theadClasses);
+      }
       this.$header.find('tr').each((i, el) => {
         const column = []
 


### PR DESCRIPTION
If a thead exists and $.BootstrapTable.DEFAULTS.theadClasses is set the class is never set on init.