### PR TITLE
Updated event name to lowercase hyphen format of vue component

### DIFF
--- a/site/docs/vuejs/component.md
+++ b/site/docs/vuejs/component.md
@@ -14,7 +14,7 @@ toc: true
   :columns="columns"
   :data="data"
   :options="options"
-  @onPostBody="onPostBody"
+  @on-post-body="onPostBody"
 />
 {% endhighlight %}
 
@@ -52,9 +52,11 @@ toc: true
 
 ## Events
 
-The calling method syntax: `@onEvent="onEvent"`.
+The calling method syntax: `@on-event="onEvent"`.
 
 All events (without `onAll`) are defined in [Events API](/docs/api/events/).
+
+**Note:** you need to convert event name to lowercase + hyphen format, for example: `onClickRow` should be `on-click-row`.
 
 ## Methods
 

--- a/src/vue/BootstrapTable.vue
+++ b/src/vue/BootstrapTable.vue
@@ -32,7 +32,9 @@ export default {
     this.$table = $(this.$el)
 
     this.$table.on('all.bs.table', (e, name, args) => {
-      this.$emit($.fn.bootstrapTable.events[name], ...args)
+      let eventName = $.fn.bootstrapTable.events[name]
+      eventName = eventName.replace(/([A-Z])/g, '-$1').toLowerCase()
+      this.$emit(eventName, ...args)
     })
 
     this._initTable()


### PR DESCRIPTION
Fix #4575 

Example: https://codesandbox.io/s/vue-template-qqyco

```vue
<template>
  <BootstrapTable 
    :columns="columns" 
    :data="data" 
    :options="options" 
    @on-click-row="onClickRow"
  />
</template>

<script>
export default {
  name: "App",
  data () {
    return {
      columns: [],
      data: [],
      options: {}
    };
  },
  methods: {
    onClickRow (row) {
      alert(JSON.stringify(row))
    }
  }
}
</script>
```