### PR TITLE
Search highlight bugfix

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1574,11 +1574,11 @@ class BootstrapTable {
           this.options.undefinedText : value
       }
 
-      if (this.searchText && this.options.searchHighlight) {
+      if (column.searchable && this.searchText && this.options.searchHighlight) {
         let defValue = ''
         const regExp = new RegExp(`(${ this.searchText.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') })`, 'gim')
         const marker = '<mark>$1</mark>'
-        const isHTML = !/<(?=.*? .*?\/ ?>|br|hr|input|!--|wbr)[a-z]+.*?>|<([a-z]+).*?<\/\1>/i.test(value.toString())
+        const isHTML = value && /<(?=.*? .*?\/ ?>|br|hr|input|!--|wbr)[a-z]+.*?>|<([a-z]+).*?<\/\1>/i.test(value)
 
         if (isHTML) {
           // value can contains a HTML tags

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1575,7 +1575,21 @@ class BootstrapTable {
       }
 
       if (this.searchText && this.options.searchHighlight) {
-        value = Utils.calculateObjectValue(column, column.searchHighlightFormatter, [value, this.searchText], value.toString().replace(new RegExp(`(${ this.searchText.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') })`, 'gim'), '<mark>$1</mark>'))
+        let defValue = ''
+        const regExp = new RegExp(`(${ this.searchText.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') })`, 'gim')
+        const marker = '<mark>$1</mark>'
+        const isHTML = !/<(?=.*? .*?\/ ?>|br|hr|input|!--|wbr)[a-z]+.*?>|<([a-z]+).*?<\/\1>/i.test(value.toString())
+
+        if (isHTML) {
+          // value can contains a HTML tags
+          const textContent = new DOMParser().parseFromString(value.toString(), 'text/html').documentElement.textContent
+
+          defValue = value.toString().replace(textContent, textContent.replace(regExp, marker))
+        } else {
+          // but usually not
+          defValue = value.toString().replace(regExp, marker)
+        }
+        value = Utils.calculateObjectValue(column, column.searchHighlightFormatter, [value, this.searchText], defValue)
       }
 
       if (item[`_${field}_data`] && !Utils.isEmptyObject(item[`_${field}_data`])) {

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1583,8 +1583,9 @@ class BootstrapTable {
         if (isHTML) {
           // value can contains a HTML tags
           const textContent = new DOMParser().parseFromString(value.toString(), 'text/html').documentElement.textContent
+          const textReplaced = textContent.replace(regExp, marker)
 
-          defValue = value.toString().replace(textContent, textContent.replace(regExp, marker))
+          defValue = value.replace(new RegExp(`(>\\s*)(${textContent})(\\s*)`, 'gm'), `$1${textReplaced}$3`)
         } else {
           // but usually not
           defValue = value.toString().replace(regExp, marker)


### PR DESCRIPTION
**Bug fix?**
yes

**New Feature?**
no

**Resolve an issue?**
Fix #5534

**Example**
Open online editor with 'https://live.bootstrap-table.com/example/welcomes/from-html.html'. Add a `data-search-highlight="true"` attribute to the 'table'-tag and typing 'a' into the search field, the name column will show destroyed HTML.

**My solution**
I check the value of the `searchchable` attribute for the column and ignore any columns marked as not searchable.

Then I check if the value contains HTML tags and, if this is true, I use `DOMParser` to replace the substring only in `textContent`. For the rest, the old functionality is used.

