### PR TITLE
Detailview per column

### DIFF
--- a/site/docs/api/column-options.md
+++ b/site/docs/api/column-options.md
@@ -403,7 +403,7 @@ The column options is defined in `jQuery.fn.bootstrapTable.columnDefaults`.
 
 - **Detail:**
 
-  Format your detail view when detailView and detailViewByClick is set to true. Return a String and it will be appended into the detail view cell, optionally render the element directly using the third parameter which is a jQuery element of the target cell.
+  Format your detail view when `detailView` and `detailViewByClick` is set to `true`. Return a `String` and it will be appended into the detail view cell, optionally render the element directly using the third parameter which is a jQuery element of the target cell.
   
   Fallback is the detail-formatter of the table.
 

--- a/site/docs/api/column-options.md
+++ b/site/docs/api/column-options.md
@@ -394,3 +394,19 @@ The column options is defined in `jQuery.fn.bootstrapTable.columnDefaults`.
   Set `true` to show the title of column with 'radio' or 'singleSelect' 'checkbox' option.
 
 - **Default:** `false`
+
+## detailFormatter
+
+- **Attribute:** `data-detail-formatter`
+
+- **Type:** `Function`
+
+- **Detail:**
+
+  Format your detail view when detailView and detailViewByClick is set to true. Return a String and it will be appended into the detail view cell, optionally render the element directly using the third parameter which is a jQuery element of the target cell.
+  
+  Fallback is the detail-formatter of the table.
+
+- **Default:** `function(index, row, element) { return '' }`
+
+- **Example:** [Detail View](https://examples.bootstrap-table.com/#options/detail-view.html)

--- a/site/docs/api/table-options.md
+++ b/site/docs/api/table-options.md
@@ -1160,6 +1160,18 @@ The table options are defined in `jQuery.fn.bootstrapTable.defaults`.
 
 - **Example:** [Detail Filter](https://examples.bootstrap-table.com/#options/detail-filter.html)
 
+## detailViewByClick
+
+- **Attribute:** `data-detail-view-by-click`
+
+- **Type:** `Boolean`
+
+- **Detail:**
+
+  Set `true` to toggle the detail view, when a cell is clicked.
+
+- **Example:** [Toggle detail view by click](https://examples.bootstrap-table.com/#options/detail-view-by-click.html)
+
 ## toolbar
 
 - **Attribute:** `data-toolbar`

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -559,6 +559,7 @@
     footerFormatter: undefined,
     events: undefined,
     sorter: undefined,
+    detailFormatters: [],
     sortName: undefined,
     cellStyle: undefined,
     searchable: true,
@@ -2001,19 +2002,19 @@
           }
         }
 
-        if(
-            type === 'click' &&
+        if (
+          type === 'click' &&
             this.options.detailViewByClick
-        ){
-            const $detailIcon = $tr.find('.detail-icon')
-            let detailFormatter = this.header.detailFormatters[index - 1] || undefined
-            this.toggleDetailView($detailIcon, detailFormatter);
+        ) {
+          const $detailIcon = $tr.find('.detail-icon')
+          const detailFormatter = this.header.detailFormatters[index - 1] || undefined
+          this.toggleDetailView($detailIcon, detailFormatter)
         }
       })
 
       this.$body.find('> tr[data-index] > td > .detail-icon').off('click').on('click', e => {
         e.preventDefault()
-        this.toggleDetailView($(e.currentTarget));
+        this.toggleDetailView($(e.currentTarget))
         return false
       })
 
@@ -2071,28 +2072,28 @@
       this.trigger('post-body', data)
     }
 
-    toggleDetailView($iconElement, columnDetailFormatter) {
-        const $tr = $iconElement.parent().parent()
-        const index = $tr.data('index')
-        const row = this.data[index]
+    toggleDetailView ($iconElement, columnDetailFormatter) {
+      const $tr = $iconElement.parent().parent()
+      const index = $tr.data('index')
+      const row = this.data[index]
 
-        // remove and update
-        if ($tr.next().is('tr.detail-view')) {
-            $iconElement.html(Utils.sprintf(this.constants.html.icon, this.options.iconsPrefix, this.options.icons.detailOpen))
-            this.trigger('collapse-row', index, row, $tr.next())
-            $tr.next().remove()
-        } else {
-            $iconElement.html(Utils.sprintf(this.constants.html.icon, this.options.iconsPrefix, this.options.icons.detailClose))
-            $tr.after(Utils.sprintf('<tr class="detail-view"><td colspan="%s"></td></tr>', $tr.children('td').length))
-            const $element = $tr.next().find('td')
-            let detailFormatter = columnDetailFormatter || this.options.detailFormatter
-            const content = Utils.calculateObjectValue(this.options, detailFormatter, [index, row, $element], '')
-            if ($element.length === 1) {
-                $element.append(content)
-            }
-            this.trigger('expand-row', index, row, $element)
+      // remove and update
+      if ($tr.next().is('tr.detail-view')) {
+        $iconElement.html(Utils.sprintf(this.constants.html.icon, this.options.iconsPrefix, this.options.icons.detailOpen))
+        this.trigger('collapse-row', index, row, $tr.next())
+        $tr.next().remove()
+      } else {
+        $iconElement.html(Utils.sprintf(this.constants.html.icon, this.options.iconsPrefix, this.options.icons.detailClose))
+        $tr.after(Utils.sprintf('<tr class="detail-view"><td colspan="%s"></td></tr>', $tr.children('td').length))
+        const $element = $tr.next().find('td')
+        const detailFormatter = columnDetailFormatter || this.options.detailFormatter
+        const content = Utils.calculateObjectValue(this.options, detailFormatter, [index, row, $element], '')
+        if ($element.length === 1) {
+          $element.append(content)
         }
-        this.resetView()
+        this.trigger('expand-row', index, row, $element)
+      }
+      this.resetView()
     }
 
     initServer (silent, query, url) {

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -2002,13 +2002,8 @@
           }
         }
 
-        if (
-          type === 'click' &&
-            this.options.detailViewByClick
-        ) {
-          const $detailIcon = $tr.find('.detail-icon')
-          const detailFormatter = this.header.detailFormatters[index - 1] || undefined
-          this.toggleDetailView($detailIcon, detailFormatter)
+        if (type === 'click' && this.options.detailViewByClick) {
+          this.toggleDetailView($tr.find('.detail-icon'), this.header.detailFormatters[index - 1])
         }
       })
 

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -559,7 +559,7 @@
     footerFormatter: undefined,
     events: undefined,
     sorter: undefined,
-    detailFormatters: [],
+    detailFormatter: undefined,
     sortName: undefined,
     cellStyle: undefined,
     searchable: true,


### PR DESCRIPTION
@startovernow requested in Isuse #3375 a option to have different detail views by click on a cell.

I added the table option detailViewByClick(data-detail-view-by-click) to allow open the detail view if someone clicked on a cell.

In the next step i added a column option detailFormatter(data-detail-formatter) to define the column detail view formatter.

If no column detail is found the backup is the default detail view (table option detailView).

Jsfiddle demo: https://jsfiddle.net/xc019fzk/
The first and the second Columns are column detail views and the last column use the default table detail formatter.
