### PR TITLE
Added regex search

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -7,7 +7,6 @@
     "no-descending-specificity": null,
     "declaration-bang-space-before": null,
     "number-leading-zero": null,
-    "rule-empty-line-before": null,
-    "no-irregular-whitespace": true
+    "rule-empty-line-before": null
   }
 }

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,12 +1,13 @@
 {
-  'extends': 'stylelint-config-standard',
-  'rules': {
-    'indentation': null,
-    'selector-pseudo-element-colon-notation': null,
-    'function-comma-space-after': null,
-    'no-descending-specificity': null,
-    'declaration-bang-space-before': null,
-    'number-leading-zero': null,
-    'rule-empty-line-before': null
+  "extends": "stylelint-config-standard",
+  "rules": {
+    "indentation": null,
+    "selector-pseudo-element-colon-notation": null,
+    "function-comma-space-after": null,
+    "no-descending-specificity": null,
+    "declaration-bang-space-before": null,
+    "number-leading-zero": null,
+    "rule-empty-line-before": null,
+    "no-irregular-whitespace": true
   }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -202,6 +202,7 @@ interface BootstrapTableOptions{
     onColumnSwitch?: (field, checked) => boolean;
     searchSelector?: boolean;
     strictSearch?: boolean;
+    regexSearch?: boolean;
     multipleSelectRow?: boolean;
     onLoadError?: (status) => boolean;
     buttonsToolbar?: any;

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "rollup-plugin-node-resolve": "^5.0.4",
     "rollup-plugin-terser": "^7.0.0",
     "rollup-plugin-vue": "5.1.9",
-    "stylelint": "^13.3.3",
+    "stylelint": "^13.13.1",
     "stylelint-config-standard": "^22.0.0",
     "vue-template-compiler": "^2.6.10"
   },

--- a/site/docs/api/table-options.md
+++ b/site/docs/api/table-options.md
@@ -1089,7 +1089,7 @@ The table options are defined in `jQuery.fn.bootstrapTable.defaults`.
 
 - **Default:** `false`
 
-- **Example:** [Remember Order](https://examples.bootstrap-table.com/#options/regex-search.html)
+- **Example:** [Regex Search](https://examples.bootstrap-table.com/#options/regex-search.html)
 
 ## rememberOrder
 

--- a/site/docs/api/table-options.md
+++ b/site/docs/api/table-options.md
@@ -1074,6 +1074,23 @@ The table options are defined in `jQuery.fn.bootstrapTable.defaults`.
 
 - **Example:** [Query Params Type](https://examples.bootstrap-table.com/#options/query-params-type.html)
 
+## regexSearch
+
+- **Attribute:** `data-regex-search`
+
+- **Type:** `Boolean`
+
+- **Detail:**
+
+  Set `true` to enable the regex search.
+  Is this option enabled, you can search with regex e.g. `[47a]$` for all items which ends with a `4`, `7` or `a`.     
+  The regex can be entered with `/[47a]$/gim` or without `[47a]$` flags, the default flags are `gim`.
+
+
+- **Default:** `false`
+
+- **Example:** [Remember Order](https://examples.bootstrap-table.com/#options/regex-search.html)
+
 ## rememberOrder
 
 - **Attribute:** `data-remember-order`
@@ -1161,7 +1178,9 @@ The table options are defined in `jQuery.fn.bootstrapTable.defaults`.
   - Comparisons (<, >, <=, =<, >=, =>).
     Example: 4 is larger than 3.
 
-  Note: If you want to use a custom search input use the [searchSelector](https://bootstrap-table.com/docs/api/table-options/#searchSelector).
+  Notes:
+  - If you want to use a custom search input use the [searchSelector](https://bootstrap-table.com/docs/api/table-options/#searchSelector).
+  - You can also search via regex using the [regexSearch](https://bootstrap-table.com/docs/api/table-options/#regexSearch) option.
 
 - **Default:** `false`
 

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -240,6 +240,7 @@ const DEFAULTS = {
   searchHighlight: false,
   searchOnEnterKey: false,
   strictSearch: false,
+  regexSearch: false,
   searchSelector: false,
   visibleSearch: false,
   showButtonIcons: true,

--- a/src/extensions/filter-control/bootstrap-table-filter-control.js
+++ b/src/extensions/filter-control/bootstrap-table-filter-control.js
@@ -172,29 +172,29 @@ $.BootstrapTable = class extends $.BootstrapTable {
 
   initSearch () {
     const that = this
-    const fp = $.isEmptyObject(that.filterColumnsPartial) ? null : that.filterColumnsPartial
+    const filterPartial = $.isEmptyObject(that.filterColumnsPartial) ? null : that.filterColumnsPartial
 
     super.initSearch()
 
-    if (this.options.sidePagination === 'server' || fp === null) {
+    if (this.options.sidePagination === 'server' || filterPartial === null) {
       return
     }
 
     // Check partial column filter
-    that.data = fp ?
+    that.data = filterPartial ?
       that.data.filter((item, i) => {
         const itemIsExpected = []
         const keys1 = Object.keys(item)
-        const keys2 = Object.keys(fp)
+        const keys2 = Object.keys(filterPartial)
         const keys = keys1.concat(keys2.filter(item => !keys1.includes(item)))
 
         keys.forEach(key => {
           const thisColumn = that.columns[that.fieldsColumnsIndex[key]]
-          const fval = (fp[key] || '').toLowerCase()
+          const filterValue = (filterPartial[key] || '').toLowerCase()
           let value = Utils.unescapeHTML(Utils.getItemField(item, key, false))
           let tmpItemIsExpected
 
-          if (fval === '') {
+          if (filterValue === '') {
             tmpItemIsExpected = true
           } else {
             // Fix #142: search use formatted data
@@ -219,14 +219,13 @@ $.BootstrapTable = class extends $.BootstrapTable {
                   if (this.options.searchAccentNeutralise) {
                     objectValue = Utils.normalizeAccent(objectValue)
                   }
-
-                  tmpItemIsExpected = that.isValueExpected(fval, objectValue, thisColumn, key)
+                  tmpItemIsExpected = that.isValueExpected(filterValue, objectValue, thisColumn, key)
                 })
               } else if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
                 if (this.options.searchAccentNeutralise) {
                   value = Utils.normalizeAccent(value)
                 }
-                tmpItemIsExpected = that.isValueExpected(fval, value, thisColumn, key)
+                tmpItemIsExpected = that.isValueExpected(filterValue, value, thisColumn, key)
               }
             }
           }
@@ -248,6 +247,8 @@ $.BootstrapTable = class extends $.BootstrapTable {
       tmpItemIsExpected = value.toString().toLowerCase() === searchValue.toString().toLowerCase()
     } else if (column.filterStartsWithSearch) {
       tmpItemIsExpected = (`${value}`).toLowerCase().indexOf(searchValue) === 0
+    } else if (this.options.regexSearch) {
+      tmpItemIsExpected = Utils.regexCompare(value, searchValue)
     } else {
       tmpItemIsExpected = (`${value}`).toLowerCase().includes(searchValue)
     }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -201,7 +201,7 @@ export default {
       if (regexpParts) {
         regex = new RegExp(regexpParts[1], regexpParts[2])
       } else {
-        regex = new RegExp(search)
+        regex = new RegExp(search, 'gim')
       }
 
       if (value.toString().search(regex) !== -1) {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -196,6 +196,7 @@ export default {
   regexCompare (value, search) {
     try {
       const regexpParts = search.match(/^\/(.*?)\/([gim]*)$/)
+
       if (value.toString().search(regexpParts ? new RegExp(regexpParts[1], regexpParts[2]) : new RegExp(search, 'gim')) !== -1) {
         return true
       }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -193,6 +193,25 @@ export default {
     return true
   },
 
+  regexCompare (value, search) {
+    try {
+      const regexpParts = search.match(/^\/(.*?)\/([gim]*)$/)
+      let regex
+
+      if (regexpParts) {
+        regex = new RegExp(regexpParts[1], regexpParts[2])
+      } else {
+        regex = new RegExp(search)
+      }
+
+      if (value.toString().search(regex) !== -1) {
+        return true
+      }
+    } catch (e) {
+      return false
+    }
+  },
+
   escapeHTML (text) {
     if (typeof text === 'string') {
       return text

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -196,15 +196,7 @@ export default {
   regexCompare (value, search) {
     try {
       const regexpParts = search.match(/^\/(.*?)\/([gim]*)$/)
-      let regex
-
-      if (regexpParts) {
-        regex = new RegExp(regexpParts[1], regexpParts[2])
-      } else {
-        regex = new RegExp(search, 'gim')
-      }
-
-      if (value.toString().search(regex) !== -1) {
+      if (value.toString().search(regexpParts ? new RegExp(regexpParts[1], regexpParts[2]) : new RegExp(search, 'gim')) !== -1) {
         return true
       }
     } catch (e) {


### PR DESCRIPTION
**🤔Type of Request**
- [ ] **Bug fix**
- [x] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
<!-- Please prefix each issue number with  "Fix #"  (e.g. Fix #200)  -->
Fix #5786 

**📝Changelog**

<!-- The type of the change. --->
- [x] **Core**
- [x] **Extensions**

Added a new search option which allows to filter the table using regex.

**💡Example(s)?**
<!-- Please use our online Editor (https://live.bootstrap-table.com/) to create example(s) (Before and after your changes).
     On our Wiki (https://github.com/wenzhixin/bootstrap-table/wiki/Online-Editor-Explanation) you can read how to use the editor.-->
Example: https://live.bootstrap-table.com/code/UtechtDustin/8414
e.g. search for `[57]$` to get the rows which data ends with `5`  or `7`.


**☑️Self Check before Merge**

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed (https://github.com/wenzhixin/bootstrap-table-examples/pull/439)
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
