### PR TITLE
Fix filter control clearing select values afer search

### DIFF
--- a/src/extensions/filter-control/utils.js
+++ b/src/extensions/filter-control/utils.js
@@ -112,7 +112,12 @@ export function fixHeaderCSS ({ $tableHeader }) {
 }
 
 export function getElementClass ($element) {
-  return $element.attr('class').replace('form-control', '').replace('focus-temp', '').replace('search-input', '').trim()
+  return $element.attr('class')
+    .replace('form-control', '')
+    .replace('form-select', '')
+    .replace('focus-temp', '')
+    .replace('search-input', '')
+    .trim()
 }
 
 export function getCursorPosition (el) {


### PR DESCRIPTION
**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
https://github.com/wenzhixin/bootstrap-table/issues/6125

**📝Changelog**

<!-- The type of the change. --->
- [ ] **Core**
- [x] **Extensions**

Fixes an issue where select values where cleared after selecting a value from the drop down in cases where server side search / pagination was used.

**💡Example(s)?**
<!-- Please use our online Editor (https://live.bootstrap-table.com/) to create example(s) (Before and after your changes).
     On our Wiki (https://github.com/wenzhixin/bootstrap-table/wiki/Online-Editor-Explanation) you can read how to use the editor.-->

- [x] Before: https://live.bootstrap-table.com/code/coshlo/11382
- [x] After: https://live.bootstrap-table.com/code/kwridan/11708

Steps:
- Select an item from the drop down
- Verify it isn't cleared when the search / filtering completes

**☑️Self Check before Merge**

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->

**📝 Additional Notes**

- In scenarios where a `select` filter control is used along with server search & pagination, selected values were being cleared on performing search
- This was caused by `cacheValues` failing to cache the the select value, and subsequently the value could not be restored in `setValues`
- This was caused due to the logic for `getElementClass` missing a case for filtering out `form-select` which meant it wasn't able to locate / select the element 

An example of the classes for a select:

```html
<select class="form-select bootstrap-table-filter-control-price">
<!-- ... -->
</select>
```

**❓Questions**

- In `cacheValues`, https://github.com/wenzhixin/bootstrap-table/blob/develop/src/extensions/filter-control/utils.js#L151 does this need to search for the element again by its classname? _(given `$field` already points to the correct element)_
