### PR TITLE
Fix bug - 4746 - Column checkbox not being disabled in case of toggleAll

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -2342,7 +2342,7 @@ class BootstrapTable {
     this.initBody()
 
     if (this.options.showColumns) {
-      const $items = this.$toolbar.find('.keep-open input').prop('disabled', false)
+      const $items = this.$toolbar.find('.keep-open input:not(".toggle-all")').prop('disabled', false)
 
       if (needUpdate) {
         $items.filter(Utils.sprintf('[value="%s"]', index)).prop('checked', checked)


### PR DESCRIPTION
Fixes issue #4746
Where column checkbox is not being disabled when the checked column
count is equal to minimumCountColumns