### PR TITLE
sort after searching

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -887,6 +887,8 @@ class BootstrapTable {
         return false
       }) : this.data
     }
+
+    this.initSort()
   }
 
   initPagination () {


### PR DESCRIPTION
fix #4764 
fix #3073

Sort column `id` to `desc`
search for `a`

before: https://live.bootstrap-table.com/code/LabInc-Nico/1468
after: https://live.bootstrap-table.com/code/UtechtDustin/1643