### PR TITLE
Improved updateCell to update one HTML cell only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 ChangeLog
 ---------
 
+### 1.21.1
+
+#### Core
+
+- **Update:** Improved `updateCell` to update one HTML cell only.
+- **Update:** Updated `fr-FR` locale.
+- **Update:** Added missing locales for aria-label.
+
+#### Extensions
+
+- **Update(export):** Added missing locales for aria-label.
+
 ### 1.21.0
 
 #### Core

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -2665,15 +2665,36 @@ class BootstrapTable {
     this.initBody(true)
   }
 
+  _updateCellOnly (field, index) {
+    const rowHtml = this.initRow(this.options.data[index], index)
+    let fieldIndex = this.getVisibleFields().indexOf(field)
+
+    if (fieldIndex === -1) {
+      return
+    }
+
+    fieldIndex += Utils.getDetailViewIndexOffset(this.options)
+
+    this.$body.find(`>tr[data-index=${index}]`)
+      .find(`>td:eq(${fieldIndex})`)
+      .replaceWith($(rowHtml).find(`>td:eq(${fieldIndex})`))
+
+    this.initBodyEvent()
+    this.initFooter()
+    this.resetView()
+    this.updateSelected()
+  }
+
   updateCell (params) {
     if (!params.hasOwnProperty('index') ||
       !params.hasOwnProperty('field') ||
       !params.hasOwnProperty('value')) {
       return
     }
-    this.data[params.index][params.field] = params.value
+    this.options.data[params.index][params.field] = params.value
 
     if (params.reinit === false) {
+      this._updateCellOnly(params.field, params.index)
       return
     }
     this.initSort()
@@ -2684,15 +2705,17 @@ class BootstrapTable {
     const allParams = Array.isArray(params) ? params : [params]
 
     allParams.forEach(({ id, field, value }) => {
-      const rowId = this.options.data.indexOf(this.getRowByUniqueId(id))
+      const index = this.options.data.indexOf(this.getRowByUniqueId(id))
 
-      if (rowId === -1) {
+      if (index === -1) {
         return
       }
-      this.options.data[rowId][field] = value
+      this.options.data[index][field] = value
     })
 
     if (params.reinit === false) {
+      this._updateCellOnly(params.field,
+        this.options.data.indexOf(this.getRowByUniqueId(params.id)))
       return
     }
     this.initSort()


### PR DESCRIPTION
**🤔Type of Request**
- [ ] **Bug fix**
- [ ] **New feature**
- [x] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
Fix #3612

**📝Changelog**

<!-- The type of the change. --->
- [x] **Core**
- [ ] **Extensions**

Improved `updateCell` to update one HTML cell only.

**💡Example(s)?**
Before: https://live.bootstrap-table.com/code/wenzhixin/12528
After: https://live.bootstrap-table.com/code/wenzhixin/12529

Update other rows or cols to show the problem.

**☑️Self Check before Merge**

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
