### PR TITLE
The checked property is ignored on checkbox columns where the field has a value

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1454,7 +1454,8 @@ class BootstrapTable {
         type = column.radio ? 'radio' : type
 
         const c = column['class'] || ''
-        const isChecked = (typeof(value.checked) !== 'undefined' ? value.checked : (value === true || value_ || value && value.checked) && value !== false)
+        const isChecked = Utils.isObject(value) && value.hasOwnProperty('checked') ?
+          value.checked : (value === true || value_) && value !== false
         const isDisabled = !column.checkboxEnabled || (value && value.disabled)
 
         text = [

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1454,7 +1454,7 @@ class BootstrapTable {
         type = column.radio ? 'radio' : type
 
         const c = column['class'] || ''
-        const isChecked = (value === true || value_ || (value && value.checked)) && value !== false
+        const isChecked = (typeof(value.checked) !== 'undefined' ? value.checked : (value === true || value_ || value && value.checked) && value !== false)
         const isDisabled = !column.checkboxEnabled || (value && value.disabled)
 
         text = [

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -15,6 +15,10 @@ export default {
     })
     return flag ? str : ''
   },
+  
+  isObject (val) {
+    return val !== null && typeof val === 'object' && !Array.isArray(val)
+  },
 
   isEmptyObject (obj = {}) {
     return Object.entries(obj).length === 0 && obj.constructor === Object

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -17,7 +17,7 @@ export default {
   },
   
   isObject (val) {
-    return val !== null && typeof val === 'object' && !Array.isArray(val)
+    return val instanceof Object && !Array.isArray(val)
   },
 
   isEmptyObject (obj = {}) {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -15,7 +15,7 @@ export default {
     })
     return flag ? str : ''
   },
-  
+
   isObject (val) {
     return val instanceof Object && !Array.isArray(val)
   },


### PR DESCRIPTION
The checked property is ignored if the field has a value.

For example:
I am setting the checkbox column to the Id field so there is always a value. If I set the formatter to checked: false the checkbox is still checked because the field has a value.

`function checkboxFormatter(){
return {
checked: false,
disabled: true
}`

**Bug fix?**
yes

**New Feature?**
no

**Resolve an issue?**
<!-- Please prefix each issue number with  "Fix #"  (e.g. Fix #200)  -->

**Example(s)?**
https://live.bootstrap-table.com/code/TantumLabs/4276