### PR TITLE
Removed the div with class input-group-append.

### DIFF
--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -160,7 +160,7 @@ const CONSTANTS = {
       pagination: ['<ul class="pagination%s">', '</ul>'],
       paginationItem: '<li class="page-item%s"><a class="page-link" aria-label="%s" href="javascript:void(0)">%s</a></li>',
       icon: '<i class="%s %s"></i>',
-      inputGroup: '<div class="input-group">%s<div class="input-group-append">%s</div></div>',
+      inputGroup: '<div class="input-group">%s%s</div>',
       searchInput: '<input class="%s%s" type="text" placeholder="%s">',
       searchButton: '<button class="%s" type="button" name="search" title="%s">%s %s</button>',
       searchClearButton: '<button class="%s" type="button" name="clearSearch" title="%s">%s %s</button>'


### PR DESCRIPTION
**🤔Type of Request**
- [ ] **Bug fix**
- [ ] **New feature**
- [x] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
<!-- Please prefix each issue number with  "Fix #"  (e.g. Fix #200)  -->
Fix #5767 

**📝Changelog**

Dropped the wrapper div with the `input-group-append` class, this class was dropped in BS5.

<!-- The type of the change. --->
- [ ] **Core**
- [x] **Extensions**

<!-- Describe changes from the user side. -->

**💡Example(s)?**
<!-- Please use our online Editor (https://live.bootstrap-table.com/) to create example(s) (Before and after your changes).
     On our Wiki (https://github.com/wenzhixin/bootstrap-table/wiki/Online-Editor-Explanation) you can read how to use the editor.-->

Before: https://live.bootstrap-table.com/code/UtechtDustin/8408
After: https://live.bootstrap-table.com/code/UtechtDustin/8409

**☑️Self Check before Merge**

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
