### PR TITLE
Fix-#5426: Ignore to export icon columns when using detailView

### DIFF
--- a/src/extensions/export/bootstrap-table-export.js
+++ b/src/extensions/export/bootstrap-table-export.js
@@ -195,6 +195,21 @@ $.BootstrapTable = class extends $.BootstrapTable {
       })
 
       const data = this.getData()
+      
+      // Fix #5426
+      if(o.detailView && o.detailViewIcon){
+        if(o.exportOptions.ignoreColumn){
+          if(o.detailViewAlign == 'left')
+            o.exportOptions.ignoreColumn = $.merge([0], o.exportOptions.ignoreColumn)
+          else if(o.detailViewAlign == 'right')
+            o.exportOptions.ignoreColumn = $.merge([this.columns.length], o.exportOptions.ignoreColumn)
+        } else {
+          if(o.detailViewAlign == 'left')
+            o.exportOptions.ignoreColumn = [0]
+          else if(o.detailViewAlign == 'right')
+            o.exportOptions.ignoreColumn = [this.columns.length]
+        }
+      }
 
       if (o.exportFooter) {
         const $footerRow = this.$tableFooter.find('tr').first()


### PR DESCRIPTION
**Bug fix?**
yes
<!-- yes/no -->

**New Feature?**
no
<!-- yes/no -->

**Resolve an issue?**
Fix #5426
<!-- Please prefix each issue number with  "Fix #"  (e.g. Fix #200)  -->

**Example(s)?**
Before: https://live.bootstrap-table.com/code/zhfanrui/5805 
After: https://live.bootstrap-table.com/code/zhfanrui/5807

Export to see the difference. 

<!-- Please use our online Editor (https://live.bootstrap-table.com/) to create example(s) (Before and after your changes).
     On our Wiki (https://github.com/wenzhixin/bootstrap-table/wiki/Online-Editor-Explanation) you can read how to use the editor.-->
     

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->