### PR TITLE
Add else condition when one of the element is null

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1034,6 +1034,9 @@ class BootstrapTable {
             for (let i = 0; i < props.length; i++) {
               if (value[props[i]] !== null) {
                 value = value[props[i]]
+              } else {
+                value = null
+                break;
               }
             }
           } else {


### PR DESCRIPTION
**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
<!-- Please prefix each issue number with  "Fix #"  (e.g. Fix #200)  -->

Fix #6189

**📝Changelog**

<!-- The type of the change. --->
- [x] **Core**
- [ ] **Extensions**

<!-- Describe changes from the user side. -->

In order to avoid returning parent value, adds a condition that return null if one of the elements is null

**💡Example(s)?**
<!-- Please use our online Editor (https://live.bootstrap-table.com/) to create example(s) (Before and after your changes).
     On our Wiki (https://github.com/wenzhixin/bootstrap-table/wiki/Online-Editor-Explanation) you can read how to use the editor.-->

**☑️Self Check before Merge**

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
