### PR TITLE
Fixed search escape bug

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -185,7 +185,7 @@ class BootstrapTable {
     // if options.data is setting, do not process tbody and tfoot data
     if (!this.options.data.length) {
       this.options.data = Utils.trToData(this.columns, this.$el.find('>tbody>tr'))
-      if (data.length) {
+      if (this.options.data.length) {
         this.fromHtml = true
       }
     }
@@ -766,7 +766,7 @@ class BootstrapTable {
         return
       }
 
-      const s = this.searchText && (this.options.escape
+      const s = this.searchText && (this.fromHtml
         ? Utils.escapeHTML(this.searchText) : this.searchText).toLowerCase()
       const f = Utils.isEmptyObject(this.filterColumns) ? null : this.filterColumns
 


### PR DESCRIPTION
* Refs #2098

Before: https://live.bootstrap-table.com/code/wenzhixin/1613
After: https://live.bootstrap-table.com/code/wenzhixin/1614

Search `&s` will show the problem.

* Fix #4787

Before: https://live.bootstrap-table.com/code/slmint/1528
After: https://live.bootstrap-table.com/code/wenzhixin/1615