### PR TITLE
Fixed an issue with vertical scrolling event

### DIFF
--- a/src/extensions/sticky-header/bootstrap-table-sticky-header.js
+++ b/src/extensions/sticky-header/bootstrap-table-sticky-header.js
@@ -56,6 +56,11 @@ $.BootstrapTable = class extends $.BootstrapTable {
       .on('scroll', () => this.renderStickyHeader())
   }
 
+  horizontalScroll () {
+    super.horizontalScroll()
+    this.$tableBody.on('scroll', () => this.matchPositionX())
+  }
+
   renderStickyHeader () {
     const that = this
     this.$stickyHeader = this.$header.clone(true, true)


### PR DESCRIPTION
**Bug fix?**
yes

**New Feature?**
no

**Resolve an issue?**
https://stackoverflow.com/questions/63239938/bootstrap-table-sticky-header-doesnt-move-left-right-with-table-content-when-sc

**Example(s)?**
Scroll to the right (the header will not be positioned)
Before: https://live.bootstrap-table.com/code/UtechtDustin/4247
After: https://live.bootstrap-table.com/code/UtechtDustin/4248     

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->