### PR TITLE
Fixes resetting the page number to 1 when searching and cookies enabled

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -943,7 +943,7 @@ class BootstrapTable {
       }
     }
 
-    if (!firedByInitSearchText && !this.options.cookie) {
+    if (!firedByInitSearchText) {
       this.options.pageNumber = 1
     }
     this.initSearch()

--- a/src/extensions/cookie/bootstrap-table-cookie.js
+++ b/src/extensions/cookie/bootstrap-table-cookie.js
@@ -393,7 +393,7 @@ $.BootstrapTable = class extends $.BootstrapTable {
     if (this.options.search) {
       UtilsCookie.setCookie(this, UtilsCookie.cookieIds.searchText, this.searchText)
     }
-    UtilsCookie.setCookie(this, UtilsCookie.cookieIds.pageNumber, 1)
+    UtilsCookie.setCookie(this, UtilsCookie.cookieIds.pageNumber, this.options.pageNumber)
   }
 
   initHeader (...args) {

--- a/src/extensions/cookie/bootstrap-table-cookie.js
+++ b/src/extensions/cookie/bootstrap-table-cookie.js
@@ -393,7 +393,7 @@ $.BootstrapTable = class extends $.BootstrapTable {
     if (this.options.search) {
       UtilsCookie.setCookie(this, UtilsCookie.cookieIds.searchText, this.searchText)
     }
-    UtilsCookie.setCookie(this, UtilsCookie.cookieIds.pageNumber, this.options.pageNumber)
+    UtilsCookie.setCookie(this, UtilsCookie.cookieIds.pageNumber, 1)
   }
 
   initHeader (...args) {


### PR DESCRIPTION
**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**

Fixes #6401 

Without the cookie extension when searching the page number was reset to 1.
With the cookie extension enabled for some reason when searching the page number was not reset to 1.

I personally don't see why it would not be reset.

**📝Changelog**

<!-- The type of the change. --->
- [x] **Core**
- [x] **Extensions**

Code change is actually in core, but extension related..

<!-- Describe changes from the user side. -->

**💡Example(s)?**

https://live.bootstrap-table.com/code/marceloverdijk/12941

**☑️Self Check before Merge**

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
