### PR TITLE
fixed z-index with loading screen

### DIFF
--- a/src/themes/theme.scss
+++ b/src/themes/theme.scss
@@ -38,6 +38,7 @@
         text-align: left;
         max-height: 300px;
         overflow: auto;
+        z-index: 1001;
       }
 
       label {


### PR DESCRIPTION
Small css fix.

If the loading screen is shown the dropdowns have a smaller z-index as the loading Screen.
Example: https://examples.bootstrap-table.com/#extensions/treegrid.html