### PR TITLE
Feature/loading font size

### DIFF
--- a/site/docs/api/table-options.md
+++ b/site/docs/api/table-options.md
@@ -602,6 +602,19 @@ The table options are defined in `jQuery.fn.bootstrapTable.defaults`.
 
 - **Example:** [Table Locale](https://examples.bootstrap-table.com/#options/table-locale.html)
 
+## loadingFontSize
+
+- **Attribute:** `data-loading-font-size`
+
+- **Type:** `String`
+
+- **Detail:**
+
+  To define the font size of the loading text, the default value is `'auto'`, it will be calculated automatically according to the table width, between 12px and 32px.
+
+- **Default:** `'auto'`
+
+- **Example:** [Loading Font Size](https://examples.bootstrap-table.com/#options/loading-font-size.html)
 
 ## loadingTemplate
 

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -2696,12 +2696,16 @@ class BootstrapTable {
   showLoading () {
     this.$tableLoading.css('display', 'flex')
 
-    let fontSize = this.$tableLoading.width() * 0.04
+    let fontSize = this.options.loadingFontSize
 
-    fontSize = Math.max(12, fontSize)
-    fontSize = Math.min(32, fontSize)
+    if (this.options.loadingFontSize === 'auto') {
+      fontSize = this.$tableLoading.width() * 0.04
+      fontSize = Math.max(12, fontSize)
+      fontSize = Math.min(32, fontSize)
+      fontSize = `${fontSize}px`
+    }
 
-    this.$tableLoading.find('.loading-text').css('font-size', `${fontSize}px`)
+    this.$tableLoading.find('.loading-text').css('font-size', fontSize)
   }
 
   hideLoading () {

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -2695,6 +2695,13 @@ class BootstrapTable {
 
   showLoading () {
     this.$tableLoading.css('display', 'flex')
+
+    let fontSize = this.$tableLoading.width() * 0.04
+
+    fontSize = Math.max(12, fontSize)
+    fontSize = Math.min(32, fontSize)
+
+    this.$tableLoading.find('.loading-text').css('font-size', `${fontSize}px`)
   }
 
   hideLoading () {

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -236,6 +236,7 @@ const DEFAULTS = {
   html: CONSTANTS.html,
   iconSize: undefined,
   iconsPrefix: CONSTANTS.iconsPrefix, // glyphicon or fa(font-awesome)
+  loadingFontSize: 'auto',
   loadingTemplate (loadingMessage) {
     return `<span class="loading-wrap">
       <span class="loading-text">${loadingMessage}</span>

--- a/src/themes/_theme.scss
+++ b/src/themes/_theme.scss
@@ -212,7 +212,6 @@
           justify-content: center;
 
           .loading-text {
-            font-size: 2rem;
             margin-right: 6px;
           }
 


### PR DESCRIPTION
Fix #4942

Auto font size example: https://live.bootstrap-table.com/code/wenzhixin/2891
`16px`: https://live.bootstrap-table.com/code/wenzhixin/2892
`2rem`: https://live.bootstrap-table.com/code/wenzhixin/2893