### PR TITLE
Set filterDefault only if the field is not already set

### DIFF
--- a/src/extensions/filter-control/utils.js
+++ b/src/extensions/filter-control/utils.js
@@ -411,7 +411,9 @@ export function createControls (that, header) {
         that.filterColumnsPartial = {}
       }
 
-      that.filterColumnsPartial[column.field] = column.filterDefault
+      if (!(column.field in that.filterColumnsPartial)) {
+        that.filterColumnsPartial[column.field] = column.filterDefault
+      }
     }
 
     $.each(header.find('th'), (_, th) => {


### PR DESCRIPTION
**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
<!-- Please prefix each issue number with  "Fix #"  (e.g. Fix #200)  -->
Fix #6324

**📝Changelog**

<!-- The type of the change. --->
- [ ] **Core**
- [x] **Extensions**

<!-- Describe changes from the user side. -->
Fixed an bug which sets the filterDefault option as filter if multiple filters exists.

**💡Example(s)?**
<!-- Please use our online Editor (https://live.bootstrap-table.com/) to create example(s) (Before and after your changes).
     On our Wiki (https://github.com/wenzhixin/bootstrap-table/wiki/Online-Editor-Explanation) you can read how to use the editor.-->
Before: https://live.bootstrap-table.com/code/sdespont/12383
After: https://live.bootstrap-table.com/code/UtechtDustin/12390

**☑️Self Check before Merge**

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
