### PR TITLE
Fixed flat not polyfilled error in vue cli3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ ChangeLog
 - **Update:** Fixed `virtualScroll` option bug with treegrid extension.
 - **Update:** Fixed input keyboard bug for mobile extension.
 - **Update:** Fixed detail view column reorder bug for reorder-columns extension.
+- **Update:** Fixed `flat` not polyfilled error in vue cli3.
 - **Update:** Removed `resetWidth` method and use `resetView` instead.
 
 ### 1.15.5

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -77,7 +77,7 @@ export default {
   },
 
   updateFieldGroup (columns) {
-    const allColumns = columns.flat()
+    const allColumns = [].concat(...columns)
 
     for (const c of columns) {
       for (const r of c) {


### PR DESCRIPTION
ref https://github.com/vuejs/vue-cli/issues/3834

Because the Array method `flat` not polyfilled in Vue cli3, it will cause that cannot work in lower version IE. So we use ES6 solution instead.

Example: https://live.bootstrap-table.com/code/wenzhixin/1176
Link: https://medium.com/dailyjs/flatten-array-using-array-flat-in-javascript-ee4d0b2423e5