### PR TITLE
updateCellByUniqueId bug fix

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -2288,11 +2288,7 @@ class BootstrapTable {
   }
 
   updateCellByUniqueId (params) {
-    if (!params.hasOwnProperty('id') ||
-      !params.hasOwnProperty('field') ||
-      !params.hasOwnProperty('value')) {
-      return
-    }
+    
     const allParams = Array.isArray(params) ? params : [params]
 
     allParams.forEach(({id, field, value}) => {

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -2288,7 +2288,6 @@ class BootstrapTable {
   }
 
   updateCellByUniqueId (params) {
-    
     const allParams = Array.isArray(params) ? params : [params]
 
     allParams.forEach(({id, field, value}) => {


### PR DESCRIPTION
```
if (!params.hasOwnProperty('id') ||
      !params.hasOwnProperty('field') ||
      !params.hasOwnProperty('value')) {
      return
    }
```

Was preventing passing multiples entries to updateCellByUniqueId.

Other methods may have to be fixed.