### PR TITLE
First time issue with cookie and filter-control

### DIFF
--- a/src/extensions/cookie/bootstrap-table-cookie.js
+++ b/src/extensions/cookie/bootstrap-table-cookie.js
@@ -195,11 +195,10 @@ const UtilsCookie = {
   },
   initCookieFilters (bootstrapTable) {
     setTimeout(() => {
+      const cachedFilters = {}
       const parsedCookieFilters = JSON.parse(UtilsCookie.getCookie(bootstrapTable, bootstrapTable.options.cookieIdTable, UtilsCookie.cookieIds.filterControl))
 
       if (!bootstrapTable.options.filterControlValuesLoaded && parsedCookieFilters) {
-
-        const cachedFilters = {}
         const header = UtilsCookie.getCurrentHeader(bootstrapTable)
         const searchControls = UtilsCookie.getCurrentSearchControls(bootstrapTable)
 
@@ -226,10 +225,11 @@ const UtilsCookie = {
           applyCookieFilters(this, filteredCookies)
         })
 
-        bootstrapTable.initColumnSearch(cachedFilters)
-        bootstrapTable.options.filterControlValuesLoaded = true
-        bootstrapTable.initServer()
       }
+
+      bootstrapTable.initColumnSearch(cachedFilters)
+      bootstrapTable.options.filterControlValuesLoaded = true
+      bootstrapTable.initServer()
     }, 250)
   }
 }


### PR DESCRIPTION
This fixes an issue where Cookie data is not present (e.g. first time visit to a page) and filter-control enabled (with a select input).