### PR TITLE
Fixed hide loading bug when canceling the request

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -2012,7 +2012,9 @@ class BootstrapTable {
         }
         this.load(data)
         this.trigger('load-error', jqXHR && jqXHR.status, jqXHR)
-        if (!silent) this.$tableLoading.hide()
+        if (!silent) {
+          this.hideLoading()
+        }
       }
     })
 

--- a/src/extensions/pipeline/bootstrap-table-pipeline.js
+++ b/src/extensions/pipeline/bootstrap-table-pipeline.js
@@ -300,7 +300,9 @@ BootstrapTable.prototype.initServer = function (silent, query, url) {
       }
       self.load(res)
       self.trigger('load-success', res)
-      if (!silent) self.$tableLoading.hide()
+      if (!silent) {
+        self.hideLoading()
+      }
     },
     error (res) {
       let data = []
@@ -312,7 +314,9 @@ BootstrapTable.prototype.initServer = function (silent, query, url) {
       }
       self.load(data)
       self.trigger('load-error', res.status, res)
-      if (!silent) self.$tableLoading.hide()
+      if (!silent) {
+        self.hideLoading()
+      }
     }
   })
 


### PR DESCRIPTION
**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
Fix #5858 

**📝Changelog**

<!-- The type of the change. --->
- [x] **Core**
- [ ] **Extensions**

Fixed hide loading bug when canceling the request.

**💡Example(s)?**
Before: https://live.bootstrap-table.com/code/wenzhixin/10809
After: https://live.bootstrap-table.com/code/wenzhixin/10810

> In order to reproduce the problem, you might want to set your browser to "slow 3G" throttling, so that you are able to simulate slow connections. Then perform a search query, wait for the "loading, please wait..." message and then hit another letter, so that the current search query gets canceled and the XHR connection fails loading. After that the "loading" message is gone, although the search functionality still works. Specially on slow connection the "loading" message is very important.

**☑️Self Check before Merge**

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
