### PR TITLE
added table option to apply a function to choose which rows should show

### DIFF
--- a/site/docs/api/table-options.md
+++ b/site/docs/api/table-options.md
@@ -1141,6 +1141,20 @@ The table options are defined in `jQuery.fn.bootstrapTable.defaults`.
 
 - **Example:** [Detail View](https://examples.bootstrap-table.com/#options/detail-view.html)
 
+## showDetailView
+
+- **Attribute:** `data-show-detail-view`
+
+- **Type:** `Function`
+
+- **Detail:**
+
+  Apply a function to choose which rows should display the icons to show/hide the detail view.
+
+- **Default:** `showDetailView: function (index, row) { return true }`
+
+- **Example:** [Show Detail View](https://examples.bootstrap-table.com/#options/show-detail-view.html)
+
 ## detailFormatter
 
 - **Attribute:** `data-detail-formatter`

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -396,6 +396,9 @@
     uniqueId: undefined,
     cardView: false,
     detailView: false,
+    showDetailView: function (index, row) {
+      return true
+    },
     detailFormatter (index, row) {
       return ''
     },
@@ -1816,7 +1819,7 @@
       if (!this.options.cardView && this.options.detailView) {
         html.push('<td>')
 
-        if (Utils.calculateObjectValue(null, this.options.detailFilter, [i, item])) {
+        if (Utils.calculateObjectValue(null, this.options.detailFilter, [i, item]) && Utils.calculateObjectValue(null, this.options.showDetailView, [i, item])) {
           html.push(`
             <a class="detail-icon" href="#">
             ${Utils.sprintf(this.constants.html.icon, this.options.iconsPrefix, this.options.icons.detailOpen)}


### PR DESCRIPTION
Add a table option `showDetailView` to choose which rows should display the detail view.
Requested by @RenanCristiano in issue #2652.

Demo: https://jsfiddle.net/khfnLr18/1/