### PR TITLE
Use the internal onColumnSearch function to prevent event issues

### DIFF
--- a/src/extensions/filter-control/bootstrap-table-filter-control.js
+++ b/src/extensions/filter-control/bootstrap-table-filter-control.js
@@ -446,12 +446,11 @@
                   `.date-filter-control.bootstrap-table-filter-control-${field}`
                 )
                 .datepicker(filterDatepickerOptions)
-                .on('changeDate', ({ currentTarget }) => {
-                  $(currentTarget).val(
-                    currentTarget.value
-                  )
-                  // Fired the keyup event
-                  $(currentTarget).keyup()
+                .on('changeDate', (event) => {
+                  clearTimeout(event.currentTarget.timeoutId || 0)
+                  event.currentTarget.timeoutId = setTimeout(() => {
+                    that.onColumnSearch(event)
+                  }, that.options.searchTimeOut)
                 })
             }
           })


### PR DESCRIPTION
Fix the bug reported by @SEModer in #4157 .

Jsfiddle demo: http://jsfiddle.net/omLn58uj/1/