### PR TITLE
Introduces new searchClearSelector

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -189,7 +189,7 @@ export interface BootstrapTableOptions {
   method?: string;
   onColumnSwitch?: (field: string, checked: boolean) => boolean | void;
   searchSelector?: boolean;
-  searchClearButtonSelector?: boolean;
+  searchClearSelector?: boolean;
   strictSearch?: boolean;
   multipleSelectRow?: boolean;
   onLoadError?: (status: string, jqXHR: JQuery.jqXHR) => boolean | void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -189,6 +189,7 @@ export interface BootstrapTableOptions {
   method?: string;
   onColumnSwitch?: (field: string, checked: boolean) => boolean | void;
   searchSelector?: boolean;
+  searchClearButtonSelector?: boolean;
   strictSearch?: boolean;
   multipleSelectRow?: boolean;
   onLoadError?: (status: string, jqXHR: JQuery.jqXHR) => boolean | void;

--- a/site/docs/api/table-options.md
+++ b/site/docs/api/table-options.md
@@ -1180,6 +1180,7 @@ The table options are defined in `jQuery.fn.bootstrapTable.defaults`.
 
   Notes:
   - If you want to use a custom search input, use the [searchSelector](https://bootstrap-table.com/docs/api/table-options/#searchSelector).
+    In that case you can also use a custom search clear button using [searchClearSelector](https://bootstrap-table.com/docs/api/table-options/#searchClearSelector).
   - You can also search via regex using the [regexSearch](https://bootstrap-table.com/docs/api/table-options/#regexSearch) option.
 
 - **Default:** `false`
@@ -1256,6 +1257,20 @@ The table options are defined in `jQuery.fn.bootstrapTable.defaults`.
 - **Default:** `false`
 
 - **Example:** [Search Selector](https://examples.bootstrap-table.com/#options/search-selector.html)
+
+## searchClearSelector
+
+- **Attribute:** `data-search-clear-selector`
+
+- **Type:** `Boolean|String`
+
+- **Detail:**
+
+  If this option is set (must be a valid dom selector, e.g. `#customSearchClear`), the found dom element will be used to clear the search input when clicked. Only effective when used in combination with [searchSelector](https://bootstrap-table.com/docs/api/table-options/#searchSelector)
+
+- **Default:** `false`
+
+- **Example:** [Search Selector](https://examples.bootstrap-table.com/#options/search-clear-selector.html)
 
 ## searchText
 

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -919,6 +919,12 @@ class BootstrapTable {
       const $searchInput = Utils.getSearchInput(this)
 
       handleInputEvent($searchInput)
+
+      if (typeof opts.searchClearButtonSelector === 'string') {
+        $(opts.searchClearButtonSelector).click(() => {
+          this.resetSearch()
+        })
+      }
     }
   }
 

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -920,8 +920,8 @@ class BootstrapTable {
 
       handleInputEvent($searchInput)
 
-      if (typeof opts.searchClearButtonSelector === 'string') {
-        $(opts.searchClearButtonSelector).click(() => {
+      if (typeof opts.searchClearSelector === 'string') {
+        $(opts.searchClearSelector).click(() => {
           this.resetSearch()
         })
       }

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -183,7 +183,7 @@ const DEFAULTS = {
   strictSearch: false,
   regexSearch: false,
   searchSelector: false,
-  searchClearButtonSelector: false,
+  searchClearSelector: false,
   visibleSearch: false,
   showButtonIcons: true,
   showButtonText: false,

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -183,6 +183,7 @@ const DEFAULTS = {
   strictSearch: false,
   regexSearch: false,
   searchSelector: false,
+  searchClearButtonSelector: false,
   visibleSearch: false,
   showButtonIcons: true,
   showButtonText: false,


### PR DESCRIPTION
**🤔Type of Request**
- [ ] **Bug fix**
- [x] **New feature**
- [x] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**

Fixes #6406

**📝Changelog**

<!-- The type of the change. --->
- [x] **Core**
- [ ] **Extensions**

<!-- Describe changes from the user side. -->
Introduces a new searchClearSelector table option.
Together with the existing `searchSelector` this would make it very easy to create a custom search bar without having to write any custom javascript as it automatically connects the BT events/methods to the selector.

**💡Example(s)?**

https://live.bootstrap-table.com/code/marceloverdijk/12945

**☑️Self Check before Merge**

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [ ] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
