### PR TITLE
Impoved Search - Added check for comperations (<,>,<=,=<,>=,=>)

### DIFF
--- a/site/docs/api/table-options.md
+++ b/site/docs/api/table-options.md
@@ -705,6 +705,14 @@ The table options are defined in `jQuery.fn.bootstrapTable.defaults`.
 - **Detail:**
 
   Enable the search input.
+  
+  There are 3 ways to search:
+  - The value contains the search query (Default).   
+    Example: Github contains git.
+  - The value must be identical to the search query.  
+    Example: Github (value) and Github (search query).
+  - Comparsions (<, >, <=, =<, >=, =>)   
+    Example: 4 is larger than 3.
 
 - **Default:** `false`
 
@@ -732,7 +740,8 @@ The table options are defined in `jQuery.fn.bootstrapTable.defaults`.
 
 - **Detail:**
 
-  Enable the strict search.
+  Enable the strict search.   
+  Disables the comparison checks.
 
 - **Default:** `false`
 

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1396,7 +1396,32 @@
             }
 
             if (typeof value === 'string' || typeof value === 'number') {
-              if (this.options.strictSearch) {
+              const largerSmallerEqualsRegex = /(?:(<=|=>|=<|>=|>|<)(?:\s+)?(\d+)?|(\d+)?(\s+)?(<=|=>|=<|>=|>|<))/gm
+              let matches = largerSmallerEqualsRegex.exec(s);
+
+              if (matches !== null) {
+                  let operator = matches[1] || matches[5] + 'l'
+                  let comperationValue = matches[2] || matches[3]
+
+                  switch(operator) {
+                      case '>':
+                      case '<l':
+                          return Number.parseInt(value) > Number.parseInt(comperationValue);
+                      case '<':
+                      case '>l':
+                          return Number.parseInt(value) < Number.parseInt(comperationValue);
+                      case '<=':
+                      case '=<':
+                      case '>=l':
+                      case '=>l':
+                          return Number.parseInt(value) <= Number.parseInt(comperationValue);
+                      case '>=':
+                      case '=>':
+                      case '<=l':
+                      case '=<l':
+                          return Number.parseInt(value) >= Number.parseInt(comperationValue);
+                  }
+              } else if (this.options.strictSearch) {
                 if ((`${value}`).toLowerCase() === s) {
                   return true
                 }

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1396,37 +1396,44 @@
             }
 
             if (typeof value === 'string' || typeof value === 'number') {
-              const largerSmallerEqualsRegex = /(?:(<=|=>|=<|>=|>|<)(?:\s+)?(\d+)?|(\d+)?(\s+)?(<=|=>|=<|>=|>|<))/gm
-              let matches = largerSmallerEqualsRegex.exec(s);
-
-              if (matches !== null) {
-                  let operator = matches[1] || matches[5] + 'l'
-                  let comperationValue = matches[2] || matches[3]
-
-                  switch(operator) {
-                      case '>':
-                      case '<l':
-                          return Number.parseInt(value) > Number.parseInt(comperationValue);
-                      case '<':
-                      case '>l':
-                          return Number.parseInt(value) < Number.parseInt(comperationValue);
-                      case '<=':
-                      case '=<':
-                      case '>=l':
-                      case '=>l':
-                          return Number.parseInt(value) <= Number.parseInt(comperationValue);
-                      case '>=':
-                      case '=>':
-                      case '<=l':
-                      case '=<l':
-                          return Number.parseInt(value) >= Number.parseInt(comperationValue);
-                  }
-              } else if (this.options.strictSearch) {
+              if (this.options.strictSearch) {
                 if ((`${value}`).toLowerCase() === s) {
                   return true
                 }
               } else {
-                if ((`${value}`).toLowerCase().includes(s)) {
+                const largerSmallerEqualsRegex = /(?:(<=|=>|=<|>=|>|<)(?:\s+)?(\d+)?|(\d+)?(\s+)?(<=|=>|=<|>=|>|<))/gm
+                let matches = largerSmallerEqualsRegex.exec(s);
+                let comperationCheck = false;
+
+                if (matches !== null) {
+                  let operator = matches[1] || matches[5] + 'l'
+                  let comperationValue = matches[2] || matches[3]
+
+                  switch(operator) {
+                    case '>':
+                    case '<l':
+                      comperationCheck = Number.parseInt(value) > Number.parseInt(comperationValue);
+                      break;
+                    case '<':
+                    case '>l':
+                      comperationCheck = Number.parseInt(value) < Number.parseInt(comperationValue);
+                      break;
+                    case '<=':
+                    case '=<':
+                    case '>=l':
+                    case '=>l':
+                      comperationCheck = Number.parseInt(value) <= Number.parseInt(comperationValue);
+                      break;
+                    case '>=':
+                    case '=>':
+                    case '<=l':
+                    case '=<l':
+                      comperationCheck = Number.parseInt(value) >= Number.parseInt(comperationValue);
+                      break;
+                  }
+                }
+
+                if (comperationCheck || (`${value}`).toLowerCase().includes(s)) {
                   return true
                 }
               }


### PR DESCRIPTION
I impoved the search checks so comperations search (<,>,<=,=<,>=,=>) are possible now.
This feature was requested by @ManicPumpkin on Issue #3042.

The following comperations are possible:
```
> value
< value
<= value
=< value
>= value
=> value
value <
value >
value <=
value =<
value >=
value =>
```

JsFiddle Demo: https://jsfiddle.net/s2gpvoqu/