### PR TITLE
Footer colspan and server response

### DIFF
--- a/site/docs/api/column-options.md
+++ b/site/docs/api/column-options.md
@@ -228,7 +228,7 @@ The column options is defined in `jQuery.fn.bootstrapTable.columnDefaults`.
   The function, takes two parameter:
 
   * `data`: Array of all the data rows.
-  * `value`: If footer data isset, the value of the footer column.
+  * `value`: If footer data is set, the value of the footer column.
 
   the function should return a string with the text to show in the footer cell.
 

--- a/site/docs/api/column-options.md
+++ b/site/docs/api/column-options.md
@@ -225,9 +225,10 @@ The column options is defined in `jQuery.fn.bootstrapTable.columnDefaults`.
 
   The context (this) is the column Object.
 
-  The function, take one parameter:
+  The function, takes two parameter:
 
-  * `data`: Array of all the  data rows.
+  * `data`: Array of all the data rows.
+  * `value`: If footer data isset, the value of the footer column.
 
   the function should return a string with the text to show in the footer cell.
 

--- a/site/docs/api/column-options.md
+++ b/site/docs/api/column-options.md
@@ -225,7 +225,7 @@ The column options is defined in `jQuery.fn.bootstrapTable.columnDefaults`.
 
   The context (this) is the column Object.
 
-  The function, takes two parameter:
+  The function, takes two parameters:
 
   * `data`: Array of all the data rows.
   * `value`: If footer data is set, the value of the footer column.

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -212,6 +212,7 @@ const DEFAULTS = {
   totalField: 'total',
   totalNotFilteredField: 'totalNotFiltered',
   dataField: 'rows',
+  footerField: 'footer',
   pagination: false,
   paginationParts: ['pageInfo', 'pageSize', 'pageList'],
   showExtendedPagination: false,


### PR DESCRIPTION
**Description**
This PR adds the ability to use colspans in the footer.
I also added the ability to use the values from the footer (or from a server response) in the footerFormatter.

**Bug fix?**
no

**New Feature?**
yes

**Resolve an issue?**
Fix #3046
Fix #2276

**Example(s)?**
FooterFormatter with value from footer: https://live.bootstrap-table.com/code/UtechtDustin/3974
Footer colspan: https://live.bootstrap-table.com/code/UtechtDustin/3975
Footer multiple colspans: https://live.bootstrap-table.com/code/UtechtDustin/3976
Both works with paginationSide `Server`, an json should looks like:
```
{
  "rows": [
    {
      "id": 0,
      "name": "Item 0",
      "price": "$0",
      "amount": 3
    },
    {
      "id": 1,
      "name": "Item 1",
      "price": "$1",
      "amount": 4
    },
    {
      "id": 2,
      "name": "Item 2",
      "price": "$2",
      "amount": 8
    }
  ],
  "footer": {
    "id": "fid",
    "_id_colspan": 2,
    "name": "fname"
  }
}
```

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->