### PR TITLE
Fix for #5803 (multiple-sort and hide-show column interaction with no default sortPriority bug)

### DIFF
--- a/src/extensions/multiple-sort/bootstrap-table-multiple-sort.js
+++ b/src/extensions/multiple-sort/bootstrap-table-multiple-sort.js
@@ -656,13 +656,16 @@ BootstrapTable.prototype.initToolbar = function (...args) {
     })
 
     this.$el.on('column-switch.bs.table', (field, checked) => {
-      for (let i = 0; i < that.options.sortPriority.length; i++) {
-        if (that.options.sortPriority[i].sortName === checked) {
-          that.options.sortPriority.splice(i, 1)
+      if (that.options.sortPriority !== null && that.options.sortPriority.length > 0) {
+        for (let i = 0; i < that.options.sortPriority.length; i++) {
+          if (that.options.sortPriority[i].sortName === checked) {
+            that.options.sortPriority.splice(i, 1)
+          }
         }
-      }
 
-      that.assignSortableArrows()
+        that.assignSortableArrows()
+      }
+      
       that.$sortModal.remove()
       showSortModal(that)
     })


### PR DESCRIPTION
Fix exception interaction with hide/show columns prior to multisort if no sortPriority exists

**🤔Type of Request**
- [X] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
<!-- Please prefix each issue number with  "Fix #"  (e.g. Fix #200)  -->

Could not find existing issue for this, apologies if I missed one. Created #5803 for it. 

**📝Changelog**

<!-- The type of the change. --->
- [ ] **Core**
- [X] **Extensions**

Fix for multiple sort and hide/show column interaction with no sortPriority defined.

<!-- Describe changes from the user side. -->

Change should not be user visible.

**💡Example(s)?**
<!-- Please use our online Editor (https://live.bootstrap-table.com/) to create example(s) (Before and after your changes).
     On our Wiki (https://github.com/wenzhixin/bootstrap-table/wiki/Online-Editor-Explanation) you can read how to use the editor.-->

**☑️Self Check before Merge**

⚠️ Please check all items below before review. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
