### PR TITLE
fix for virtual-scroll undefined default method call

### DIFF
--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -337,6 +337,9 @@ const DEFAULTS = {
   },
   onTogglePagination (newState) {
     return false
+  },
+  onVirtualScroll (newState) {
+    return false
   }
 }
 

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -338,7 +338,7 @@ const DEFAULTS = {
   onTogglePagination (newState) {
     return false
   },
-  onVirtualScroll (newState) {
+  onVirtualScroll (startIndex, endIndex) {
     return false
   }
 }


### PR DESCRIPTION
fixes https://github.com/wenzhixin/bootstrap-table/issues/5997

**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
<!-- Please prefix each issue number with  "Fix #"  (e.g. Fix #200)  -->
Fix https://github.com/wenzhixin/bootstrap-table/issues/5997

**📝Changelog**

<!-- The type of the change. --->
- [x] **Core**
- [ ] **Extensions**

Adding default `onVirtualScroll` implementation

<!-- Describe changes from the user side. -->
when virtual-scroll is triggered there is no default empty implementation which could throw

**💡Example(s)?**
<!-- Please use our online Editor (https://live.bootstrap-table.com/) to create example(s) (Before and after your changes).
     On our Wiki (https://github.com/wenzhixin/bootstrap-table/wiki/Online-Editor-Explanation) you can read how to use the editor.-->
Visible on https://examples.bootstrap-table.com/index.html#welcomes/large-data.html

**☑️Self Check before Merge**

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
