### PR TITLE
fix bootstrap-table-sticky-header

### DIFF
--- a/src/extensions/sticky-header/bootstrap-table-sticky-header.js
+++ b/src/extensions/sticky-header/bootstrap-table-sticky-header.js
@@ -107,9 +107,16 @@ $.BootstrapTable = class extends $.BootstrapTable {
     // show sticky when top anchor touches header, and when bottom anchor not exceeded
     if (top > start && top <= end) {
       // ensure clone and source column widths are the same
-      this.$stickyHeader.find('tr:eq(0)').find('th').each((index, el) => {
-        $(el).css('min-width', this.$header.find('tr:eq(0)').find('th').eq(index).css('width'))
-      })
+      // this.$stickyHeader.find('tr:eq(0)').find('th').each((index, el) => {
+      //   $(el).css('min-width', this.$header.find('tr:eq(0)').find('th').eq(index).css('width'))
+      // })
+      // "y" axis
+      this.$stickyHeader.find('tr').map(function(index, el) {
+        var axis_x = $(el).find('th');
+        axis_x.each(function(indexX, elX) {
+          $__default['default'](elX).css('min-width', _this4.$header.find('tr:eq('+index+')').find('th:eq('+ indexX+')').css('width'));
+        });
+      });
       // match bootstrap table style
       this.$stickyContainer.show().addClass('fix-sticky fixed-table-container')
       // stick it in position

--- a/src/extensions/sticky-header/bootstrap-table-sticky-header.js
+++ b/src/extensions/sticky-header/bootstrap-table-sticky-header.js
@@ -107,16 +107,13 @@ $.BootstrapTable = class extends $.BootstrapTable {
     // show sticky when top anchor touches header, and when bottom anchor not exceeded
     if (top > start && top <= end) {
       // ensure clone and source column widths are the same
-      // this.$stickyHeader.find('tr:eq(0)').find('th').each((index, el) => {
-      //   $(el).css('min-width', this.$header.find('tr:eq(0)').find('th').eq(index).css('width'))
-      // })
-      // "y" axis
-      this.$stickyHeader.find('tr').map(function(index, el) {
-        var axis_x = $(el).find('th');
-        axis_x.each(function(indexX, elX) {
-          $__default['default'](elX).css('min-width', _this4.$header.find('tr:eq('+index+')').find('th:eq('+ indexX+')').css('width'));
-        });
-      });
+      this.$stickyHeader.find('tr').each((indexRows, rows) => {
+        const columns = $(rows).find('th')
+
+        columns.each((indexColumns, celd) => {
+          $(celd).css('min-width', this.$header.find(`tr:eq(${indexRows})`).find(`th:eq(${indexColumns})`).css('width'))
+        })
+      })
       // match bootstrap table style
       this.$stickyContainer.show().addClass('fix-sticky fixed-table-container')
       // stick it in position


### PR DESCRIPTION
when there are two or more rows and they have different sizes, the cells are corrected sizes

**Bug fix?**
yes

Normal table
![normal](https://user-images.githubusercontent.com/8785295/115457985-c5547d80-a1ea-11eb-9d20-cbf956faa77e.PNG)

Scroll table
![scroll](https://user-images.githubusercontent.com/8785295/115458006-ca193180-a1ea-11eb-83fb-ad907fb092f4.PNG)

Correccion
![new](https://user-images.githubusercontent.com/8785295/115458005-ca193180-a1ea-11eb-8afd-82ff43b22724.PNG)

I leave the correction of the code

