### PR TITLE
Fixed an falsey if statement

### DIFF
--- a/src/extensions/filter-control/utils.js
+++ b/src/extensions/filter-control/utils.js
@@ -307,7 +307,7 @@ export function initFilterSelectControls (that) {
         const formatter = that.options.editable && column.editable ? column._formatter : that.header.formatters[j]
         let formattedValue = Utils.calculateObjectValue(that.header, formatter, [fieldValue, data[i], i], fieldValue)
 
-        if (!fieldValue) {
+        if (fieldValue === undefined || fieldValue === null) {
           fieldValue = formattedValue
           column._forceFormatter = true
         }


### PR DESCRIPTION
**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
<!-- Please prefix each issue number with  "Fix #"  (e.g. Fix #200)  -->
Fix #6370

**📝Changelog**

<!-- The type of the change. --->
- [ ] **Core**
- [x] **Extensions**

<!-- Describe changes from the user side. -->
Fixed an falsey if statement while using the `filterControl` extension with a `select` filter and set `searchFormatter` to `false`.  

**💡Example(s)?**
Before: https://live.bootstrap-table.com/code/jonatanschroeder/12702
After: https://live.bootstrap-table.com/code/UtechtDustin/13019

Select `#1` as filter and/or check the generated select options.

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
