### PR TITLE
Added an option to replace row

### DIFF
--- a/site/docs/api/methods.md
+++ b/site/docs/api/methods.md
@@ -137,6 +137,7 @@ The calling method syntax: `$('#table').bootstrapTable('method', parameter)`.
 
   * `index`: the row index to be updated.
   * `row`: the new row data.
+  * `replace` (optional): set to `true` to replace the row instead of extending.
 
 - **Example:** [Update Row](https://examples.bootstrap-table.com/#methods/update-row.html)
 
@@ -160,6 +161,7 @@ The calling method syntax: `$('#table').bootstrapTable('method', parameter)`.
 
   * `id`: a row id where the id should be the uniqueid field assigned to the table.
   * `row`: the new row data.
+  * `replace` (optional): set to `true` to replace the row instead of extending.
 
 - **Example:** [Update By Unique Id](https://examples.bootstrap-table.com/#methods/update-by-unique-id.html)
 

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -2061,7 +2061,13 @@ class BootstrapTable {
       if (!params.hasOwnProperty('index') || !params.hasOwnProperty('row')) {
         continue
       }
+
       $.extend(this.options.data[params.index], params.row)
+      if (params.hasOwnProperty('replace') && params.replace) {
+        this.options.data[params.index] = params.row
+      } else {
+        $.extend(this.options.data[params.index], params.row)
+      }
     }
 
     this.initSearch()
@@ -2122,7 +2128,11 @@ class BootstrapTable {
       if (rowId === -1) {
         continue
       }
-      $.extend(this.options.data[rowId], params.row)
+      if (params.hasOwnProperty('replace') && params.replace) {
+        this.options.data[rowId] = params.row
+      } else {
+        $.extend(this.options.data[rowId], params.row)
+      }
     }
 
     this.initSearch()

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -2124,10 +2124,10 @@ class BootstrapTable {
       }
 
       const rowId = this.options.data.indexOf(this.getRowByUniqueId(params.id))
-
       if (rowId === -1) {
         continue
       }
+
       if (params.hasOwnProperty('replace') && params.replace) {
         this.options.data[rowId] = params.row
       } else {


### PR DESCRIPTION
Added an option for the methods UpdateRow and updateByUniqueId to replace the row instead of extending it.

fix #3079
Demo: http://jsfiddle.net/y0rwqba5/