### PR TITLE
Renamed table option maintainSelected

### DIFF
--- a/site/docs/api/table-options.md
+++ b/site/docs/api/table-options.md
@@ -1114,19 +1114,21 @@ The table options are defined in `jQuery.fn.bootstrapTable.defaults`.
 
 - **Example:** [Checkbox Header](https://examples.bootstrap-table.com/#options/checkbox-header.html)
 
-## maintainSelected
+## maintainMetaData
 
-- **Attribute:** `data-maintain-selected`
+- **Attribute:** `data-maintain-meta-data`
 
 - **Type:** `Boolean`
 
 - **Detail:**
 
-  Set `true` to maintain selected rows on change page and search.
+  Set `true` to maintain the following meta data on change page and search
+   * selected rows
+   * hidden rows
 
 - **Default:** `false`
 
-- **Example:** [Maintain Selected](https://examples.bootstrap-table.com/#options/maintain-selected.html)
+- **Example:** [Maintain Meta Data](https://examples.bootstrap-table.com/#options/maintain-selected.html)
 
 ## multipleSelectRow
 

--- a/site/docs/api/table-options.md
+++ b/site/docs/api/table-options.md
@@ -1128,7 +1128,7 @@ The table options are defined in `jQuery.fn.bootstrapTable.defaults`.
 
 - **Default:** `false`
 
-- **Example:** [Maintain Meta Data](https://examples.bootstrap-table.com/#options/maintain-selected.html)
+- **Example:** [Maintain Meta Data](https://examples.bootstrap-table.com/#options/maintain-meta-data.html)
 
 ## multipleSelectRow
 

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1080,7 +1080,7 @@ class BootstrapTable {
       return
     }
 
-    if (!this.options.maintainSelected) {
+    if (!this.options.maintainMetaData) {
       this.resetRows()
     }
 

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -181,7 +181,7 @@ const DEFAULTS = {
   },
   singleSelect: false,
   checkboxHeader: true,
-  maintainSelected: false,
+  maintainMetaData: false,
   multipleSelectRow: false,
   uniqueId: undefined,
   cardView: false,


### PR DESCRIPTION
This PR renames the table option `maintainSelected` to `maintainMetaData`, because this maintains all meta data which will reset on the `resetRows` function.

As example with this option set to `true` it dont reset the hiddenRows which fixes #2349