### PR TITLE
Fixed exportOptions option cannot support data attribute

### DIFF
--- a/src/extensions/export/bootstrap-table-export.js
+++ b/src/extensions/export/bootstrap-table-export.js
@@ -84,6 +84,10 @@ $.BootstrapTable = class extends $.BootstrapTable {
         exportTypes = types.map(t => t.slice(1, -1))
       }
 
+      if (typeof o.exportOptions === 'string') {
+        o.exportOptions = Utils.calculateObjectValue(null, o.exportOptions)
+      }
+
       this.$export = this.$toolbar.find('>.columns div.export')
       if (this.$export.length) {
         this.updateExportButton()


### PR DESCRIPTION
**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
Fix #6107 

**📝Changelog**

<!-- The type of the change. --->
- [ ] **Core**
- [x] **Extensions**

Fixed the `exportOptions` option cannot support the data attribute.

**💡Example(s)?**
Before: https://live.bootstrap-table.com/code/wenzhixin/11324
After: https://live.bootstrap-table.com/code/wenzhixin/11323

**☑️Self Check before Merge**

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
