### PR TITLE
fix issue with filtercontrol and cookie extension

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -653,8 +653,8 @@ class BootstrapTable {
     }
   }
 
-  onSearch ({currentTarget, firedByInitSearchText} = {}) {
-    if (currentTarget !== undefined) {
+  onSearch ({currentTarget, firedByInitSearchText} = {}, overwriteSearchText = true) {
+    if (currentTarget !== undefined && overwriteSearchText) {
       const text = $(currentTarget).val().trim()
 
       if (this.options.trimOnSearch && $(currentTarget).val() !== text) {

--- a/src/extensions/filter-control/bootstrap-table-filter-control.js
+++ b/src/extensions/filter-control/bootstrap-table-filter-control.js
@@ -757,7 +757,7 @@ $.BootstrapTable = class extends $.BootstrapTable {
 
     this.options.pageNumber = 1
     this.EnableControls(false)
-    this.onSearch()
+    this.onSearch(event, false)
     this.trigger('column-search', $field, text)
   }
 


### PR DESCRIPTION
reverted old commit(#4311) which fixed #2776.
But after that commit the filtercontrol extension dont work with the cookie extension caused of the missing event (to fetch the value), that is the reason of the new parameter which still prevent the issue of the old commit.