### PR TITLE
Fix for Ie (printing)

### DIFF
--- a/src/extensions/print/bootstrap-table-print.js
+++ b/src/extensions/print/bootstrap-table-print.js
@@ -173,6 +173,8 @@ $.BootstrapTable = class extends $.BootstrapTable {
     const table = buildTable(data, this.options.columns)
     const newWin = window.open('')
     newWin.document.write(this.options.printPageBuilder.call(this, table))
+    newWin.document.close()
+    newWin.focus()
     newWin.print()
     newWin.close()
   }


### PR DESCRIPTION
Fix #4701 

I cant create a example with our editor because the editor dont work with ie11.
I also cant create a example with jsfiddle or codepen because both of them dont allow ie, so i used js.do!

Before: https://js.do/code/373181
After: https://js.do/code/373180