### PR TITLE
dont go through the detail view column

### DIFF
--- a/src/extensions/reorder-columns/bootstrap-table-reorder-columns.js
+++ b/src/extensions/reorder-columns/bootstrap-table-reorder-columns.js
@@ -122,7 +122,7 @@ BootstrapTable.prototype.makeRowsReorderable = function () {
       let columnsHidden = []
       let columnIndex = -1
       const optionsColumns = []
-      that.$header.find('th').each(function (i) {
+      that.$header.find('th:not(.detail)').each(function (i) {
         ths.push($(this).data('field'))
         formatters.push($(this).data('formatter'))
       })


### PR DESCRIPTION
Just reorder the columns and check the console (`that.columns[columnIndex] is undefined`).

Before: https://live.bootstrap-table.com/code/UtechtDustin/1024
After: https://live.bootstrap-table.com/code/UtechtDustin/1025