### PR TITLE
Resets the page number to 1 when sorting

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -551,13 +551,20 @@ class BootstrapTable {
     // Assign the correct sortable arrow
     this.getCaret()
 
+    // if (this.options.sidePagination === 'server' && this.options.serverSort) {
+    //   this.options.pageNumber = 1
+    //   this.initServer(this.options.silentSort)
+    //   return
+    // }
+
     if (this.options.pagination) {
       this.options.pageNumber = 1
-    }
-
-    if (this.options.sidePagination === 'server' && this.options.serverSort) {
-      this.initServer(this.options.silentSort)
-      return
+      if (this.options.sidePagination === 'server' && this.options.serverSort) {
+        this.initServer(this.options.silentSort)
+        return
+      } else {
+        this.initPagination()
+      }
     }
 
     this.initSort()

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -556,9 +556,8 @@ class BootstrapTable {
       if (this.options.sidePagination === 'server' && this.options.serverSort) {
         this.initServer(this.options.silentSort)
         return
-      } else {
-        this.initPagination()
       }
+      this.initPagination()
     }
 
     this.initSort()

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -551,8 +551,11 @@ class BootstrapTable {
     // Assign the correct sortable arrow
     this.getCaret()
 
-    if (this.options.sidePagination === 'server' && this.options.serverSort) {
+    if (this.options.pagination) {
       this.options.pageNumber = 1
+    }
+
+    if (this.options.sidePagination === 'server' && this.options.serverSort) {
       this.initServer(this.options.silentSort)
       return
     }

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -551,12 +551,6 @@ class BootstrapTable {
     // Assign the correct sortable arrow
     this.getCaret()
 
-    // if (this.options.sidePagination === 'server' && this.options.serverSort) {
-    //   this.options.pageNumber = 1
-    //   this.initServer(this.options.silentSort)
-    //   return
-    // }
-
     if (this.options.pagination) {
       this.options.pageNumber = 1
       if (this.options.sidePagination === 'server' && this.options.serverSort) {


### PR DESCRIPTION
**🤔Type of Request**
- [x] **Bug fix**
- [x] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**

This resets the page number to 1 when sorting.
For server side sort this was already the behaviour as changed per #4414.
From an user perspective I think this is desired as when sorting you want to start with the first results (first page) and not stay on page x.

Fixes #6402 

Note if a configuration property is desired then just let me know; I will update the PR accordingly.

**📝Changelog**

<!-- The type of the change. --->
- [x] **Core**
- [ ] **Extensions**

<!-- Describe changes from the user side. -->

**💡Example(s)?**

https://live.bootstrap-table.com/code/marceloverdijk/12938

**☑️Self Check before Merge**

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
