### PR TITLE
add title attribute

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1935,6 +1935,8 @@
         }
         if (item[`_${field}_title`]) {
           title_ = Utils.sprintf(' title="%s"', item[`_${field}_title`])
+        } else {
+          title_ = Utils.sprintf(' title="%s"', item[ field ])
         }
         cellStyle = Utils.calculateObjectValue(this.header,
           this.header.cellStyles[j], [value_, item, i, field], cellStyle)


### PR DESCRIPTION
When the table has many columns and the displayed content is truncated, the detailed data can be displayed by hovering the mouse over the corresponding column。