### PR TITLE
Reset page number when sorting option `sortResetPage`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -162,7 +162,7 @@ export interface BootstrapTableOptions {
   pageSize?: number;
   footerField?: string;
   showFullscreen?: boolean;
-  sortPageReset?: boolean;
+  sortResetPage?: boolean;
   sortStable?: boolean;
   searchAlign?: string;
   ajax?: (params: BootstrapAjaxParams) => any;

--- a/index.d.ts
+++ b/index.d.ts
@@ -162,6 +162,7 @@ export interface BootstrapTableOptions {
   pageSize?: number;
   footerField?: string;
   showFullscreen?: boolean;
+  sortPageReset?: boolean;
   sortStable?: boolean;
   searchAlign?: string;
   ajax?: (params: BootstrapAjaxParams) => any;

--- a/site/docs/api/table-options.md
+++ b/site/docs/api/table-options.md
@@ -1657,6 +1657,20 @@ The table options are defined in `jQuery.fn.bootstrapTable.defaults`.
 
 - **Example:** [Sort Reset](https://examples.bootstrap-table.com/#options/sort-reset.html)
 
+## sortResetPage
+
+- **Attribute:** `data-sort-reset-page`
+
+- **Type:** `Boolean`
+
+- **Detail:**
+
+  Set `true` to reset the page number when sorting
+
+- **Default:** `false`
+
+- **Example:** [Sort Reset Page](https://examples.bootstrap-table.com/#options/sort-reset-page.html)
+
 ## sortStable
 
 - **Attribute:** `data-sort-stable`

--- a/site/docs/api/table-options.md
+++ b/site/docs/api/table-options.md
@@ -1665,7 +1665,7 @@ The table options are defined in `jQuery.fn.bootstrapTable.defaults`.
 
 - **Detail:**
 
-  Set `true` to reset the page number when sorting
+  Set `true` to reset the page number when sorting.
 
 - **Default:** `false`
 

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -557,6 +557,10 @@ class BootstrapTable {
       return
     }
 
+    if (this.options.pagination && this.options.sortResetPage) {
+      this.options.pageNumber = 1
+    }
+
     this.initSort()
     this.initBody()
   }

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -559,6 +559,7 @@ class BootstrapTable {
 
     if (this.options.pagination && this.options.sortResetPage) {
       this.options.pageNumber = 1
+      this.initPagination()
     }
 
     this.initSort()


### PR DESCRIPTION
**🤔Type of Request**
- [ ] **Bug fix**
- [ ] **New feature**
- [x] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**

Introduces a new `sortResetPage` option to reset the page number when sorting.
Note that current default behaviour and behaviour for server side sorting is kept as is.

Fixes #6402 

**📝Changelog**

<!-- The type of the change. --->
- [x] **Core**
- [ ] **Extensions**

<!-- Describe changes from the user side. -->

**💡Example(s)?**

https://live.bootstrap-table.com/code/marceloverdijk/13109

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
