### PR TITLE
fixed filtercontrol with fixed-column

### DIFF
--- a/src/extensions/fixed-columns/bootstrap-table-fixed-columns.js
+++ b/src/extensions/fixed-columns/bootstrap-table-fixed-columns.js
@@ -233,6 +233,26 @@ $.BootstrapTable = class extends $.BootstrapTable {
       this.$fixedBodyRight.scrollLeft(this.$fixedBodyRight.find('table').width())
       this.$fixedBodyRight.css('overflow-y', this.options.height ? 'auto' : 'hidden')
     }
+
+    const that = this
+    if (this.options.filterControl) {
+      $(this.$fixedColumns).off('keyup change mouseup').on('keyup change mouse', function (e) {
+        const $target = $(e.target)
+        const value = $target.val()
+        const field = $target.parents('th').data('field')
+        const $coreTh = that.$header.find('th[data-field="' + field + '"]')
+
+        if ($target.is('input')) {
+          $coreTh.find('input').val(value)
+        } else if ($target.is('select')) {
+          const $select = $coreTh.find('select')
+          $select.find('option[selected]').removeAttr('selected')
+          $select.find('option[value="' + value + '"]').attr('selected', true)
+        }
+
+        that.triggerSearch()
+      })
+    }
   }
 
   getFixedColumnsWidth (isRight) {

--- a/src/extensions/fixed-columns/bootstrap-table-fixed-columns.js
+++ b/src/extensions/fixed-columns/bootstrap-table-fixed-columns.js
@@ -233,26 +233,6 @@ $.BootstrapTable = class extends $.BootstrapTable {
       this.$fixedBodyRight.scrollLeft(this.$fixedBodyRight.find('table').width())
       this.$fixedBodyRight.css('overflow-y', this.options.height ? 'auto' : 'hidden')
     }
-
-    const that = this
-    if (this.options.filterControl) {
-      $(this.$fixedColumns).off('keyup change mouseup').on('keyup change mouse', function (e) {
-        const $target = $(e.target)
-        const value = $target.val()
-        const field = $target.parents('th').data('field')
-        const $coreTh = that.$header.find('th[data-field="' + field + '"]')
-
-        if ($target.is('input')) {
-          $coreTh.find('input').val(value)
-        } else if ($target.is('select')) {
-          const $select = $coreTh.find('select')
-          $select.find('option[selected]').removeAttr('selected')
-          $select.find('option[value="' + value + '"]').attr('selected', true)
-        }
-
-        that.triggerSearch()
-      })
-    }
   }
 
   getFixedColumnsWidth (isRight) {
@@ -345,6 +325,25 @@ $.BootstrapTable = class extends $.BootstrapTable {
         if (this.$fixedBody) {
           this.$fixedBody.scrollTop(top)
         }
+      })
+    }
+
+    if (this.options.filterControl) {
+      $(this.$fixedColumns).off('keyup change').on('keyup change', e => {
+        const $target = $(e.target)
+        const value = $target.val()
+        const field = $target.parents('th').data('field')
+        const $coreTh = this.$header.find(`th[data-field="${field}"]`)
+
+        if ($target.is('input')) {
+          $coreTh.find('input').val(value)
+        } else if ($target.is('select')) {
+          const $select = $coreTh.find('select')
+          $select.find('option[selected]').removeAttr('selected')
+          $select.find(`option[value="${value}"]`).attr('selected', true)
+        }
+
+        this.triggerSearch()
       })
     }
   }


### PR DESCRIPTION
fix #4463 

Before: https://live.bootstrap-table.com/code/UtechtDustin/1744
After: https://live.bootstrap-table.com/code/UtechtDustin/1745

Im not sure why the example is broken in the editor, locally its working fine for me.
@wenzhixin could it possible that some css will not be compiled with the newest editor update ?

![Peek 2020-02-09 20-44](https://user-images.githubusercontent.com/13292481/74108676-05e35080-4b7d-11ea-91ab-6bf220b779f6.gif)