### PR TITLE
Trigger search if the sortPriority is used

### DIFF
--- a/src/extensions/multiple-sort/bootstrap-table-multiple-sort.js
+++ b/src/extensions/multiple-sort/bootstrap-table-multiple-sort.js
@@ -497,6 +497,10 @@ BootstrapTable.prototype.initToolbar = function (...args) {
   this.$sortModal = $(sortModalId)
   this.sortModalSelector = sortModalSelector
 
+  if (that.options.sortPriority !== null) {
+    that.onMultipleSort()
+  }
+
   _initToolbar.apply(this, Array.prototype.slice.apply(args))
 
   if (that.options.sidePagination === 'server' && !isSingleSort && that.options.sortPriority !== null) {


### PR DESCRIPTION
fix #2149 

That will not really fix the issue because his issues are already fixed.
But if you use the sortPriority currently only the arrows are shown the sort is not done!