### PR TITLE
Fixed broken page-list selector

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1317,7 +1317,7 @@ class BootstrapTable {
 
       if (opts.smartDisplay) {
         if (pageList.length < 2 || opts.totalRows <= pageList[0]) {
-          this.$pagination.find('span.page-list').hide()
+          this.$pagination.find('div.page-list').hide()
         }
       }
 


### PR DESCRIPTION
**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
Fix #5795

**📝Changelog**

<!-- The type of the change. --->
- [x] **Core**
- [ ] **Extensions**

<!-- Describe changes from the user side. -->

**💡Example(s)?**

SmartDisplay is activated, but the dropdown is not hidden (caused by a wrong selector). Caused in Commit: https://github.com/wenzhixin/bootstrap-table/pull/5601/files#diff-4399f869098600cd4a36500ebc475e2ca83b2ef55b121d6a70cf5cd859689dd9L1183

Before: https://live.bootstrap-table.com/code/UtechtDustin/9210
After: https://live.bootstrap-table.com/code/UtechtDustin/9211

**☑️Self Check before Merge**

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
