### PR TITLE
Find cookie value from existing options

### DIFF
--- a/src/extensions/cookie/bootstrap-table-cookie.js
+++ b/src/extensions/cookie/bootstrap-table-cookie.js
@@ -212,6 +212,13 @@ const UtilsCookie = {
               element.value = cookie.text
               cachedFilters[cookie.field] = cookie.text
             } else if (cookie.text !== '' && element.tagName === 'SELECT') {
+              for (var i = 0; i < element.length; i++) {
+                const currentElement = element[i]
+                if (currentElement.value === cookie.text) {
+                  currentElement.selected = true
+                  return
+                }
+              }
               const option = document.createElement('option')
               option.value = cookie.text
               option.text = cookie.text


### PR DESCRIPTION
Instead of always add a new option, first try to search from existing ones

**Bug fix?**
yes

**New Feature?**
no

**Resolve an issue?**
fix #5093

**Example(s)?**

![filter-select-cookie](https://user-images.githubusercontent.com/220968/84691773-fae26780-af44-11ea-9493-8e1ab4fb497b.gif)

https://live.bootstrap-table.com/code/albfan/3438


