### PR TITLE
Parameter not being passed to resetSearch function

### DIFF
--- a/src/extensions/filter-control/bootstrap-table-filter-control.js
+++ b/src/extensions/filter-control/bootstrap-table-filter-control.js
@@ -779,11 +779,11 @@ $.BootstrapTable = class extends $.BootstrapTable {
     super.initToolbar()
   }
 
-  resetSearch () {
+  resetSearch (text) {
     if (this.options.filterControl && this.options.showSearchClearButton) {
       this.clearFilterControl()
     }
-    super.resetSearch()
+    super.resetSearch(text)
   }
 
   clearFilterControl () {


### PR DESCRIPTION
When using $table.bootstrapTable('resetSearch', 'searchText') the parameter was not being passed to the function