### PR TITLE
Fixed icons option cannot work when it's string

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -43,6 +43,10 @@ class BootstrapTable {
     const iconsPrefix = Utils.getIconsPrefix($.fn.bootstrapTable.theme)
     const icons = Utils.getIcons(iconsPrefix)
 
+    if (typeof opts.icons === 'string') {
+      opts.icons = Utils.calculateObjectValue(null, opts.icons)
+    }
+
     opts.iconsPrefix = opts.iconsPrefix || $.fn.bootstrapTable.defaults.iconsPrefix || iconsPrefix
     opts.icons = Object.assign(icons, $.fn.bootstrapTable.defaults.icons, opts.icons)
 
@@ -58,10 +62,6 @@ class BootstrapTable {
     this.buttons = Utils.calculateObjectValue(this, opts.buttons, [], {})
     if (typeof this.buttons !== 'object') {
       this.buttons = {}
-    }
-
-    if (typeof opts.icons === 'string') {
-      opts.icons = Utils.calculateObjectValue(null, opts.icons)
     }
   }
 


### PR DESCRIPTION
**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
Fix #6135

**📝Changelog**

<!-- The type of the change. --->
- [x] **Core**
- [ ] **Extensions**

Fixed icons option cannot work bug when it's a string.

**💡Example(s)?**
Before: https://live.bootstrap-table.com/example/options/icons-prefix.html
After: https://live.bootstrap-table.com/code/wenzhixin/11412

**☑️Self Check before Merge**

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
