### PR TITLE
Fix missing form-control class when specifing data-icon-size

### DIFF
--- a/src/extensions/filter-control/utils.js
+++ b/src/extensions/filter-control/utils.js
@@ -5,7 +5,7 @@ const searchControls = 'select, input:not([type="checkbox"]):not([type="radio"])
 export function getInputClass (that, isSelect = false) {
   const formControlClass = isSelect ? that.constants.classes.select : that.constants.classes.input
 
-  return that.options.iconSize ? Utils.sprintf('%s-%s', formControlClass, that.options.iconSize) : formControlClass
+  return that.options.iconSize ? Utils.sprintf('%s %s-%s', formControlClass, formControlClass, that.options.iconSize) : formControlClass
 }
 
 export function getOptionsFromSelectControl (selectControl) {


### PR DESCRIPTION
Fix missing form-control class when specifing data-icon-size

**🤔Type of Request**
- [X] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
<!-- Please prefix each issue number with  "Fix #"  (e.g. Fix #200)  -->

**📝Changelog**
Add missing form-control class when specifing data-icon-size
<!-- The type of the change. --->
- [ ] **Core**
- [X] **Extensions**

<!-- Describe changes from the user side. -->

**💡Example(s)?**
<!-- Please use our online Editor (https://live.bootstrap-table.com/) to create example(s) (Before and after your changes).
     On our Wiki (https://github.com/wenzhixin/bootstrap-table/wiki/Online-Editor-Explanation) you can read how to use the editor.-->

Before : https://live.bootstrap-table.com/code/sdespont/11317
After : https://live.bootstrap-table.com/code/sdespont/13011

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
