### PR TITLE
#6532 - separate on/off icon+text for custom view toolbar icon

### DIFF
--- a/site/docs/extensions/custom-view.md
+++ b/site/docs/extensions/custom-view.md
@@ -107,12 +107,6 @@ This extension adds the ability to create a custom view to display the data.
 
 ## Localizations
 
-### formatToggleCustomView
-
-- **type:** `Function`
-
-- **Default:** `function () { return "Hide/Show custom view" }`
-
 ### formatToggleCustomViewOn
 
 - **type:** `Function`

--- a/site/docs/extensions/custom-view.md
+++ b/site/docs/extensions/custom-view.md
@@ -60,13 +60,8 @@ This extension adds the ability to create a custom view to display the data.
 
 ### Icons
 
-- Toggle custom view:
-    * Bootstrap3: `glyphicon glyphicon-eye-open`
-    * Bootstrap4: `fa fa-eye`
-    * Semantic: `fa fa-eye`
-    * Foundation: `fa fa-eye`
-    * Bulma: `fa fa-eye`
-    * Materialize: `remove_red_eye`
+- customViewOn: `glyphicon glyphicon-eye-open`
+- customViewOff: `glyphicon glyphicon-eye-open`
 
 ## Methods
 
@@ -116,4 +111,16 @@ This extension adds the ability to create a custom view to display the data.
 
 - **type:** `Function`
 
-- **Default:** `function () { return "Toggle custom view" }`
+- **Default:** `function () { return "Hide/Show custom view" }`
+
+### formatToggleCustomViewOn
+
+- **type:** `Function`
+
+- **Default:** `function () { return "Show custom view" }`
+
+### formatToggleCustomViewOff
+
+- **type:** `Function`
+
+- **Default:** `function () { return "Hide custom view" }`

--- a/site/docs/extensions/custom-view.md
+++ b/site/docs/extensions/custom-view.md
@@ -60,8 +60,22 @@ This extension adds the ability to create a custom view to display the data.
 
 ### Icons
 
-- customViewOn: `glyphicon glyphicon-eye-open`
-- customViewOff: `glyphicon glyphicon-eye-open`
+- customViewOn: 
+    * Bootstrap3: `glyphicon glyphicon-list`
+    * Bootstrap4: `fa fa-eye`
+    * bootstrap5: 'bi-eye',
+    * Semantic: `fa fa-eye`
+    * Foundation: `fa fa-eye`
+    * Bulma: `fa fa-eye`
+    * Materialize: `remove_red_eye`
+- customViewOff:
+    * Bootstrap3: `glyphicon glyphicon-thumbnails`
+    * Bootstrap4: `fa fa-th`
+    * bootstrap5: 'bi-grid',
+    * Semantic: `fa fa-th`
+    * Foundation: `fa fa-th`
+    * Bulma: `fa fa-th`
+    * Materialize: `grid_on`
 
 ## Methods
 

