### PR TITLE
Improve cookiesEnabled to support ' in data-attribute

### DIFF
--- a/src/extensions/cookie/bootstrap-table-cookie.js
+++ b/src/extensions/cookie/bootstrap-table-cookie.js
@@ -240,7 +240,7 @@ $.BootstrapTable = class extends $.BootstrapTable {
 
     this.options.cookiesEnabled = typeof this.options.cookiesEnabled === 'string' ?
       this.options.cookiesEnabled.replace('[', '').replace(']', '')
-        .replace(/ /g, '').toLowerCase().split(',') :
+        .replace(/'/g, '').replace(/ /g, '').toLowerCase().split(',') :
       this.options.cookiesEnabled
 
     if (this.options.filterControl) {


### PR DESCRIPTION
Fix #4798

Before: https://live.bootstrap-table.com/code/wenzhixin/1603
After: https://live.bootstrap-table.com/code/wenzhixin/1604

Supports `data-cookies-enabled="['bs.table.columns']"`