### PR TITLE
Fixed showRow method show all hidden rows bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ ChangeLog
 - **Update:** Fixed the `page-change` event before init server.
 - **Update:** Fixed `font-size` of the loading text.
 - **Update:** Fixed table `border` bug when table is hidden.
+- **Update:** Fixed `showRow` method show all hidden rows bug.
 
 #### Extensions
 

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -2339,18 +2339,16 @@ class BootstrapTable {
     } else if (visible && index > -1) {
       this.hiddenRows.splice(index, 1)
     }
-    if (visible) {
-      this.updatePagination()
-    } else {
-      this.initBody(true)
-      this.initPagination()
-    }
+
+    this.initBody(true)
+    this.initPagination()
   }
 
   getHiddenRows (show) {
     if (show) {
       this.initHiddenRows()
       this.initBody(true)
+      this.initPagination()
       return
     }
     const data = this.getData()


### PR DESCRIPTION
Fix #5034

Before: https://live.bootstrap-table.com/code/mkyral/2965
After: https://live.bootstrap-table.com/code/wenzhixin/3035