--- a/src/extensions/custom-view/bootstrap-table-custom-view.js
+++ b/src/extensions/custom-view/bootstrap-table-custom-view.js
@@ -13,23 +13,23 @@ $.extend($.fn.bootstrapTable.defaults, {
 
 $.extend($.fn.bootstrapTable.defaults.icons, {
   customViewOn: {
-    bootstrap3: 'glyphicon glyphicon-eye-open',
-    bootstrap5: 'bi-eye',
-    bootstrap4: 'fa fa-eye',
-    semantic: 'fa fa-eye',
-    foundation: 'fa fa-eye',
-    bulma: 'fa fa-eye',
-    materialize: 'remove_red_eye'
-  }[$.fn.bootstrapTable.theme] || 'fa-eye',
+    bootstrap3: 'glyphicon glyphicon-list',
+    bootstrap5: 'bi-list',
+    bootstrap4: 'fa fa-list',
+    semantic: 'fa fa-list',
+    foundation: 'fa fa-list',
+    bulma: 'fa fa-list',
+    materialize: 'list'
+  }[$.fn.bootstrapTable.theme] || 'fa-list',
   customViewOff: {
-    bootstrap3: 'glyphicon glyphicon-eye-open',
-    bootstrap5: 'bi-eye',
-    bootstrap4: 'fa fa-eye',
-    semantic: 'fa fa-eye',
-    foundation: 'fa fa-eye',
-    bulma: 'fa fa-eye',
-    materialize: 'remove_red_eye'
-  }[$.fn.bootstrapTable.theme] || 'fa-eye'
+    bootstrap3: 'glyphicon glyphicon-thumbnails',
+    bootstrap5: 'bi-grid',
+    bootstrap4: 'fa fa-th',
+    semantic: 'fa fa-th',
+    foundation: 'fa fa-th',
+    bulma: 'fa fa-th',
+    materialize: 'grid_on'
+  }[$.fn.bootstrapTable.theme] || 'fa-th'
 })
 
 $.extend($.fn.bootstrapTable.defaults, {

--- a/src/extensions/custom-view/bootstrap-table-custom-view.js
+++ b/src/extensions/custom-view/bootstrap-table-custom-view.js
@@ -12,7 +12,16 @@ $.extend($.fn.bootstrapTable.defaults, {
 })
 
 $.extend($.fn.bootstrapTable.defaults.icons, {
-  customView: {
+  customViewOn: {
+    bootstrap3: 'glyphicon glyphicon-eye-open',
+    bootstrap5: 'bi-eye',
+    bootstrap4: 'fa fa-eye',
+    semantic: 'fa fa-eye',
+    foundation: 'fa fa-eye',
+    bulma: 'fa fa-eye',
+    materialize: 'remove_red_eye'
+  }[$.fn.bootstrapTable.theme] || 'fa-eye',
+  customViewOff: {
     bootstrap3: 'glyphicon glyphicon-eye-open',
     bootstrap5: 'bi-eye',
     bootstrap4: 'fa fa-eye',
@@ -37,7 +46,13 @@ $.extend($.fn.bootstrapTable.defaults, {
 
 $.extend($.fn.bootstrapTable.locales, {
   formatToggleCustomView () {
-    return 'Toggle custom view'
+    return 'Hide/Show custom view'
+  },
+  formatToggleCustomViewOn () {
+    return 'Show custom view'
+  },
+  formatToggleCustomViewOff () {
+    return 'Hide custom view'
   }
 })
 $.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales)
@@ -62,8 +77,8 @@ $.BootstrapTable = class extends $.BootstrapTable {
     if (this.options.customView && this.options.showCustomView) {
       this.buttons = Object.assign(this.buttons, {
         customView: {
-          text: this.options.formatToggleCustomView(),
-          icon: this.options.icons.customView,
+          text: this.options.customViewDefaultView ? this.options.formatToggleCustomViewOff() : this.options.formatToggleCustomViewOn(),
+          icon: this.options.customViewDefaultView ? this.options.icons.customViewOn : this.options.icons.customViewOff,
           event: this.toggleCustomView,
           attributes: {
             'aria-label': this.options.formatToggleCustomView(),
@@ -108,6 +123,15 @@ $.BootstrapTable = class extends $.BootstrapTable {
 
   toggleCustomView () {
     this.customViewDefaultView = !this.customViewDefaultView
+
+    const icon = this.options.showButtonIcons ? this.customViewDefaultView ? this.options.icons.customViewOn : this.options.icons.customViewOff : ''
+    const text = this.options.showButtonText ? this.customViewDefaultView ? this.options.formatToggleCustomViewOff() : this.options.formatToggleCustomViewOn() : ''
+
+    this.$toolbar.find('button[name="customView"]')
+      .html(`${Utils.sprintf(this.constants.html.icon, this.options.iconsPrefix, icon)} ${text}`)
+      .attr('aria-label', text)
+      .attr('title', text)
+
     this.initBody()
     this.trigger('toggle-custom-view', this.customViewDefaultView)
   }

--- a/src/extensions/custom-view/bootstrap-table-custom-view.js
+++ b/src/extensions/custom-view/bootstrap-table-custom-view.js
@@ -45,9 +45,6 @@ $.extend($.fn.bootstrapTable.defaults, {
 })
 
 $.extend($.fn.bootstrapTable.locales, {
-  formatToggleCustomView () {
-    return 'Hide/Show custom view'
-  },
   formatToggleCustomViewOn () {
     return 'Show custom view'
   },
@@ -81,8 +78,8 @@ $.BootstrapTable = class extends $.BootstrapTable {
           icon: this.options.customViewDefaultView ? this.options.icons.customViewOn : this.options.icons.customViewOff,
           event: this.toggleCustomView,
           attributes: {
-            'aria-label': this.options.formatToggleCustomView(),
-            title: this.options.formatToggleCustomView()
+            'aria-label': this.options.customViewDefaultView ? this.options.formatToggleCustomViewOff() : this.options.formatToggleCustomViewOn(),
+            title: this.options.customViewDefaultView ? this.options.formatToggleCustomViewOff() : this.options.formatToggleCustomViewOn()
           }
         }
       })


### PR DESCRIPTION
**🤔Type of Request**
- [ ] **Bug fix**
- [x] **New feature**
- [x] **Improvement**
- [x] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**

#6532

**📝Changelog**

<!-- The type of the change. --->
- [ ] **Core**
- [x] **Extensions**

Introduces separate on/of icon+text for custom view toolbar icon.
Note that I kept both default icons the same for backwards compatibility, but with this change users can override the icon (or text) to customise the icon appearance for both states.


**💡Example(s)?**

https://live.bootstrap-table.com/code/marceloverdijk/13518

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [ ] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
