### PR TITLE
Added a new cookie for hidden columns (fix/5781)

### DIFF
--- a/site/docs/extensions/cookie.md
+++ b/site/docs/extensions/cookie.md
@@ -178,9 +178,9 @@ toc: true
 
 - **Detail:**
 
-   Set this array with the table properties (sortOrder, sortName, sortPriority, pageNumber, pageList, columns, searchText, filterControl) that you want to save
+   Set this array with the table properties (sortOrder, sortName, sortPriority, pageNumber, pageList, hiddenColumns, columns, searchText, filterControl) that you want to save
 
-- **Default:** `['bs.table.sortOrder', 'bs.table.sortName', 'bs.table.sortPriority', 'bs.table.pageNumber', 'bs.table.pageList', 'bs.table.columns', 'bs.table.searchText', 'bs.table.filterControl', 'bs.table.cardView']`
+- **Default:** `['bs.table.sortOrder', 'bs.table.sortName', 'bs.table.sortPriority', 'bs.table.pageNumber', 'bs.table.pageList', 'bs.table.hiddenColumns', 'bs.table.columns', 'bs.table.searchText', 'bs.table.filterControl', 'bs.table.cardView']`
 
 ## Methods
 
@@ -210,4 +210,5 @@ toc: true
 * Sort name
 * Multiple Sort order
 * Visible columns
+* Hidden columns
 * Card view state

--- a/src/extensions/cookie/bootstrap-table-cookie.js
+++ b/src/extensions/cookie/bootstrap-table-cookie.js
@@ -12,6 +12,7 @@ const UtilsCookie = {
     pageNumber: 'bs.table.pageNumber',
     pageList: 'bs.table.pageList',
     columns: 'bs.table.columns',
+    hiddenColumns: 'bs.table.hiddenColumns',
     cardView: 'bs.table.cardView',
     searchText: 'bs.table.searchText',
     reorderColumns: 'bs.table.reorderColumns',
@@ -178,7 +179,7 @@ $.extend($.fn.bootstrapTable.defaults, {
   cookiesEnabled: [
     'bs.table.sortOrder', 'bs.table.sortName', 'bs.table.sortPriority',
     'bs.table.pageNumber', 'bs.table.pageList',
-    'bs.table.columns', 'bs.table.searchText',
+    'bs.table.hiddenColumns', 'bs.table.columns', 'bs.table.searchText',
     'bs.table.filterControl', 'bs.table.filterBy',
     'bs.table.reorderColumns', 'bs.table.cardView'
   ],
@@ -361,7 +362,7 @@ $.BootstrapTable = class extends $.BootstrapTable {
     if (!this.options.cookie) {
       return
     }
-    UtilsCookie.setCookie(this, UtilsCookie.cookieIds.columns, JSON.stringify(this.getVisibleColumns().map(column => column.field)))
+    UtilsCookie.setCookie(this, UtilsCookie.cookieIds.hiddenColumns, JSON.stringify(this.getHiddenColumns().map(column => column.field)))
   }
 
   _toggleAllColumns (...args) {
@@ -369,7 +370,7 @@ $.BootstrapTable = class extends $.BootstrapTable {
     if (!this.options.cookie) {
       return
     }
-    UtilsCookie.setCookie(this, UtilsCookie.cookieIds.columns, JSON.stringify(this.getVisibleColumns().map(column => column.field)))
+    UtilsCookie.setCookie(this, UtilsCookie.cookieIds.hiddenColumns, JSON.stringify(this.getHiddenColumns().map(column => column.field)))
   }
 
   toggleView () {
@@ -435,6 +436,7 @@ $.BootstrapTable = class extends $.BootstrapTable {
     const cardViewCookie = UtilsCookie.getCookie(this, UtilsCookie.cookieIds.cardView)
 
     const columnsCookieValue = UtilsCookie.getCookie(this, UtilsCookie.cookieIds.columns)
+    const hiddenColumnsCookieValue = UtilsCookie.getCookie(this, UtilsCookie.cookieIds.hiddenColumns)
 
     if (typeof columnsCookieValue === 'boolean' && !columnsCookieValue) {
       throw new Error('The cookie value of filterBy must be a json!')
@@ -446,6 +448,14 @@ $.BootstrapTable = class extends $.BootstrapTable {
       columnsCookie = JSON.parse(columnsCookieValue)
     } catch (e) {
       throw new Error('Could not parse the json of the columns cookie!', columnsCookieValue)
+    }
+
+    let hiddenColumnsCookie = {}
+
+    try {
+      hiddenColumnsCookie = JSON.parse(hiddenColumnsCookieValue)
+    } catch (e) {
+      throw new Error('Could not parse the json of the hidden columns cookie!', hiddenColumnsCookieValue)
     }
 
     try {
@@ -483,7 +493,22 @@ $.BootstrapTable = class extends $.BootstrapTable {
     // cardView
     this.options.cardView = cardViewCookie === 'true' ? cardViewCookie : false
 
-    if (columnsCookie) {
+    if (hiddenColumnsCookie) {
+      for (const column of this.columns) {
+        column.visible = !hiddenColumnsCookie.filter(columnField => {
+          if (this.isSelectionColumn(column)) {
+            return true
+          }
+
+          return columnField === column.field
+        }).length > 0 || !column.switchable
+      }
+    } else if (columnsCookie) {
+      /**
+       * This is needed for the old saved cookies!
+       * It can be removed in 2-3 Versions Later!!
+       * TODO: Remove this part (column cookie) some versions later e.g. 1.22.0
+       */
       for (const column of this.columns) {
         if (!column.switchable) {
           continue
@@ -493,11 +518,6 @@ $.BootstrapTable = class extends $.BootstrapTable {
           if (this.isSelectionColumn(column)) {
             return true
           }
-          /**
-           * This is needed for the old saved cookies or the table will show no columns!
-           * It can be removed in 2-3 Versions Later!!
-           * TODO: Remove this part some versions later e.g. 1.17.3
-           */
           if (columnField instanceof Object) {
             return columnField.field === column.field
           }
@@ -514,7 +534,7 @@ $.BootstrapTable = class extends $.BootstrapTable {
 
     $.each(UtilsCookie.cookieIds, (key, value) => {
       cookies[key] = UtilsCookie.getCookie(bootstrapTable, value)
-      if (key === 'columns') {
+      if (key === 'columns' || key === 'hiddenColumns' || key === 'sortPriority') {
         cookies[key] = JSON.parse(cookies[key])
       }
     })


### PR DESCRIPTION
Port of #5825 (Thanks to @Naruto-kyun )


**🤔Type of Request**
- [ ] **Bug fix**
- [ ] **New feature**
- [x] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
<!-- Please prefix each issue number with  "Fix #"  (e.g. Fix #200)  -->
Fix #5781

**📝Changelog**

<!-- The type of the change. --->
- [ ] **Core**
- [x] **Extensions**

- Added a new cookie "hiddenColumns" which will replace the "columns" cookies in a few versions, to prevent issues with new added columns.
<!-- Describe changes from the user side. -->

**💡Example(s)?**
<!-- Please use our online Editor (https://live.bootstrap-table.com/) to create example(s) (Before and after your changes).
     On our Wiki (https://github.com/wenzhixin/bootstrap-table/wiki/Online-Editor-Explanation) you can read how to use the editor.-->
Hide the a column, show the column, add the `price` column and reload the example.
Before the new column `price` is hidden instead of shown.

Before: https://live.bootstrap-table.com/code/UtechtDustin/12317
After: https://live.bootstrap-table.com/code/UtechtDustin/12319

**☑️Self Check before Merge**

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
