### PR TITLE
Fix donation link in FAQs

### DIFF
--- a/site/docs/faq.md
+++ b/site/docs/faq.md
@@ -64,4 +64,4 @@ onClickRow: function (row, $element) {
 
 All your ideas and feedback are very appreciated! Please feel free to open issues on GitHub or send me an email.
 
-I'm also grateful for your donations: <a href="/donate">https://opencollective.com/bootstrap-table</a>.
+I'm also grateful for your donations: [https://opencollective.com/bootstrap-table](https://opencollective.com/bootstrap-table).


### PR DESCRIPTION
**Bug fix?**
<!-- yes/no -->
no

**New Feature?**
<!-- yes/no -->
no

**Resolve an issue?**
<!-- Please prefix each issue number with  "Fix #"  (e.g. Fix #200)  -->
no

**Example(s)?**
<!-- Please use our online Editor (https://live.bootstrap-table.com/) to create example(s) (Before and after your changes).
     On our Wiki (https://github.com/wenzhixin/bootstrap-table/wiki/Online-Editor-Explanation) you can read how to use the editor.-->
no

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->

Just noticed the donation link wasn't pointing to the URL it was advertising!
I just assumed this was the intended link, let me know if it should be a different link.