### PR TITLE
Dont change the view if document was resized by keyboard

### DIFF
--- a/src/extensions/mobile/bootstrap-table-mobile.js
+++ b/src/extensions/mobile/bootstrap-table-mobile.js
@@ -47,9 +47,9 @@ $.BootstrapTable = class extends $.BootstrapTable {
       // reset view if height has only changed by at least the threshold.
       const width = $(window).width()
       const height = $(window).height()
-      const activeElement = $(document.activeElement)
+      const $activeElement = $(document.activeElement)
 
-      if (activeElement && $.inArray(activeElement.prop('nodeName'), ['input', 'select', 'textarea'])) {
+      if ($activeElement.length && ['INPUT', 'SELECT', 'TEXTAREA'].includes($activeElement.prop('nodeName'))) {
         return
       }
 

--- a/src/extensions/mobile/bootstrap-table-mobile.js
+++ b/src/extensions/mobile/bootstrap-table-mobile.js
@@ -47,6 +47,11 @@ $.BootstrapTable = class extends $.BootstrapTable {
       // reset view if height has only changed by at least the threshold.
       const width = $(window).width()
       const height = $(window).height()
+      const activeElement = $(document.activeElement)
+
+      if (activeElement && $.inArray(activeElement.prop('nodeName'), ['input', 'select', 'textarea'])) {
+        return
+      }
 
       if (
         Math.abs(old.height - height) > this.options.heightThreshold ||
@@ -58,7 +63,7 @@ $.BootstrapTable = class extends $.BootstrapTable {
           height
         }
       }
-    },200))
+    }, 200))
 
     if (this.options.checkOnInit) {
       const width = $(window).width()
@@ -87,7 +92,7 @@ $.BootstrapTable = class extends $.BootstrapTable {
   }
 
   showHideColumns (checked) {
-    if (this.options.columnsHidden.length > 0 ) {
+    if (this.options.columnsHidden.length > 0) {
       this.columns.forEach(column => {
         if (this.options.columnsHidden.includes(column.field)) {
           if (column.visible !== checked) {


### PR DESCRIPTION
fix #4627

The issue is that if you click on the input, the keyboard will be displayed and resize event will be triggered (lesser height). Because of the resetView the input will be recreated and the keyboard disappears.