### PR TITLE
Allow exact match when searching term with accent

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -956,8 +956,12 @@ class BootstrapTable {
         return
       }
 
-      const s = this.searchText && (this.fromHtml ? Utils.escapeHTML(this.searchText) : this.searchText).toLowerCase()
+      let s = this.searchText && (this.fromHtml ? Utils.escapeHTML(this.searchText) : this.searchText).toLowerCase()
       const f = Utils.isEmptyObject(this.filterColumns) ? null : this.filterColumns
+
+      if (this.options.searchAccentNeutralise) {
+        s = Utils.normalizeAccent(s)
+      }
 
       // Check filter
       if (typeof this.filterOptions.filterAlgorithm === 'function') {


### PR DESCRIPTION
With attribute `data-search-accent-neutralise` set to `true`, searching with
a term containing an accent must return a result in case of exact match.

i.e.
Initial condition: `table` tag has `data-search-accent-neutralise="true"`
 - Before this commit, searching `josé` does NOT match data containing `josé`.
 - With this commit, searching `josé` matches data containing `josé`.

**Bug fix?**
yes

**New Feature?**
no

**Resolve an issue?**
Fix #5581

**Example(s)?**
[Before](https://live.bootstrap-table.com/example/options/search-accent-neutralise.html) (enter `josé` in the search bar)
[After](https://live.bootstrap-table.com/code/pieral85/6546) (enter `josé` in the search bar)
<!-- Please use our online Editor (https://live.bootstrap-table.com/) to create example(s) (Before and after your changes).
     On our Wiki (https://github.com/wenzhixin/bootstrap-table/wiki/Online-Editor-Explanation) you can read how to use the editor.-->