### PR TITLE
Removed getAllSelections method

### DIFF
--- a/site/docs/api/methods.md
+++ b/site/docs/api/methods.md
@@ -51,16 +51,6 @@ The calling method syntax: `$('#table').bootstrapTable('method', parameter)`.
 
 - **Example:** [Get Selections](https://examples.bootstrap-table.com/#methods/get-selections.html)
 
-## getAllSelections
-
-- **Parameter:** `undefined`
-
-- **Detail:**
-
-  Return all selected rows contain search or filter, when no record selected, an empty array will return.
-
-- **Example:** [Get All Selections](https://examples.bootstrap-table.com/#methods/get-all-selections.html)
-
 ## load
 
 - **Parameter:** `data`

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -2006,10 +2006,6 @@ class BootstrapTable {
     return this.data.filter(row => row[this.header.stateField] === true)
   }
 
-  getAllSelections () {
-    return this.options.data.filter(row => row[this.header.stateField] === true)
-  }
-
   load (_data) {
     let fixedScroll = false
     let data = _data

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -425,7 +425,7 @@ const METHODS = [
   'getOptions',
   'refreshOptions',
   'getData',
-  'getSelections', 'getAllSelections',
+  'getSelections',
   'load', 'append', 'prepend',
   'remove', 'removeAll',
   'insertRow', 'updateRow',


### PR DESCRIPTION
ref #776

Because in the latest version, the result of `getAllSelections` is the same as `getSelections`.

Now we can use `maintainMetaData` option to get all selected rows when enable paging and/or have filters.

Example: https://live.bootstrap-table.com/code/wenzhixin/993
