### PR TITLE
Indicate URL parameters for server side pagination

### DIFF
--- a/site/docs/api/table-options.md
+++ b/site/docs/api/table-options.md
@@ -1529,12 +1529,12 @@ The table options are defined in `jQuery.fn.bootstrapTable.defaults`.
 
 - **URL parameters:**
 
-  When `data-side-pagination` is set to `server`, bootstrap table will make calls to the `data-url` with the following URL parameters:
+  When `sidePagination` is set to `server`, bootstrap table will make calls to the `data-url` with the following URL parameters:
   
-  - `offset` with a value between 0 and `total` - 1, indicating the first record to include
-  - `limit` with a value indicating the number of rows per page
+  - `offset` with a value between 0 and `total` - 1, indicating the first record to include.
+  - `limit` with a value indicating the number of rows per page.
 
-  When implementing server-side pagination, you must implement a JSON view in a format like [this example](https://examples.wenzhixin.net.cn/examples/bootstrap_table/data).  That view must take the URL parameter values indicated above and return records starting at the `offset` index and returns the number of records indicated by `limit`.  For example, if you want records 11-20, your view must obtain the `offset=10` and `limit=10` from the URL string and return records like [this example](https://examples.wenzhixin.net.cn/examples/bootstrap_table/data?offset=10&limit=10).
+  When implementing server-side pagination, you must implement a JSON view in a format like [this example](https://examples.wenzhixin.net.cn/examples/bootstrap_table/data). That view must take the URL parameter values indicated above and return records starting at the `offset` index and returns the number of records indicated by `limit`.  For example, if you want records 11-20, your view must obtain the `offset=10` and `limit=10` from the URL string and return records like [this example](https://examples.wenzhixin.net.cn/examples/bootstrap_table/data?offset=10&limit=10).
 
 - **Default:** `'client'`
 
@@ -1849,12 +1849,12 @@ The table options are defined in `jQuery.fn.bootstrapTable.defaults`.
 
 - **URL parameters:**
 
-  When `data-side-pagination` is set to `server`, bootstrap table will make calls to the `data-url` with the following URL parameters:
+  When `sidePagination` is set to `server`, bootstrap table will make calls to the `data-url` with the following URL parameters:
   
-  - `offset` with a value between 0 and `total` - 1, indicating the first record to include
-  - `limit` with a value indicating the number of rows per page
+  - `offset` with a value between 0 and `total` - 1, indicating the first record to include.
+  - `limit` with a value indicating the number of rows per page.
 
-  When implementing server-side pagination, you must implement a JSON view in a format like [this example](https://examples.wenzhixin.net.cn/examples/bootstrap_table/data).  That view must take the URL parameter values indicated above and return records starting at the `offset` index and returns the number of records indicated by `limit`.  For example, if you want records 11-20, your view must obtain the `offset=10` and `limit=10` from the URL string and return records like [this example](https://examples.wenzhixin.net.cn/examples/bootstrap_table/data?offset=10&limit=10).
+  When implementing server-side pagination, you must implement a JSON view in a format like [this example](https://examples.wenzhixin.net.cn/examples/bootstrap_table/data). That view must take the URL parameter values indicated above and return records starting at the `offset` index and returns the number of records indicated by `limit`.  For example, if you want records 11-20, your view must obtain the `offset=10` and `limit=10` from the URL string and return records like [this example](https://examples.wenzhixin.net.cn/examples/bootstrap_table/data?offset=10&limit=10).
 
 - **Default:** `undefined`
 

--- a/site/docs/api/table-options.md
+++ b/site/docs/api/table-options.md
@@ -1521,7 +1521,7 @@ The table options are defined in `jQuery.fn.bootstrapTable.defaults`.
 
   Defines the side pagination of the table, can only be `'client'` or `'server'`.
   Using the `'server'` side requires setting the `'url'` or `'ajax'` option.
-  
+ 
   Note that the required server response format is different depending on whether the  `'sidePagination'` option is set to `'client'` or `'server'`. See the following examples:
 
   * [Without server-side pagination](https://github.com/wenzhixin/bootstrap-table-examples/blob/master/json/data1.json)

--- a/site/docs/api/table-options.md
+++ b/site/docs/api/table-options.md
@@ -1529,7 +1529,7 @@ The table options are defined in `jQuery.fn.bootstrapTable.defaults`.
 
 - **URL parameters:**
 
-  When `sidePagination` is set to `server`, bootstrap table will make calls to the `data-url` with the following URL parameters:
+  When `sidePagination` is set to `server`, the bootstrap table will make calls to the `url` with the following URL parameters:
   
   - `offset` with a value between 0 and `total` - 1, indicating the first record to include.
   - `limit` with a value indicating the number of rows per page.
@@ -1849,7 +1849,7 @@ The table options are defined in `jQuery.fn.bootstrapTable.defaults`.
 
 - **URL parameters:**
 
-  When `sidePagination` is set to `server`, bootstrap table will make calls to the `data-url` with the following URL parameters:
+  When `sidePagination` is set to `server`, the bootstrap table will make calls to the `url` with the following URL parameters:
   
   - `offset` with a value between 0 and `total` - 1, indicating the first record to include.
   - `limit` with a value indicating the number of rows per page.

--- a/site/docs/api/table-options.md
+++ b/site/docs/api/table-options.md
@@ -1521,6 +1521,7 @@ The table options are defined in `jQuery.fn.bootstrapTable.defaults`.
 
   Defines the side pagination of the table, can only be `'client'` or `'server'`.
   Using the `'server'` side requires setting the `'url'` or `'ajax'` option.
+
   Note that the required server response format is different depending on whether the  `'sidePagination'` option is set to `'client'` or `'server'`. See the following examples:
 
   * [Without server-side pagination](https://github.com/wenzhixin/bootstrap-table-examples/blob/master/json/data1.json)

--- a/site/docs/api/table-options.md
+++ b/site/docs/api/table-options.md
@@ -1521,7 +1521,6 @@ The table options are defined in `jQuery.fn.bootstrapTable.defaults`.
 
   Defines the side pagination of the table, can only be `'client'` or `'server'`.
   Using the `'server'` side requires setting the `'url'` or `'ajax'` option.
- 
   Note that the required server response format is different depending on whether the  `'sidePagination'` option is set to `'client'` or `'server'`. See the following examples:
 
   * [Without server-side pagination](https://github.com/wenzhixin/bootstrap-table-examples/blob/master/json/data1.json)

--- a/site/docs/api/table-options.md
+++ b/site/docs/api/table-options.md
@@ -1527,7 +1527,7 @@ The table options are defined in `jQuery.fn.bootstrapTable.defaults`.
   * [Without server-side pagination](https://github.com/wenzhixin/bootstrap-table-examples/blob/master/json/data1.json)
   * [With server-side pagination](https://github.com/wenzhixin/bootstrap-table-examples/blob/master/json/data2.json)
 
-- **URL parameters:**
+  **URL parameters:**
 
   When `sidePagination` is set to `server`, the bootstrap table will make calls to the `url` with the following URL parameters:
   
@@ -1847,7 +1847,7 @@ The table options are defined in `jQuery.fn.bootstrapTable.defaults`.
   * [Without server-side pagination](https://github.com/wenzhixin/bootstrap-table-examples/blob/master/json/data1.json)
   * [With server-side pagination](https://github.com/wenzhixin/bootstrap-table-examples/blob/master/json/data2.json)
 
-- **URL parameters:**
+  **URL parameters:**
 
   When `sidePagination` is set to `server`, the bootstrap table will make calls to the `url` with the following URL parameters:
   

--- a/site/docs/api/table-options.md
+++ b/site/docs/api/table-options.md
@@ -1521,11 +1521,20 @@ The table options are defined in `jQuery.fn.bootstrapTable.defaults`.
 
   Defines the side pagination of the table, can only be `'client'` or `'server'`.
   Using the `'server'` side requires setting the `'url'` or `'ajax'` option.
-
+  
   Note that the required server response format is different depending on whether the  `'sidePagination'` option is set to `'client'` or `'server'`. See the following examples:
 
   * [Without server-side pagination](https://github.com/wenzhixin/bootstrap-table-examples/blob/master/json/data1.json)
   * [With server-side pagination](https://github.com/wenzhixin/bootstrap-table-examples/blob/master/json/data2.json)
+
+- **URL parameters:**
+
+  When `data-side-pagination` is set to `server`, bootstrap table will make calls to the `data-url` with the following URL parameters:
+  
+  - `offset` with a value between 0 and `total` - 1, indicating the first record to include
+  - `limit` with a value indicating the number of rows per page
+
+  When implementing server-side pagination, you must implement a JSON view in a format like [this example](https://examples.wenzhixin.net.cn/examples/bootstrap_table/data).  That view must take the URL parameter values indicated above and return records starting at the `offset` index and returns the number of records indicated by `limit`.  For example, if you want records 11-20, your view must obtain the `offset=10` and `limit=10` from the URL string and return records like [this example](https://examples.wenzhixin.net.cn/examples/bootstrap_table/data?offset=10&limit=10).
 
 - **Default:** `'client'`
 
@@ -1837,6 +1846,15 @@ The table options are defined in `jQuery.fn.bootstrapTable.defaults`.
 
   * [Without server-side pagination](https://github.com/wenzhixin/bootstrap-table-examples/blob/master/json/data1.json)
   * [With server-side pagination](https://github.com/wenzhixin/bootstrap-table-examples/blob/master/json/data2.json)
+
+- **URL parameters:**
+
+  When `data-side-pagination` is set to `server`, bootstrap table will make calls to the `data-url` with the following URL parameters:
+  
+  - `offset` with a value between 0 and `total` - 1, indicating the first record to include
+  - `limit` with a value indicating the number of rows per page
+
+  When implementing server-side pagination, you must implement a JSON view in a format like [this example](https://examples.wenzhixin.net.cn/examples/bootstrap_table/data).  That view must take the URL parameter values indicated above and return records starting at the `offset` index and returns the number of records indicated by `limit`.  For example, if you want records 11-20, your view must obtain the `offset=10` and `limit=10` from the URL string and return records like [this example](https://examples.wenzhixin.net.cn/examples/bootstrap_table/data?offset=10&limit=10).
 
 - **Default:** `undefined`
 


### PR DESCRIPTION
I'd tried to use bootstrap table's server side pagination over a year ago and never figured out how to get it to work.  I was working in Django and tried to implement the view that the data-url was calling, but I was missing this key piece of information.  I happened upon the URL parameters in the last answer of a stack post and it was like an epiphany.  I went back to the documentation to see how I'd possibly missed the URL parameters that the view needed to be able to obtain, and was shocked to see that it wasn't a part of the documentation.  Hopefully, this addition to the documentation will make the server-side pagination attempts of others easier to implement...

And if there are other parameters that could be passed, such as for `serverSort`, it would be good to add those as well.

**🤔Type of Request**
- [ ] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [x] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
<!-- Please prefix each issue number with  "Fix #"  (e.g. Fix #200)  -->

**📝Changelog**

<!-- The type of the change. --->
- [ ] **Core**
- [ ] **Extensions**

<!-- Describe changes from the user side. -->

**💡Example(s)?**
<!-- Please use our online Editor (https://live.bootstrap-table.com/) to create example(s) (Before and after your changes).
     On our Wiki (https://github.com/wenzhixin/bootstrap-table/wiki/Online-Editor-Explanation) you can read how to use the editor.-->

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
