### PR TITLE
use the main dataset instead of the current one

### DIFF
--- a/site/docs/api/methods.md
+++ b/site/docs/api/methods.md
@@ -167,16 +167,6 @@ The calling method syntax: `$('#table').bootstrapTable('method', parameter)`.
 
 - **Example:** [Filter By](https://examples.bootstrap-table.com/#methods/filter-by.html)
 
-## getAllSelections
-
-- **Parameter:** `undefined`
-
-- **Detail:**
-
-  Return all selected rows contain search or filter, when no record selected, an empty array will return.
-
-- **Example:** [Get All Selections](https://examples.bootstrap-table.com/#methods/get-all-selections.html)
-
 ## getData
 
 - **Parameter:** `params`
@@ -249,6 +239,7 @@ The calling method syntax: `$('#table').bootstrapTable('method', parameter)`.
 - **Detail:**
 
   Return selected rows, when no record selected, an empty array will return.
+  The selected rows will be unselected while some actions happens e.g. searching or page change, if you want to maintain the selections please use [maintainMetaData](https://bootstrap-table.com/docs/api/table-options/#maintainmetadata). 
 
 - **Example:** [Get Selections](https://examples.bootstrap-table.com/#methods/get-selections.html)
 

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -2676,7 +2676,7 @@ class BootstrapTable {
 
   _toggleCheck (checked, index) {
     const $el = this.$selectItem.filter(`[data-index="${index}"]`)
-    const row = this.data[index]
+    const row = this.options.data[index]
 
     if (
       $el.is(':radio') ||

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -2222,11 +2222,6 @@ class BootstrapTable {
   }
 
   getSelections () {
-    // fix #2424: from html with checkbox
-    return this.data.filter(row => row[this.header.stateField] === true)
-  }
-
-  getAllSelections () {
     return this.options.data.filter(row => row[this.header.stateField] === true)
   }
 

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -500,7 +500,7 @@ const METHODS = [
   'getOptions',
   'refreshOptions',
   'getData',
-  'getSelections', 'getAllSelections',
+  'getSelections',
   'load', 'append', 'prepend',
   'remove', 'removeAll',
   'insertRow', 'updateRow',


### PR DESCRIPTION
**Bug fix?**
yes

**New Feature?**
no

**Resolve an issue?**
Fix #5278

**Example(s)?**
Bug1:
Check the first checkbox, delete the row.
Do the same for the second row => Deletion is not working

Bug2:
Check the first checkbox, delete the row.
Click on "getSelections", there is still the removed row.

Before: https://live.bootstrap-table.com/code/UtechtDustin/4645
After: https://live.bootstrap-table.com/code/UtechtDustin/4646

This issue also removes the `getAllSelections` which no more needed, because of the option [maintainMetaData](https://bootstrap-table.com/docs/api/table-options/#maintainmetadata).
If you have arguments against it, please explain them.

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->