### PR TITLE
Fix search text overwritting

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -631,7 +631,7 @@ class BootstrapTable {
         </div>
       `,
       Utils.sprintf(this.constants.html.inputGroup,
-        `<input class="${this.constants.classes.input}${Utils.sprintf(' input-%s', o.iconSize)}" type="text" placeholder="${o.formatSearch()}">`,
+        `<input class="${this.constants.classes.input}${Utils.sprintf(' input-%s', o.iconSize)} search-input" type="text" placeholder="${o.formatSearch()}">`,
         (o.showSearchButton ? showSearchButton : '') +
         (o.showSearchClearButton ? showSearchClearButton : ''))
       ))
@@ -685,8 +685,10 @@ class BootstrapTable {
         return
       }
 
-      this.searchText = text
-      this.options.searchText = text
+      if ($(currentTarget).hasClass('search-input')) {
+        this.searchText = text
+        this.options.searchText = text
+      }
     }
 
     if (!firedByInitSearchText) {


### PR DESCRIPTION
Only set the search text if it was triggered by the original search input to prevent overwriting the search text (e.g. for the filter-control extension).

fix #2203 
Demo: http://jsfiddle.net/6nt0wxpy/4/