### PR TITLE
types: Fix type of classes option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,22 +1,5 @@
 /// <reference types="jquery" />
 
-interface BootstrapTableClasses{
-    buttons: string;
-    buttonsGroup: string;
-    inputGroup: string;
-    buttonsPrefix: string;
-    paginationActive: string;
-    buttonActive: string;
-    dropdownActive: string;
-    pull: string;
-    input: string;
-    dropup: string;
-    buttonsDropdown: string;
-    paginationDropdown: string;
-    inputPrefix: string
-}
-
-// eslint-disable-next-line no-unused-vars
 interface BootstrapTableHtml{
     searchInput: string;
     searchButton: string;
@@ -289,7 +272,7 @@ interface BootstrapTableOptions{
     pagination?: boolean;
     queryParams?: (params: any) => any;
     paginationSuccessivelySize?: number;
-    classes?: BootstrapTableClasses;
+    classes?: string;
     rememberOrder?: boolean;
     paginationPagesBySide?: number;
     trimOnSearch?: boolean;


### PR DESCRIPTION
**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**📝Changelog**

<!-- The type of the change. --->
- [x] **Core**
- [ ] **Extensions**

Updates the type of the `classes` option to reflect that it is a string, as per the docs: https://github.com/wenzhixin/bootstrap-table/blob/89b744758d179740548f1d850a1f8595a7d73f46/site/docs/api/table-options.md?plain=1#L260

**☑️Self Check before Merge**

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
