### PR TITLE
Fixed all checkbox not auto check after pagination changed

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1761,9 +1761,9 @@ class BootstrapTable {
     }
 
     this.initBodyEvent()
-    this.updateSelected()
     this.initFooter()
     this.resetView()
+    this.updateSelected()
 
     if (this.options.sidePagination !== 'server') {
       this.options.totalRows = data.length
@@ -2997,9 +2997,6 @@ class BootstrapTable {
     if (params && params.height) {
       this.options.height = params.height
     }
-
-    this.$selectAll.prop('checked', this.$selectItem.length > 0 &&
-      this.$selectItem.length === this.$selectItem.filter(':checked').length)
 
     this.$tableContainer.toggleClass('has-card-view', this.options.cardView)
 


### PR DESCRIPTION
**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
no

**📝Changelog**
Fixed all checkboxes not auto check after pagination changed.

<!-- The type of the change. --->
- [x] **Core**
- [ ] **Extensions**

<!-- Describe changes from the user side. -->

**💡Example(s)?**
Before: https://live.bootstrap-table.com/code/wenzhixin/9444
After: https://live.bootstrap-table.com/code/wenzhixin/9456

Click the check-all and jump to page 2, and then jump back to page 1 to reproduce the problem.

**☑️Self Check before Merge**

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
