### PR TITLE
Fix #6066

### DIFF
--- a/src/extensions/editable/bootstrap-table-editable.js
+++ b/src/extensions/editable/bootstrap-table-editable.js
@@ -172,7 +172,7 @@ $.BootstrapTable = class extends $.BootstrapTable {
   }
 
   getData (params) {
-    const data = super.getData(params)
+    const data = structuredClone(super.getData(params))
 
     if (params && params.escape) {
       for (const row of data) {


### PR DESCRIPTION
…e function #6066

**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
<!-- Please prefix each issue number with  "Fix #"  (e.g. Fix #200)  -->
Fix #6066

**📝Changelog**

<!-- The type of the change. --->
- [ ] **Core**
- [x] **Extensions**

<!-- Describe changes from the user side. -->
Make deep copy of the data to not modify original object by the escape function

**💡Example(s)?**
<!-- Please use our online Editor (https://live.bootstrap-table.com/) to create example(s) (Before and after your changes).
     On our Wiki (https://github.com/wenzhixin/bootstrap-table/wiki/Online-Editor-Explanation) you can read how to use the editor.-->

http://jsfiddle.net/vxLk6r2s/3/

Here after clicking getData link I would expect to see: `[{ key:1, val:1 },{ key:2, val:2 }]`, not `"[object Object],[object Object]"`.

Note: you can get the expected result e.g. by removing the `editable` from the column.

**☑️Self Check before Merge**

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
