### PR TITLE
Cookie multi sort

### DIFF
--- a/site/docs/extensions/cookie.md
+++ b/site/docs/extensions/cookie.md
@@ -178,9 +178,9 @@ toc: true
 
 - **Detail:**
 
-   Set this array with the table properties (sortOrder, sortName, pageNumber, pageList, columns, searchText, filterControl) that you want to save
+   Set this array with the table properties (sortOrder, sortName, sortPriority, pageNumber, pageList, columns, searchText, filterControl) that you want to save
 
-- **Default:** `['bs.table.sortOrder', 'bs.table.sortName', 'bs.table.pageNumber', 'bs.table.pageList', 'bs.table.columns', 'bs.table.searchText', 'bs.table.filterControl']`
+- **Default:** `['bs.table.sortOrder', 'bs.table.sortName', 'bs.table.sortPriority', 'bs.table.pageNumber', 'bs.table.pageList', 'bs.table.columns', 'bs.table.searchText', 'bs.table.filterControl']`
 
 ## Methods
 
@@ -207,4 +207,5 @@ toc: true
 * Search text
 * Search filter control
 * Sort order
+* Multiple Sort order
 * Visible columns

--- a/src/extensions/cookie/bootstrap-table-cookie.js
+++ b/src/extensions/cookie/bootstrap-table-cookie.js
@@ -380,14 +380,13 @@ $.BootstrapTable = class extends $.BootstrapTable {
     if (this.options.sortName === undefined || this.options.sortOrder === undefined) {
       UtilsCookie.deleteCookie(this, this.options.cookieIdTable, UtilsCookie.cookieIds.sortName)
       UtilsCookie.deleteCookie(this, this.options.cookieIdTable, UtilsCookie.cookieIds.sortOrder)
-      return
     } else {
       this.options.sortPriority = null
       UtilsCookie.deleteCookie(this, this.options.cookieIdTable, UtilsCookie.cookieIds.sortPriority)
-    }
 
-    UtilsCookie.setCookie(this, UtilsCookie.cookieIds.sortOrder, this.options.sortOrder)
-    UtilsCookie.setCookie(this, UtilsCookie.cookieIds.sortName, this.options.sortName)
+      UtilsCookie.setCookie(this, UtilsCookie.cookieIds.sortOrder, this.options.sortOrder)
+      UtilsCookie.setCookie(this, UtilsCookie.cookieIds.sortName, this.options.sortName)
+    }
   }
 
   onMultipleSort (...args) {
@@ -395,17 +394,14 @@ $.BootstrapTable = class extends $.BootstrapTable {
 
     if (this.options.sortPriority === undefined) {
       UtilsCookie.deleteCookie(this, this.options.cookieIdTable, UtilsCookie.cookieIds.sortPriority)
-      return
     } else {
       this.options.sortName = undefined
       this.options.sortOrder = undefined
       UtilsCookie.deleteCookie(this, this.options.cookieIdTable, UtilsCookie.cookieIds.sortName)
       UtilsCookie.deleteCookie(this, this.options.cookieIdTable, UtilsCookie.cookieIds.sortOrder)
+	  
+	  UtilsCookie.setCookie(this, UtilsCookie.cookieIds.sortPriority, JSON.stringify(this.options.sortPriority))
     }
-
-    let priority = this.options.sortPriority
-
-    UtilsCookie.setCookie(this, UtilsCookie.cookieIds.sortPriority, JSON.stringify(this.options.sortPriority))
   }
 
   onPageNumber (...args) {
@@ -483,7 +479,7 @@ $.BootstrapTable = class extends $.BootstrapTable {
 
     const sortOrderCookie = UtilsCookie.getCookie(this, this.options.cookieIdTable, UtilsCookie.cookieIds.sortOrder)
     const sortOrderNameCookie = UtilsCookie.getCookie(this, this.options.cookieIdTable, UtilsCookie.cookieIds.sortName)
-    let   sortPriorityCookie = UtilsCookie.getCookie(this, this.options.cookieIdTable, UtilsCookie.cookieIds.sortPriority)
+    let sortPriorityCookie = UtilsCookie.getCookie(this, this.options.cookieIdTable, UtilsCookie.cookieIds.sortPriority)
     const pageNumberCookie = UtilsCookie.getCookie(this, this.options.cookieIdTable, UtilsCookie.cookieIds.pageNumber)
     const pageListCookie = UtilsCookie.getCookie(this, this.options.cookieIdTable, UtilsCookie.cookieIds.pageList)
     const searchTextCookie = UtilsCookie.getCookie(this, this.options.cookieIdTable, UtilsCookie.cookieIds.searchText)
@@ -508,24 +504,24 @@ $.BootstrapTable = class extends $.BootstrapTable {
       throw new Error('Could not parse the json of the sortPriority cookie!', sortPriorityCookie)
     }
 
-    if(!sortPriorityCookie){
+    if (!sortPriorityCookie){
       // sortOrder
       this.options.sortOrder = sortOrderCookie  ? sortOrderCookie : this.options.sortOrder
       // sortName
       this.options.sortName = sortOrderNameCookie ? sortOrderNameCookie : this.options.sortName
     } else {
-       // sortOrder
-       this.options.sortOrder = undefined
-       // sortName
-       this.options.sortName = undefined
+      // sortOrder
+      this.options.sortOrder = undefined
+      // sortName
+      this.options.sortName = undefined
     }
 
-    if(this.options.sortOrder || this.options.sortName){
+    if (this.options.sortOrder || this.options.sortName){
       // sortPriority
       this.options.sortPriority = null
     } else {
       // sortPriority
-      this.options.sortPriority = sortPriorityCookie  ? sortPriorityCookie : this.options.sortPriority
+      this.options.sortPriority = sortPriorityCookie ? sortPriorityCookie : this.options.sortPriority
     }
 
     // pageNumber

--- a/src/extensions/cookie/bootstrap-table-cookie.js
+++ b/src/extensions/cookie/bootstrap-table-cookie.js
@@ -522,12 +522,12 @@ $.BootstrapTable = class extends $.BootstrapTable {
 
     if(this.options.sortOrder || this.options.sortName){
       // sortPriority
-      this.options.sortPriority = undefined
+      this.options.sortPriority = null
     } else {
       // sortPriority
       this.options.sortPriority = sortPriorityCookie  ? sortPriorityCookie : this.options.sortPriority
     }
-    
+
     // pageNumber
     this.options.pageNumber = pageNumberCookie ? +pageNumberCookie : this.options.pageNumber
     // pageSize

--- a/src/extensions/cookie/bootstrap-table-cookie.js
+++ b/src/extensions/cookie/bootstrap-table-cookie.js
@@ -403,7 +403,13 @@ $.BootstrapTable = class extends $.BootstrapTable {
       UtilsCookie.deleteCookie(this, this.options.cookieIdTable, UtilsCookie.cookieIds.sortOrder)
     }
 
-    UtilsCookie.setCookie(this, UtilsCookie.cookieIds.sortPriority, JSON.stringify(this.options.sortPriority))
+    let priority = this.options.sortPriority
+
+    if (typeof priority !== "string") {
+      priority = JSON.stringify(priority)
+    }
+
+    UtilsCookie.setCookie(this, UtilsCookie.cookieIds.sortPriority, priority)
   }
 
   onPageNumber (...args) {

--- a/src/extensions/cookie/bootstrap-table-cookie.js
+++ b/src/extensions/cookie/bootstrap-table-cookie.js
@@ -509,11 +509,11 @@ $.BootstrapTable = class extends $.BootstrapTable {
     }
 
     // sortOrder
-    this.options.sortOrder = sortOrderCookie ? sortOrderCookie : this.options.sortOrder
+    this.options.sortOrder = sortOrderCookie && !this.options.sortPriority ? sortOrderCookie : this.options.sortOrder
     // sortName
-    this.options.sortName = sortOrderNameCookie ? sortOrderNameCookie : this.options.sortName
+    this.options.sortName = sortOrderNameCookie && !this.options.sortPriority ? sortOrderNameCookie : this.options.sortName
     // sortPriority
-    this.options.sortPriority = sortPriorityCookie ? sortPriorityCookie : this.options.sortPriority
+    this.options.sortPriority = sortPriorityCookie && (!this.options.sortOrder || this.options.sortName) ? sortPriorityCookie : this.options.sortPriority
     // pageNumber
     this.options.pageNumber = pageNumberCookie ? +pageNumberCookie : this.options.pageNumber
     // pageSize

--- a/src/extensions/cookie/bootstrap-table-cookie.js
+++ b/src/extensions/cookie/bootstrap-table-cookie.js
@@ -399,7 +399,7 @@ $.BootstrapTable = class extends $.BootstrapTable {
       this.options.sortOrder = undefined
       UtilsCookie.deleteCookie(this, this.options.cookieIdTable, UtilsCookie.cookieIds.sortName)
       UtilsCookie.deleteCookie(this, this.options.cookieIdTable, UtilsCookie.cookieIds.sortOrder)
-      
+
       UtilsCookie.setCookie(this, UtilsCookie.cookieIds.sortPriority, JSON.stringify(this.options.sortPriority))
     }
   }

--- a/src/extensions/cookie/bootstrap-table-cookie.js
+++ b/src/extensions/cookie/bootstrap-table-cookie.js
@@ -395,7 +395,7 @@ $.BootstrapTable = class extends $.BootstrapTable {
       return
     }
 
-    UtilsCookie.setCookie(this, UtilsCookie.cookieIds.sortPriority, this.options.sortPriority)
+    UtilsCookie.setCookie(this, UtilsCookie.cookieIds.sortPriority, JSON.stringify(this.options.sortPriority))
   }
 
   onPageNumber (...args) {

--- a/src/extensions/cookie/bootstrap-table-cookie.js
+++ b/src/extensions/cookie/bootstrap-table-cookie.js
@@ -504,24 +504,24 @@ $.BootstrapTable = class extends $.BootstrapTable {
       throw new Error('Could not parse the json of the sortPriority cookie!', sortPriorityCookie)
     }
 
+    // sortOrder
+    this.options.sortOrder = undefined
+    // sortName
+    this.options.sortName = undefined
+
     if (!sortPriorityCookie) {
       // sortOrder
       this.options.sortOrder = sortOrderCookie ? sortOrderCookie : this.options.sortOrder
       // sortName
       this.options.sortName = sortOrderNameCookie ? sortOrderNameCookie : this.options.sortName
-    } else {
-      // sortOrder
-      this.options.sortOrder = undefined
-      // sortName
-      this.options.sortName = undefined
     }
+
+    // sortPriority
+    this.options.sortPriority = sortPriorityCookie ? sortPriorityCookie : this.options.sortPriority
 
     if (this.options.sortOrder || this.options.sortName) {
       // sortPriority
       this.options.sortPriority = null
-    } else {
-      // sortPriority
-      this.options.sortPriority = sortPriorityCookie ? sortPriorityCookie : this.options.sortPriority
     }
 
     // pageNumber

--- a/src/extensions/cookie/bootstrap-table-cookie.js
+++ b/src/extensions/cookie/bootstrap-table-cookie.js
@@ -405,11 +405,7 @@ $.BootstrapTable = class extends $.BootstrapTable {
 
     let priority = this.options.sortPriority
 
-    if (typeof priority !== "string") {
-      priority = JSON.stringify(priority)
-    }
-
-    UtilsCookie.setCookie(this, UtilsCookie.cookieIds.sortPriority, priority)
+    UtilsCookie.setCookie(this, UtilsCookie.cookieIds.sortPriority, JSON.stringify(this.options.sortPriority))
   }
 
   onPageNumber (...args) {
@@ -487,7 +483,7 @@ $.BootstrapTable = class extends $.BootstrapTable {
 
     const sortOrderCookie = UtilsCookie.getCookie(this, this.options.cookieIdTable, UtilsCookie.cookieIds.sortOrder)
     const sortOrderNameCookie = UtilsCookie.getCookie(this, this.options.cookieIdTable, UtilsCookie.cookieIds.sortName)
-    const sortPriorityCookie = UtilsCookie.getCookie(this, this.options.cookieIdTable, UtilsCookie.cookieIds.sortPriority)
+    let   sortPriorityCookie = UtilsCookie.getCookie(this, this.options.cookieIdTable, UtilsCookie.cookieIds.sortPriority)
     const pageNumberCookie = UtilsCookie.getCookie(this, this.options.cookieIdTable, UtilsCookie.cookieIds.pageNumber)
     const pageListCookie = UtilsCookie.getCookie(this, this.options.cookieIdTable, UtilsCookie.cookieIds.pageList)
     const searchTextCookie = UtilsCookie.getCookie(this, this.options.cookieIdTable, UtilsCookie.cookieIds.searchText)
@@ -504,6 +500,12 @@ $.BootstrapTable = class extends $.BootstrapTable {
       columnsCookie = JSON.parse(columnsCookieValue)
     } catch (e) {
       throw new Error('Could not parse the json of the columns cookie!', columnsCookieValue)
+    }
+
+    try {
+      sortPriorityCookie = JSON.parse(sortPriorityCookie)
+    } catch (e) {
+      throw new Error('Could not parse the json of the sortPriority cookie!', sortPriorityCookie)
     }
 
     // sortOrder

--- a/src/extensions/cookie/bootstrap-table-cookie.js
+++ b/src/extensions/cookie/bootstrap-table-cookie.js
@@ -399,8 +399,8 @@ $.BootstrapTable = class extends $.BootstrapTable {
       this.options.sortOrder = undefined
       UtilsCookie.deleteCookie(this, this.options.cookieIdTable, UtilsCookie.cookieIds.sortName)
       UtilsCookie.deleteCookie(this, this.options.cookieIdTable, UtilsCookie.cookieIds.sortOrder)
-	  
-	  UtilsCookie.setCookie(this, UtilsCookie.cookieIds.sortPriority, JSON.stringify(this.options.sortPriority))
+      
+      UtilsCookie.setCookie(this, UtilsCookie.cookieIds.sortPriority, JSON.stringify(this.options.sortPriority))
     }
   }
 
@@ -504,9 +504,9 @@ $.BootstrapTable = class extends $.BootstrapTable {
       throw new Error('Could not parse the json of the sortPriority cookie!', sortPriorityCookie)
     }
 
-    if (!sortPriorityCookie){
+    if (!sortPriorityCookie) {
       // sortOrder
-      this.options.sortOrder = sortOrderCookie  ? sortOrderCookie : this.options.sortOrder
+      this.options.sortOrder = sortOrderCookie ? sortOrderCookie : this.options.sortOrder
       // sortName
       this.options.sortName = sortOrderNameCookie ? sortOrderNameCookie : this.options.sortName
     } else {
@@ -516,7 +516,7 @@ $.BootstrapTable = class extends $.BootstrapTable {
       this.options.sortName = undefined
     }
 
-    if (this.options.sortOrder || this.options.sortName){
+    if (this.options.sortOrder || this.options.sortName) {
       // sortPriority
       this.options.sortPriority = null
     } else {

--- a/src/extensions/cookie/bootstrap-table-cookie.js
+++ b/src/extensions/cookie/bootstrap-table-cookie.js
@@ -381,6 +381,9 @@ $.BootstrapTable = class extends $.BootstrapTable {
       UtilsCookie.deleteCookie(this, this.options.cookieIdTable, UtilsCookie.cookieIds.sortName)
       UtilsCookie.deleteCookie(this, this.options.cookieIdTable, UtilsCookie.cookieIds.sortOrder)
       return
+    } else {
+      this.options.sortPriority = undefined
+      UtilsCookie.deleteCookie(this, this.options.cookieIdTable, UtilsCookie.cookieIds.sortPriority)
     }
 
     UtilsCookie.setCookie(this, UtilsCookie.cookieIds.sortOrder, this.options.sortOrder)
@@ -393,6 +396,11 @@ $.BootstrapTable = class extends $.BootstrapTable {
     if (this.options.sortPriority === undefined) {
       UtilsCookie.deleteCookie(this, this.options.cookieIdTable, UtilsCookie.cookieIds.sortPriority)
       return
+    } else {
+      this.options.sortName = undefined
+      this.options.sortOrder = undefined
+      UtilsCookie.deleteCookie(this, this.options.cookieIdTable, UtilsCookie.cookieIds.sortName)
+      UtilsCookie.deleteCookie(this, this.options.cookieIdTable, UtilsCookie.cookieIds.sortOrder)
     }
 
     UtilsCookie.setCookie(this, UtilsCookie.cookieIds.sortPriority, JSON.stringify(this.options.sortPriority))

--- a/src/extensions/cookie/bootstrap-table-cookie.js
+++ b/src/extensions/cookie/bootstrap-table-cookie.js
@@ -8,6 +8,7 @@ const UtilsCookie = {
   cookieIds: {
     sortOrder: 'bs.table.sortOrder',
     sortName: 'bs.table.sortName',
+    sortPriority: 'bs.table.sortPriority',
     pageNumber: 'bs.table.pageNumber',
     pageList: 'bs.table.pageList',
     columns: 'bs.table.columns',
@@ -275,7 +276,7 @@ $.extend($.fn.bootstrapTable.defaults, {
   cookieSameSite: 'Lax',
   cookieIdTable: '',
   cookiesEnabled: [
-    'bs.table.sortOrder', 'bs.table.sortName',
+    'bs.table.sortOrder', 'bs.table.sortName', 'bs.table.sortPriority',
     'bs.table.pageNumber', 'bs.table.pageList',
     'bs.table.columns', 'bs.table.searchText',
     'bs.table.filterControl', 'bs.table.filterBy',
@@ -386,6 +387,17 @@ $.BootstrapTable = class extends $.BootstrapTable {
     UtilsCookie.setCookie(this, UtilsCookie.cookieIds.sortName, this.options.sortName)
   }
 
+  onMultipleSort (...args) {
+    super.onMultipleSort(...args)
+
+    if (this.options.sortPriority === undefined) {
+      UtilsCookie.deleteCookie(this, this.options.cookieIdTable, UtilsCookie.cookieIds.sortPriority)
+      return
+    }
+
+    UtilsCookie.setCookie(this, UtilsCookie.cookieIds.sortPriority, this.options.sortPriority)
+  }
+
   onPageNumber (...args) {
     super.onPageNumber(...args)
     UtilsCookie.setCookie(this, UtilsCookie.cookieIds.pageNumber, this.options.pageNumber)
@@ -461,6 +473,7 @@ $.BootstrapTable = class extends $.BootstrapTable {
 
     const sortOrderCookie = UtilsCookie.getCookie(this, this.options.cookieIdTable, UtilsCookie.cookieIds.sortOrder)
     const sortOrderNameCookie = UtilsCookie.getCookie(this, this.options.cookieIdTable, UtilsCookie.cookieIds.sortName)
+    const sortPriorityCookie = UtilsCookie.getCookie(this, this.options.cookieIdTable, UtilsCookie.cookieIds.sortPriority)
     const pageNumberCookie = UtilsCookie.getCookie(this, this.options.cookieIdTable, UtilsCookie.cookieIds.pageNumber)
     const pageListCookie = UtilsCookie.getCookie(this, this.options.cookieIdTable, UtilsCookie.cookieIds.pageList)
     const searchTextCookie = UtilsCookie.getCookie(this, this.options.cookieIdTable, UtilsCookie.cookieIds.searchText)
@@ -483,6 +496,8 @@ $.BootstrapTable = class extends $.BootstrapTable {
     this.options.sortOrder = sortOrderCookie ? sortOrderCookie : this.options.sortOrder
     // sortName
     this.options.sortName = sortOrderNameCookie ? sortOrderNameCookie : this.options.sortName
+    // sortPriority
+    this.options.sortPriority = sortPriorityCookie ? sortPriorityCookie : this.options.sortPriority
     // pageNumber
     this.options.pageNumber = pageNumberCookie ? +pageNumberCookie : this.options.pageNumber
     // pageSize

--- a/src/extensions/cookie/bootstrap-table-cookie.js
+++ b/src/extensions/cookie/bootstrap-table-cookie.js
@@ -508,12 +508,26 @@ $.BootstrapTable = class extends $.BootstrapTable {
       throw new Error('Could not parse the json of the sortPriority cookie!', sortPriorityCookie)
     }
 
-    // sortOrder
-    this.options.sortOrder = sortOrderCookie && !this.options.sortPriority ? sortOrderCookie : this.options.sortOrder
-    // sortName
-    this.options.sortName = sortOrderNameCookie && !this.options.sortPriority ? sortOrderNameCookie : this.options.sortName
-    // sortPriority
-    this.options.sortPriority = sortPriorityCookie && (!this.options.sortOrder || this.options.sortName) ? sortPriorityCookie : this.options.sortPriority
+    if(!sortPriorityCookie){
+      // sortOrder
+      this.options.sortOrder = sortOrderCookie  ? sortOrderCookie : this.options.sortOrder
+      // sortName
+      this.options.sortName = sortOrderNameCookie ? sortOrderNameCookie : this.options.sortName
+    } else {
+       // sortOrder
+       this.options.sortOrder = undefined
+       // sortName
+       this.options.sortName = undefined
+    }
+
+    if(this.options.sortOrder || this.options.sortName){
+      // sortPriority
+      this.options.sortPriority = undefined
+    } else {
+      // sortPriority
+      this.options.sortPriority = sortPriorityCookie  ? sortPriorityCookie : this.options.sortPriority
+    }
+    
     // pageNumber
     this.options.pageNumber = pageNumberCookie ? +pageNumberCookie : this.options.pageNumber
     // pageSize

--- a/src/extensions/cookie/bootstrap-table-cookie.js
+++ b/src/extensions/cookie/bootstrap-table-cookie.js
@@ -382,7 +382,7 @@ $.BootstrapTable = class extends $.BootstrapTable {
       UtilsCookie.deleteCookie(this, this.options.cookieIdTable, UtilsCookie.cookieIds.sortOrder)
       return
     } else {
-      this.options.sortPriority = undefined
+      this.options.sortPriority = null
       UtilsCookie.deleteCookie(this, this.options.cookieIdTable, UtilsCookie.cookieIds.sortPriority)
     }
 


### PR DESCRIPTION
**Bug fix?**
no

**New Feature?**
yes

**Resolve an issue?**
No

**Example(s)?**
Before: https://live.bootstrap-table.com/code/Naruto-kyun/7597
After: https://live.bootstrap-table.com/code/Naruto-kyun/7598

Current cookie extension dont remembre user ordering when multiple sort is enabled