### PR TITLE
Fixed escape column option not override table option bug.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ jobs:
     - stage: test
       language: node_js
       node_js:
-        - 12
+        - 14
       name: "Lint src and check docs"
       cache:
         npm: true
@@ -22,7 +22,7 @@ jobs:
     - stage: test
       language: node_js
       node_js:
-        - 12
+        - 14
       name: "Cypress Test"
       cache:
         npm: true
@@ -40,7 +40,7 @@ jobs:
       rvm:
         - 2.4.1
       before_install:
-        - nvm install 12
+        - nvm install 14
       script: ./deploy.sh
       if: branch = master AND type = push
       cache: bundler

--- a/site/docs/api/column-options.md
+++ b/site/docs/api/column-options.md
@@ -156,7 +156,7 @@ The column options is defined in `jQuery.fn.bootstrapTable.columnDefaults`.
 
   Escapes a string for insertion into HTML, replacing &, <, >, ", \`, and ' characters.
 
-- **Default:** `false`
+- **Default:** `undefined`
 
 - **Example:** [Column Escape](https://examples.bootstrap-table.com/#column-options/escape.html)
 

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1512,8 +1512,9 @@ class BootstrapTable {
     }
 
     this.header.fields.forEach((field, j) => {
+      const column = this.columns[j]
       let text = ''
-      let value_ = Utils.getItemField(item, field, this.options.escape)
+      let value_ = Utils.getItemField(item, field, column.escape ?? this.options.escape)
       let value = ''
       let type = ''
       let cellStyle = {}
@@ -1525,7 +1526,6 @@ class BootstrapTable {
       let rowspan_ = ''
       let colspan_ = ''
       let title_ = ''
-      const column = this.columns[j]
 
       if ((this.fromHtml || this.autoMergeCells) && typeof value_ === 'undefined') {
         if ((!column.checkbox) && (!column.radio)) {
@@ -1794,7 +1794,7 @@ class BootstrapTable {
       const fields = this.getVisibleFields()
       const field = fields[index - Utils.getDetailViewIndexOffset(this.options)]
       const column = this.columns[this.fieldsColumnsIndex[field]]
-      const value = Utils.getItemField(item, field, this.options.escape)
+      const value = Utils.getItemField(item, field, column.escape ?? this.options.escape)
 
       if ($td.find('.detail-icon').length) {
         return

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1514,7 +1514,7 @@ class BootstrapTable {
     this.header.fields.forEach((field, j) => {
       const column = this.columns[j]
       let text = ''
-      let value_ = Utils.getItemField(item, field, column.escape ?? this.options.escape)
+      let value_ = Utils.getItemField(item, field, this.options.escape, column.escape)
       let value = ''
       let type = ''
       let cellStyle = {}
@@ -1794,7 +1794,7 @@ class BootstrapTable {
       const fields = this.getVisibleFields()
       const field = fields[index - Utils.getDetailViewIndexOffset(this.options)]
       const column = this.columns[this.fieldsColumnsIndex[field]]
-      const value = Utils.getItemField(item, field, column.escape ?? this.options.escape)
+      const value = Utils.getItemField(item, field, this.options.escape, column.escape)
 
       if ($td.find('.detail-icon').length) {
         return

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -445,7 +445,7 @@ const COLUMN_DEFAULTS = {
   detailFormatter: undefined,
   searchFormatter: true,
   searchHighlightFormatter: false,
-  escape: false,
+  escape: undefined,
   events: undefined
 }
 

--- a/src/extensions/fixed-columns/bootstrap-table-fixed-columns.js
+++ b/src/extensions/fixed-columns/bootstrap-table-fixed-columns.js
@@ -144,7 +144,7 @@ $.BootstrapTable = class extends $.BootstrapTable {
       const inputSelector = `[name="${this.options.selectItemName}"]`
       const $input = $el.find(inputSelector)
 
-      if (typeof index === undefined) {
+      if (typeof index === 'undefined') {
         return
       }
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -364,8 +364,13 @@ export default {
     return dataAttr
   },
 
-  getItemField (item, field, escape) {
+  getItemField (item, field, escape, columnEscape = undefined) {
     let value = item
+
+    // use column escape if it is defined
+    if (typeof columnEscape !== 'undefined') {
+      escape = columnEscape
+    }
 
     if (typeof field !== 'string' || item.hasOwnProperty(field)) {
       return escape ? this.escapeHTML(item[field]) : item[field]


### PR DESCRIPTION
**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
Fix #6071

**📝Changelog**

<!-- The type of the change. --->
- [x] **Core**
- [ ] **Extensions**

Fixed escape column option does not override table option bug.

**💡Example(s)?**
Before: https://live.bootstrap-table.com/code/wenzhixin/10759
After: https://live.bootstrap-table.com/code/wenzhixin/10760

**☑️Self Check before Merge**

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
