### PR TITLE
Also set the totalRows option if pagination is not active

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -2077,6 +2077,10 @@
       this.updateSelected()
       this.resetView()
 
+      if (this.options.sidePagination !== 'server') {
+        this.options.totalRows = data.length
+      }
+
       this.trigger('post-body', data)
     }
 


### PR DESCRIPTION
Currently the totalRows option is only set if pagination is true (option is set in initPagination).
`$("table").bootstrapTable('getOptions').totalRows` will always return 0 if pagination is set to false (more informations in issue #4227)

Issue found by @basementmedia2 in issue #4227

Not working jsfiddle: https://jsfiddle.net/g71pdr42/2/
Working jsfiddle: https://jsfiddle.net/g71pdr42/3/