### PR TITLE
fix onPostBody this context

### DIFF
--- a/src/extensions/reorder-rows/bootstrap-table-reorder-rows.js
+++ b/src/extensions/reorder-rows/bootstrap-table-reorder-rows.js
@@ -45,7 +45,7 @@ $.BootstrapTable = class extends $.BootstrapTable {
     this.options.onPostBody = () => {
       setTimeout(() => {
         this.makeRowsReorderable()
-        onPostBody.apply()
+        onPostBody.call(this.options, this.options.data)
       }, 1)
     }
 


### PR DESCRIPTION
When I use reorder-rows plugin, parameter `data` and `this` in onPostBody are lost. Then, I change the source code and everything seems right. So, I created this pr and I'm still not sure if I considered everything.
Before: https://live.bootstrap-table.com/code/Zhangjin1993/2786
After: https://live.bootstrap-table.com/code/Zhangjin1993/2787