### PR TITLE
go through the filtered data not through the whole data

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1952,12 +1952,11 @@ class BootstrapTable {
 
   getSelections () {
     // fix #2424: from html with checkbox
-    return this.options.data.filter(row =>
-      row[this.header.stateField] === true)
+    return this.data.filter(row => row[this.header.stateField] === true)
   }
 
   getAllSelections () {
-    return this.options.data.filter(row => row[this.header.stateField])
+    return this.data.filter(row => row[this.header.stateField])
   }
 
   load (_data) {

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -681,6 +681,10 @@ class BootstrapTable {
         $(currentTarget).val(text)
       }
 
+      if (this.searchText === text) {
+        return
+      }
+
       this.searchText = text
       this.options.searchText = text
     }

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -528,7 +528,7 @@ class BootstrapTable {
         <button class="${this.constants.buttonsClass} dropdown-toggle" type="button" data-toggle="dropdown"
         aria-label="Columns" title="${o.formatColumns()}">
         ${o.showButtonIcons ? Utils.sprintf(this.constants.html.icon, o.iconsPrefix, o.icons.columns) : '' }
-        ${o.showButtonText ? o.formatColumns() : ''} 
+        ${o.showButtonText ? o.formatColumns() : ''}
         ${this.constants.html.dropdownCaret}
         </button>
         ${this.constants.html.toolbarDropdown[0]}`)
@@ -1956,7 +1956,7 @@ class BootstrapTable {
   }
 
   getAllSelections () {
-    return this.data.filter(row => row[this.header.stateField])
+    return this.options.data.filter(row => row[this.header.stateField] === true)
   }
 
   load (_data) {


### PR DESCRIPTION
fix #4002

In my opinion we should add this as option and also add the options from the `getData` function (only currentPage, include hidden rows).
What do you think ?

Demo: http://jsfiddle.net/nxjbmu23/5/
Check the first checkbox, now the method (button) will return one row.
Search for 13 and check the method again, it will show you 0 rows because the other data is filtered out.