### PR TITLE
Bug fix in Searching formatted Columns using ColumnOptions Context

### DIFF
--- a/src/extensions/filter-control/bootstrap-table-filter-control.js
+++ b/src/extensions/filter-control/bootstrap-table-filter-control.js
@@ -1,6 +1,6 @@
 /**
  * @author: Dennis Hernández
- * @version: v3.0.0
+ * @version: v3.0.1
  */
 
 import * as UtilsFilterControl from './utils.js'
@@ -248,7 +248,7 @@ $.BootstrapTable = class extends $.BootstrapTable {
               if (thisColumn) {
                 if (thisColumn.searchFormatter || thisColumn._forceFormatter) {
                   value = $.fn.bootstrapTable.utils.calculateObjectValue(
-                    that.header,
+                    thisColumn,
                     that.header.formatters[$.inArray(key, that.header.fields)],
                     [value, item, i],
                     value
@@ -348,7 +348,7 @@ $.BootstrapTable = class extends $.BootstrapTable {
     }
 
     if (column.filterCustomSearch) {
-      const customSearchResult = Utils.calculateObjectValue(this, column.filterCustomSearch, [searchValue, value, key, this.options.data], true)
+      const customSearchResult = Utils.calculateObjectValue(column, column.filterCustomSearch, [searchValue, value, key, this.options.data], true)
 
       if (customSearchResult !== null) {
         tmpItemIsExpected = customSearchResult


### PR DESCRIPTION
Fixed bug in bootstrap-table-filter-control.js where calculateObjectValue would set the formatter context to the header instead of the ColumnOptions.

**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
<!-- Please prefix each issue number with  "Fix #"  (e.g. Fix #200)  -->

**📝Changelog**

<!-- The type of the change. --->
- [ ] **Core**
- [x] **Extensions**

<!-- Describe changes from the user side. -->

**💡Example(s)?**
https://live.bootstrap-table.com/code/adragon202/12632
<!-- Please use our online Editor (https://live.bootstrap-table.com/) to create example(s) (Before and after your changes).
     On our Wiki (https://github.com/wenzhixin/bootstrap-table/wiki/Online-Editor-Explanation) you can read how to use the editor.-->

**☑️Self Check before Merge**

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
