### PR TITLE
fix/6126

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1786,6 +1786,11 @@ class BootstrapTable {
     // click to select by column
     this.$body.find('> tr[data-index] > td').off('click dblclick').on('click dblclick', e => {
       const $td = $(e.currentTarget)
+
+      if ($td.find('.detail-icon').length) {
+        return
+      }
+
       const $tr = $td.parent()
       const $cardViewArr = $(e.target).parents('.card-views').children()
       const $cardViewTarget = $(e.target).parents('.card-view')
@@ -1796,10 +1801,6 @@ class BootstrapTable {
       const field = fields[index - Utils.getDetailViewIndexOffset(this.options)]
       const column = this.columns[this.fieldsColumnsIndex[field]]
       const value = Utils.getItemField(item, field, this.options.escape, column.escape)
-
-      if ($td.find('.detail-icon').length) {
-        return
-      }
 
       this.trigger(e.type === 'click' ? 'click-cell' : 'dbl-click-cell', field, value, item, $td)
       this.trigger(e.type === 'click' ? 'click-row' : 'dbl-click-row', item, $tr, field)


### PR DESCRIPTION
Check if the td is the detail view column before getting more data.

**🤔Type of Request**
- [ ] **Bug fix**
- [ ] **New feature**
- [x] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
<!-- Please prefix each issue number with  "Fix #"  (e.g. Fix #200)  -->
Fix #6126

**📝Changelog**

<!-- The type of the change. --->
- [x] **Core**
- [ ] **Extensions**

<!-- Describe changes from the user side. -->
Improved a check to prevent errors while clicking on the detail view td instead of the detail view icon.

**💡Example(s)?**
<!-- Please use our online Editor (https://live.bootstrap-table.com/) to create example(s) (Before and after your changes).
     On our Wiki (https://github.com/wenzhixin/bootstrap-table/wiki/Online-Editor-Explanation) you can read how to use the editor.-->
Before: https://live.bootstrap-table.com/example/options/detail-view.html
After: https://live.bootstrap-table.com/code/UtechtDustin/11480

**☑️Self Check before Merge**

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
