### PR TITLE
Fixed reorder-rows not work property

### DIFF
--- a/src/extensions/reorder-rows/bootstrap-table-reorder-rows.js
+++ b/src/extensions/reorder-rows/bootstrap-table-reorder-rows.js
@@ -93,10 +93,26 @@ $.BootstrapTable = class extends $.BootstrapTable {
     this.options.data.splice(this.options.data.indexOf(draggingRow), 1)
     this.options.data.splice(index, 0, draggingRow)
 
+    this.initSearch()
+
     // Call the user defined function
     this.options.onReorderRowsDrop(droppedRow)
 
     // Call the event reorder-row
     this.trigger('reorder-row', newData, draggingRow, droppedRow)
+  }
+
+  initSearch () {
+    this.ignoreInitSort = true
+    super.initSearch()
+  }
+
+  initSort () {
+    if (this.ignoreInitSort) {
+      this.ignoreInitSort = false
+      return
+    }
+
+    super.initSort()
   }
 }


### PR DESCRIPTION
**Bug fix?**
yes

**New Feature?**
no

**Resolve an issue?**
no

**Example(s)?**
Before: https://live.bootstrap-table.com/code/wenzhixin/7359
After: https://live.bootstrap-table.com/code/wenzhixin/7361
     
You can reorder some rows times(sort or search) to show the problem.

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->