### PR TITLE
Fixes #5993 #6007

### DIFF
--- a/src/extensions/cookie/bootstrap-table-cookie.js
+++ b/src/extensions/cookie/bootstrap-table-cookie.js
@@ -497,7 +497,7 @@ $.BootstrapTable = class extends $.BootstrapTable {
           return columnField === column.field
         })
 
-        column.visible = (filteredColumns.length > 0 || !column.switchable) && column.visible
+        column.visible = (filteredColumns.length > 0 || !column.switchable)
       }
     }
   }


### PR DESCRIPTION
**🤔Type of Request**
- [x] **Bug fix**

**🔗Resolves an issue?**
Fix #5993 #6007
**📝Changelog**

<!-- The type of the change. --->
- [ ] **Core**
- [x] **Extensions**

<!-- Describe changes from the user side. -->
When using the cookie extension, if a user starts a column as non visible but then in the interface toggles the check to show that column, when refreshing the page or if they exit the page and then got back, the columns marked as non visible still doesn't appear.

I think this is an error, because the condition always check if the column is marked as visible, ignoring the columns that the cookie contains, and I believe the cookie must take precedence, since it's more probable that the user wants to view the columns that they already checked as visible.

Special thanks to @simonsolutions to pointing in the right direction!!. 

**💡Example(s)?**
<!-- Please use our online Editor (https://live.bootstrap-table.com/) to create example(s) (Before and after your changes).
     On our Wiki (https://github.com/wenzhixin/bootstrap-table/wiki/Online-Editor-Explanation) you can read how to use the editor.-->
https://live.bootstrap-table.com/code/inietov/10650
**☑️Self Check before Merge**

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
