### PR TITLE
fixed an issue with negativ numbers while searching with comperations

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -949,8 +949,7 @@ class BootstrapTable {
         return
       }
 
-      const s = this.searchText && (this.fromHtml ?
-        Utils.escapeHTML(this.searchText) : this.searchText).toLowerCase()
+      const s = this.searchText && (this.fromHtml ? Utils.escapeHTML(this.searchText) : this.searchText).toLowerCase()
       const f = Utils.isEmptyObject(this.filterColumns) ? null : this.filterColumns
 
       // Check filter
@@ -1034,7 +1033,7 @@ class BootstrapTable {
               }
             } else {
               const largerSmallerEqualsRegex = /(?:(<=|=>|=<|>=|>|<)(?:\s+)?(-?\d+)?|(-?\d+)?(\s+)?(<=|=>|=<|>=|>|<))/gm
-              const matches = largerSmallerEqualsRegex.exec(s)
+              const matches = largerSmallerEqualsRegex.exec(this.searchText)
               let comparisonCheck = false
 
               if (matches) {

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1033,7 +1033,7 @@ class BootstrapTable {
                 return true
               }
             } else {
-              const largerSmallerEqualsRegex = /(?:(<=|=>|=<|>=|>|<)(?:\s+)?(\d+)?|(\d+)?(\s+)?(<=|=>|=<|>=|>|<))/gm
+              const largerSmallerEqualsRegex = /(?:(<=|=>|=<|>=|>|<)(?:\s+)?(-?\d+)?|(-?\d+)?(\s+)?(<=|=>|=<|>=|>|<))/gm
               const matches = largerSmallerEqualsRegex.exec(s)
               let comparisonCheck = false
 


### PR DESCRIPTION
**Bug fix?**
yes

**New Feature?**
no

**Resolve an issue?**
https://github.com/wenzhixin/bootstrap-table/issues/3042#issuecomment-769819874

It also fix the comperasion for tables based on html.

**Example(s)?**
Before: https://live.bootstrap-table.com/code/UtechtDustin/6443
After: https://live.bootstrap-table.com/code/UtechtDustin/6441

Search for `< -100`.

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->