### PR TITLE
Fixed column events click error with detailView

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1444,7 +1444,7 @@ class BootstrapTable {
       const item = this.data[rowIndex]
       const index = this.options.cardView ? $cardViewArr.index($cardViewTarget) : $td[0].cellIndex
       const fields = this.getVisibleFields()
-      const field = fields[this.options.detailView && this.detailViewIcon && !this.options.cardView ? index - 1 : index]
+      const field = fields[this.options.detailView && this.options.detailViewIcon && !this.options.cardView ? index - 1 : index]
       const column = this.columns[this.fieldsColumnsIndex[field]]
       const value = Utils.getItemField(item, field, this.options.escape)
 


### PR DESCRIPTION
Click column events with `detailView` will cause an error:

![image](https://user-images.githubusercontent.com/2117018/63985340-d62a1a00-cb01-11e9-9255-2d2fa93e8eeb.png)

Before: https://live.bootstrap-table.com/example/welcome.html
After: https://live.bootstrap-table.com/code/wenzhixin/520