### PR TITLE
use the bootstrap icons

### DIFF
--- a/dist/bootstrap-table.js
+++ b/dist/bootstrap-table.js
@@ -2813,7 +2813,7 @@
       }
     },
     5: {
-      iconsPrefix: 'fa',
+      iconsPrefix: 'bi',
       icons: {
         paginationSwitchDown: 'fa-caret-square-down',
         paginationSwitchUp: 'fa-caret-square-up',

--- a/dist/bootstrap-table.js
+++ b/dist/bootstrap-table.js
@@ -2813,7 +2813,7 @@
       }
     },
     5: {
-      iconsPrefix: 'bi',
+      iconsPrefix: 'fa',
       icons: {
         paginationSwitchDown: 'fa-caret-square-down',
         paginationSwitchUp: 'fa-caret-square-up',

--- a/site/themes/bootstrap5.md
+++ b/site/themes/bootstrap5.md
@@ -40,7 +40,8 @@ Put it all together and your pages should look like this:
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-giJF6kkoqNQ00vy+HMDP7azOuL0xtbfIcaT9wjKHr8RbDVddVHyTfAAsrekwKmP1" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.4.1/font/bootstrap-icons.css">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-wEmeIV1mKuiNpC+IOBjI7aAzPcEZeedi5yW5f2yOq55WWLwNGmvvx4Um1vskeMj0" crossorigin="anonymous">
     <link rel="stylesheet" href="https://unpkg.com/bootstrap-table@{{ site.current_version }}/dist/bootstrap-table.min.css">
 
     <title>Hello, Bootstrap Table!</title>
@@ -69,7 +70,7 @@ Put it all together and your pages should look like this:
     </table>
 
     <script src="https://cdn.jsdelivr.net/npm/jquery/dist/jquery.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta1/dist/js/bootstrap.bundle.min.js" integrity="sha384-ygbV9kiqUc6oa4msXn9868pTtWMgiQaeYH7/t7LECLbyPA2x65Kgf80OJFdroafW" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-p34f1UUtsS3wqzfto5wAAmdvj+osOnFyQFpp4Ua3gs/ZVWx6oOypYoCJhGGScy+8" crossorigin="anonymous"></script>
     <script src="https://unpkg.com/bootstrap-table@{{ site.current_version }}/dist/bootstrap-table.min.js"></script>
   </body>
 </html>

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -120,19 +120,19 @@ const CONSTANTS = {
     }
   },
   5: {
-    iconsPrefix: 'fa',
+    iconsPrefix: 'bi',
     icons: {
-      paginationSwitchDown: 'fa-caret-square-down',
-      paginationSwitchUp: 'fa-caret-square-up',
-      refresh: 'fa-sync',
-      toggleOff: 'fa-toggle-off',
-      toggleOn: 'fa-toggle-on',
-      columns: 'fa-th-list',
-      detailOpen: 'fa-plus',
-      detailClose: 'fa-minus',
-      fullscreen: 'fa-arrows-alt',
-      search: 'fa-search',
-      clearSearch: 'fa-trash'
+      paginationSwitchDown: 'bi-caret-down-square',
+      paginationSwitchUp: 'bi-caret-up-square',
+      refresh: 'bi-arrow-clockwise',
+      toggleOff: 'bi-toggle-off',
+      toggleOn: 'bi-toggle-on',
+      columns: 'bi-list-ul',
+      detailOpen: 'bi-plus',
+      detailClose: 'bi-dash',
+      fullscreen: 'bi-arrows-move',
+      search: 'bi-search',
+      clearSearch: 'bi-trash'
     },
     classes: {
       buttonsPrefix: 'btn',

--- a/src/extensions/auto-refresh/bootstrap-table-auto-refresh.js
+++ b/src/extensions/auto-refresh/bootstrap-table-auto-refresh.js
@@ -17,6 +17,7 @@ $.extend($.fn.bootstrapTable.defaults, {
 $.extend($.fn.bootstrapTable.defaults.icons, {
   autoRefresh: {
     bootstrap3: 'glyphicon-time icon-time',
+    bootstrap5: 'bi-clock',
     materialize: 'access_time',
     'bootstrap-table': 'icon-clock'
   }[$.fn.bootstrapTable.theme] || 'fa-clock'

--- a/src/extensions/copy-rows/bootstrap-table-copy-rows.js
+++ b/src/extensions/copy-rows/bootstrap-table-copy-rows.js
@@ -15,6 +15,7 @@ $.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales)
 $.extend($.fn.bootstrapTable.defaults.icons, {
   copy: {
     bootstrap3: 'glyphicon-copy icon-pencil',
+    bootstrap5: 'bi-clipboard',
     materialize: 'content_copy',
     'bootstrap-table': 'icon-copy'
   }[$.fn.bootstrapTable.theme] || 'fa-copy'

--- a/src/extensions/custom-view/bootstrap-table-custom-view.js
+++ b/src/extensions/custom-view/bootstrap-table-custom-view.js
@@ -14,6 +14,7 @@ $.extend($.fn.bootstrapTable.defaults, {
 $.extend($.fn.bootstrapTable.defaults.icons, {
   customView: {
     bootstrap3: 'glyphicon glyphicon-eye-open',
+    bootstrap5: 'bi-eye',
     bootstrap4: 'fa fa-eye',
     semantic: 'fa fa-eye',
     foundation: 'fa fa-eye',

--- a/src/extensions/export/bootstrap-table-export.js
+++ b/src/extensions/export/bootstrap-table-export.js
@@ -43,6 +43,7 @@ $.extend($.fn.bootstrapTable.columnDefaults, {
 $.extend($.fn.bootstrapTable.defaults.icons, {
   export: {
     bootstrap3: 'glyphicon-export icon-share',
+    bootstrap5: 'bi-download',
     materialize: 'file_download',
     'bootstrap-table': 'icon-download'
   }[$.fn.bootstrapTable.theme] || 'fa-download'

--- a/src/extensions/filter-control/bootstrap-table-filter-control.js
+++ b/src/extensions/filter-control/bootstrap-table-filter-control.js
@@ -70,15 +70,14 @@ $.extend($.fn.bootstrapTable.Constructor.EVENTS, {
 })
 
 $.extend($.fn.bootstrapTable.defaults.icons, {
-  clear: {
-    bootstrap3: 'glyphicon-trash icon-clear'
-  }[$.fn.bootstrapTable.theme] || 'fa-trash',
   filterControlSwitchHide: {
     bootstrap3: 'glyphicon-zoom-out icon-zoom-out',
+    bootstrap5: 'bi-zoom-out',
     materialize: 'zoom_out'
   }[$.fn.bootstrapTable.theme] || 'fa-search-minus',
   filterControlSwitchShow: {
     bootstrap3: 'glyphicon-zoom-in icon-zoom-in',
+    bootstrap5: 'bi-zoom-in',
     materialize: 'zoom_in'
   }[$.fn.bootstrapTable.theme] || 'fa-search-plus'
 })

--- a/src/extensions/group-by-v2/bootstrap-table-group-by.js
+++ b/src/extensions/group-by-v2/bootstrap-table-group-by.js
@@ -21,10 +21,12 @@ const groupBy = (array, f) => {
 $.extend($.fn.bootstrapTable.defaults.icons, {
   collapseGroup: {
     bootstrap3: 'glyphicon-chevron-up',
+    bootstrap5: 'bi-chevron-up',
     materialize: 'arrow_drop_down'
   }[$.fn.bootstrapTable.theme] || 'fa-angle-up',
   expandGroup: {
     bootstrap3: 'glyphicon-chevron-down',
+    bootstrap5: 'bi-chevron-down',
     materialize: 'arrow_drop_up'
   }[$.fn.bootstrapTable.theme] || 'fa-angle-down'
 })

--- a/src/extensions/multiple-sort/bootstrap-table-multiple-sort.js
+++ b/src/extensions/multiple-sort/bootstrap-table-multiple-sort.js
@@ -12,7 +12,7 @@ $.extend($.fn.bootstrapTable.defaults.icons, {
   plus: {
     bootstrap3: 'glyphicon-plus',
     bootstrap4: 'fa-plus',
-    bootstrap5: 'fa-plus',
+    bootstrap5: 'bi-plus',
     semantic: 'fa-plus',
     materialize: 'plus',
     foundation: 'fa-plus',
@@ -22,7 +22,7 @@ $.extend($.fn.bootstrapTable.defaults.icons, {
   minus: {
     bootstrap3: 'glyphicon-minus',
     bootstrap4: 'fa-minus',
-    bootstrap5: 'fa-minus',
+    bootstrap5: 'bi-dash',
     semantic: 'fa-minus',
     materialize: 'minus',
     foundation: 'fa-minus',
@@ -32,7 +32,7 @@ $.extend($.fn.bootstrapTable.defaults.icons, {
   sort: {
     bootstrap3: 'glyphicon-sort',
     bootstrap4: 'fa-sort',
-    bootstrap5: 'fa-sort',
+    bootstrap5: 'bi-arrow-down-up',
     semantic: 'fa-sort',
     materialize: 'sort',
     foundation: 'fa-sort',

--- a/src/extensions/toolbar/bootstrap-table-toolbar.js
+++ b/src/extensions/toolbar/bootstrap-table-toolbar.js
@@ -69,7 +69,7 @@ const theme = {
   },
   bootstrap5: {
     icons: {
-      advancedSearchIcon: 'fa-chevron-down'
+      advancedSearchIcon: 'bi-chevron-down'
     },
     html: {
       modal: `


### PR DESCRIPTION
**Bug fix?**
no

**New Feature?**
no

**Resolve an issue?**
fix #5718

**Example(s)?**
Not possible @wenzhixin we need the newest bootstrap 5 version and the bootstrap icons for the editor.
Also we should now set bootstrap 5 as default on our examples  (https://examples.bootstrap-table.com/).
     
<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->