### PR TITLE
Fixed toggleCheck and remove bug

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -2391,36 +2391,35 @@ class BootstrapTable {
   }
 
   remove (params) {
-    const len = this.options.data.length
-    let i
-    let row
+    let removed = 0
 
-    if (!params.hasOwnProperty('field') || !params.hasOwnProperty('values')) {
-      return
-    }
+    for (let i = this.options.data.length - 1; i >= 0; i--) {
 
-    for (i = len - 1; i >= 0; i--) {
-      let exists = false
-
-      row = this.options.data[i]
+      const row = this.options.data[i]
 
       if (!row.hasOwnProperty(params.field) && params.field !== '$index') {
         continue
-      } else if (!row.hasOwnProperty(params.field) && params.field === '$index') {
-        exists = params.values.includes(i)
-      } else {
-        exists = params.values.includes(row[params.field])
       }
-      if (exists) {
+
+      if (
+        !row.hasOwnProperty(params.field) &&
+        params.field === '$index' &&
+        params.values.includes(i) ||
+        params.values.includes(row[params.field])
+      ) {
+        removed++
+
         this.options.data.splice(i, 1)
-        if (this.options.sidePagination === 'server') {
-          this.options.totalRows -= 1
-        }
       }
     }
 
-    if (len === this.options.data.length) {
+    if (!removed) {
       return
+    }
+
+    if (this.options.sidePagination === 'server') {
+      this.options.totalRows -= removed
+      this.data = [...this.options.data]
     }
 
     this.initSearch()
@@ -2546,6 +2545,11 @@ class BootstrapTable {
 
     if (len === this.options.data.length) {
       return
+    }
+
+    if (this.options.sidePagination === 'server') {
+      this.options.totalRows -= 1
+      this.data = [...this.options.data]
     }
 
     this.initSearch()
@@ -2807,7 +2811,7 @@ class BootstrapTable {
 
   _toggleCheck (checked, index) {
     const $el = this.$selectItem.filter(`[data-index="${index}"]`)
-    const row = this.options.data[index]
+    const row = this.data[index]
 
     if (
       $el.is(':radio') ||


### PR DESCRIPTION
**Bug fix?**
yes

**New Feature?**
no

### Fix #5298 

* Bug 1:
1. Check the first checkbox, delete the row.
2. Do the same for the second row => Deletion is not working

* Bug 2:
1. Check the first checkbox, delete the row.
2. Click on `getSelections`, there is still the removed row.

Before: https://live.bootstrap-table.com/code/UtechtDustin/4645
After: https://live.bootstrap-table.com/code/wenzhixin/5403
     
### Fix #5403

1. Select all rows using checkbox.
2. Search for some keyword.
3. Uncheck a row from the search results.
4. Clear search box.

Before: https://live.bootstrap-table.com/code/supmanyu/5191
After: https://live.bootstrap-table.com/code/wenzhixin/5405

### Fix #5384 

* Bug 1:
1. Reorder column "Item name twice" (item 9 is now the first one)
2. Select item 9 then click getSelections button

Before: https://live.bootstrap-table.com/code/fvaletas/5113
After: https://live.bootstrap-table.com/code/wenzhixin/5406

* Bug 2:
1. Click the `removeByUniqueId`.
2. Click the `getData`.

Before: https://live.bootstrap-table.com/code/wenzhixin/5407
After: https://live.bootstrap-table.com/code/wenzhixin/5408

### Fix #5420 

1. Click the `Amount` column.
2. Select the first three rows.
3. Click the `getSelections`.

Before: https://live.bootstrap-table.com/code/manukieli/5302
After: https://live.bootstrap-table.com/code/wenzhixin/5409
Before: https://live.bootstrap-table.com/code/manukieli/5301
After: https://live.bootstrap-table.com/code/wenzhixin/5410

### Fix #5429 

1. search for e.g. "3"
2. check both appearing rows
3. clear the search field
4. the first two rows in the table are checked and not the rows from the previous selection

Before: https://live.bootstrap-table.com/example/options/maintain-meta-data.html
After: https://live.bootstrap-table.com/code/wenzhixin/5411