### PR TITLE
Removed resetWidth method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ChangeLog
 ---------
 
+### 1.15.6
+
+- **Update:** Removed `resetWidth` method and use `resetView` instead.
+
 ### 1.15.5
 
 - **New:** Added `jqXHR` for `responseHandler` option and `onLoadSuccess` event.

--- a/site/docs/api/methods.md
+++ b/site/docs/api/methods.md
@@ -426,14 +426,6 @@ The calling method syntax: `$('#table').bootstrapTable('method', parameter)`.
 
 - **Example:** [Reset View](https://examples.bootstrap-table.com/#methods/reset-view.html)
 
-## resetWidth
-
-- **Parameter:** `undefined`
-
-- **Detail:**
-
-  Resizes header and footer to fit current columns width.
-
 ## showLoading
 
 - **Parameter:** `undefined`

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -356,7 +356,7 @@ class BootstrapTable {
       this.$tableLoading.css('top', this.$header.outerHeight() + 1)
       // Assign the correct sortable arrow
       this.getCaret()
-      $(window).on(resizeEvent, e => this.resetWidth(e))
+      $(window).on(resizeEvent, () => this.resetView())
     }
 
     this.$selectAll = this.$header.find('[name="btSelectAll"]')
@@ -2616,15 +2616,6 @@ class BootstrapTable {
     }
 
     this.trigger('reset-view')
-  }
-
-  resetWidth () {
-    if (this.options.showHeader && this.options.height) {
-      this.fitHeader()
-    }
-    if (this.options.showFooter && !this.options.cardView) {
-      this.fitFooter()
-    }
   }
 
   showLoading () {

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -441,7 +441,7 @@ const METHODS = [
   'checkBy', 'uncheckBy',
   'refresh',
   'destroy',
-  'resetView', 'resetWidth',
+  'resetView',
   'showLoading', 'hideLoading',
   'togglePagination', 'toggleFullscreen', 'toggleView',
   'resetSearch',

--- a/tools/check-api.js
+++ b/tools/check-api.js
@@ -85,9 +85,6 @@ class Methods extends API {
     this.file = 'methods.md'
     this.options = Constants.METHODS
     this.attributes = ['Parameter', 'Detail', 'Example']
-    this.ignore = {
-      resetWidth: ['Example']
-    }
   }
 }
 


### PR DESCRIPTION
Because `resetView` method contains the function of `resetWidth`, now the `reset` event of window uses the method of `resetwidth`, which is not comprehensive. So I think we can remove the `resetwidth` method, and use `resetView` instead.

Will fix #4671, you can resize the `result` window to show the problem:

![image](https://user-images.githubusercontent.com/2117018/68350800-850b5780-013c-11ea-9261-53a89a7de92f.png)

Before: https://live.bootstrap-table.com/code/UtechtDustin/1048
After: https://live.bootstrap-table.com/code/wenzhixin/1079