### PR TITLE
Fixed JQueryXHR reference in typescript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,5 @@
+/// <reference types="jquery" />
+
 interface BootstrapTableClasses{
     buttons: string;
     buttonsGroup: string;
@@ -167,8 +169,8 @@ interface BootstrapAjaxParams{
     dataType: string;
     type: string;
     contentType: string;
-    error: (jqXHR: JQuery.jqXHR) => any;
-    success: (results: any, textStatus?: string, jqXHR?: JQuery.jqXHR) => any;
+    error: (jqXHR: JQueryXHR) => any;
+    success: (results: any, textStatus?: string, jqXHR?: JQueryXHR) => any;
 }
 
 interface BootstrapTableOptions{


### PR DESCRIPTION
**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**

Fixes: #5907

**📝Changelog**

Added correct JQueryXHR reference for typescript definitions

Typescript imports will work again without warnings
