### PR TITLE
Updated extend instead of $.extend

### DIFF
--- a/site/docs/extensions/export.md
+++ b/site/docs/extensions/export.md
@@ -90,8 +90,6 @@ This is an important link to check out as some file types may require extra step
 
 - **Default:** `['json', 'xml', 'csv', 'txt', 'sql', 'excel']`
 
-- **Default:** `{}`
-
 ### Icons
 
 - export: `'glyphicon-export icon-share'`

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -180,7 +180,7 @@ class BootstrapTable {
         if (typeof $th.data('field') !== 'undefined') {
           $th.data('field', `${$th.data('field')}`)
         }
-        column.push($.extend({}, {
+        column.push(Utils.extend({}, {
           title: $th.html(),
           class: $th.attr('class'),
           titleTooltip: $th.attr('title'),
@@ -202,7 +202,7 @@ class BootstrapTable {
       this.options.columns = [this.options.columns]
     }
 
-    this.options.columns = $.extend(true, [], columns, this.options.columns)
+    this.options.columns = Utils.extend(true, [], columns, this.options.columns)
     this.columns = []
     this.fieldsColumnsIndex = []
 
@@ -210,7 +210,7 @@ class BootstrapTable {
 
     this.options.columns.forEach((columns, i) => {
       columns.forEach((_column, j) => {
-        const column = $.extend({}, BootstrapTable.COLUMN_DEFAULTS, _column, { passed: _column })
+        const column = Utils.extend({}, BootstrapTable.COLUMN_DEFAULTS, _column, { passed: _column })
 
         if (typeof column.fieldIndex !== 'undefined') {
           this.columns[column.fieldIndex] = column
@@ -1981,7 +1981,7 @@ class BootstrapTable {
       params.filter = JSON.stringify(this.filterColumnsPartial, null)
     }
 
-    $.extend(params, query || {})
+    Utils.extend(params, query || {})
 
     data = Utils.calculateObjectValue(this.options, this.options.queryParams, [params], data)
 
@@ -1993,7 +1993,7 @@ class BootstrapTable {
     if (!silent) {
       this.showLoading()
     }
-    const request = $.extend({}, Utils.calculateObjectValue(null, this.options.ajaxOptions), {
+    const request = Utils.extend({}, Utils.calculateObjectValue(null, this.options.ajaxOptions), {
       type: this.options.method,
       url: url || this.options.url,
       data: this.options.contentType === 'application/json' && this.options.method === 'post' ?
@@ -2404,10 +2404,10 @@ class BootstrapTable {
 
   getOptions () {
     // deep copy and remove data
-    const options = $.extend({}, this.options)
+    const options = Utils.extend({}, this.options)
 
     delete options.data
-    return $.extend(true, {}, options)
+    return Utils.extend(true, {}, options)
   }
 
   refreshOptions (options) {
@@ -2415,7 +2415,7 @@ class BootstrapTable {
     if (Utils.compareObjects(this.options, options, true)) {
       return
     }
-    this.options = $.extend(this.options, options)
+    this.options = Utils.extend(this.options, options)
     this.trigger('refresh-options', this.options)
     this.destroy()
     this.init()
@@ -2576,7 +2576,7 @@ class BootstrapTable {
       if (params.hasOwnProperty('replace') && params.replace) {
         this.options.data[params.index] = params.row
       } else {
-        $.extend(this.options.data[params.index], params.row)
+        Utils.extend(this.options.data[params.index], params.row)
       }
     }
 
@@ -2639,7 +2639,7 @@ class BootstrapTable {
       if (params.hasOwnProperty('replace') && params.replace) {
         this.options.data[rowId] = params.row
       } else {
-        $.extend(this.options.data[rowId], params.row)
+        Utils.extend(this.options.data[rowId], params.row)
       }
       updatedUid = params.id
     }
@@ -3196,7 +3196,7 @@ class BootstrapTable {
   }
 
   filterBy (columns, options) {
-    this.filterOptions = Utils.isEmptyObject(options) ? this.options.filterOptions : $.extend(this.options.filterOptions, options)
+    this.filterOptions = Utils.isEmptyObject(options) ? this.options.filterOptions : Utils.extend(this.options.filterOptions, options)
     this.filterColumns = Utils.isEmptyObject(columns) ? {} : columns
     this.options.pageNumber = 1
     this.initSearch()
@@ -3392,8 +3392,6 @@ $.fn.bootstrapTable = function (option, ...args) {
 
   this.each((i, el) => {
     let data = $(el).data('bootstrap.table')
-    const options = $.extend(true, {}, BootstrapTable.DEFAULTS, $(el).data(),
-      typeof option === 'object' && option)
 
     if (typeof option === 'string') {
       if (!Constants.METHODS.includes(option)) {
@@ -3409,7 +3407,11 @@ $.fn.bootstrapTable = function (option, ...args) {
       if (option === 'destroy') {
         $(el).removeData('bootstrap.table')
       }
+      return
     }
+
+    const options = Utils.extend(true, {}, BootstrapTable.DEFAULTS, $(el).data(),
+      typeof option === 'object' && option)
 
     if (!data) {
       data = new $.BootstrapTable(el, options)

--- a/src/extensions/addrbar/bootstrap-table-addrbar.js
+++ b/src/extensions/addrbar/bootstrap-table-addrbar.js
@@ -6,6 +6,8 @@
  * @update: zhixin wen <wenzhixin2010@gmail.com>
  */
 
+const Utils = $.fn.bootstrapTable.utils
+
 /*
  * function: 获取浏览器地址栏中的指定参数.
  * key: 参数名
@@ -86,7 +88,7 @@ function _updateHistoryState (table, _prefix) {
   window.history.pushState({}, '', _buildUrl(params))
 }
 
-$.extend($.fn.bootstrapTable.defaults, {
+Utils.extend($.fn.bootstrapTable.defaults, {
   addrbar: false,
   addrPrefix: ''
 })

--- a/src/extensions/auto-refresh/bootstrap-table-auto-refresh.js
+++ b/src/extensions/auto-refresh/bootstrap-table-auto-refresh.js
@@ -6,7 +6,7 @@
 
 const Utils = $.fn.bootstrapTable.utils
 
-$.extend($.fn.bootstrapTable.defaults, {
+Utils.extend($.fn.bootstrapTable.defaults, {
   autoRefresh: false,
   showAutoRefresh: true,
   autoRefreshInterval: 60,
@@ -15,7 +15,7 @@ $.extend($.fn.bootstrapTable.defaults, {
   autoRefreshFunction: null
 })
 
-$.extend($.fn.bootstrapTable.defaults.icons, {
+Utils.extend($.fn.bootstrapTable.defaults.icons, {
   autoRefresh: {
     bootstrap3: 'glyphicon-time icon-time',
     bootstrap5: 'bi-clock',
@@ -24,13 +24,13 @@ $.extend($.fn.bootstrapTable.defaults.icons, {
   }[$.fn.bootstrapTable.theme] || 'fa-clock'
 })
 
-$.extend($.fn.bootstrapTable.locales, {
+Utils.extend($.fn.bootstrapTable.locales, {
   formatAutoRefresh () {
     return 'Auto Refresh'
   }
 })
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales)
+Utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales)
 
 $.BootstrapTable = class extends $.BootstrapTable {
   init (...args) {

--- a/src/extensions/cookie/bootstrap-table-cookie.js
+++ b/src/extensions/cookie/bootstrap-table-cookie.js
@@ -167,7 +167,7 @@ const UtilsCookie = {
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, {
+Utils.extend($.fn.bootstrapTable.defaults, {
   cookie: false,
   cookieExpire: '2h',
   cookiePath: null,
@@ -199,7 +199,7 @@ $.extend($.fn.bootstrapTable.defaults, {
 $.fn.bootstrapTable.methods.push('getCookies')
 $.fn.bootstrapTable.methods.push('deleteCookie')
 
-$.extend($.fn.bootstrapTable.utils, {
+Utils.extend($.fn.bootstrapTable.utils, {
   setCookie: UtilsCookie.setCookie,
   getCookie: UtilsCookie.getCookie
 })

--- a/src/extensions/copy-rows/bootstrap-table-copy-rows.js
+++ b/src/extensions/copy-rows/bootstrap-table-copy-rows.js
@@ -5,14 +5,14 @@
 
 const Utils = $.fn.bootstrapTable.utils
 
-$.extend($.fn.bootstrapTable.locales, {
+Utils.extend($.fn.bootstrapTable.locales, {
   formatCopyRows () {
     return 'Copy Rows'
   }
 })
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales)
+Utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales)
 
-$.extend($.fn.bootstrapTable.defaults.icons, {
+Utils.extend($.fn.bootstrapTable.defaults.icons, {
   copy: {
     bootstrap3: 'glyphicon-copy icon-pencil',
     bootstrap5: 'bi-clipboard',
@@ -36,14 +36,14 @@ const copyText = text => {
   $(textField).remove()
 }
 
-$.extend($.fn.bootstrapTable.defaults, {
+Utils.extend($.fn.bootstrapTable.defaults, {
   showCopyRows: false,
   copyWithHidden: false,
   copyDelimiter: ', ',
   copyNewline: '\n'
 })
 
-$.extend($.fn.bootstrapTable.columnDefaults, {
+Utils.extend($.fn.bootstrapTable.columnDefaults, {
   ignoreCopy: false,
   rawCopy: false
 })

--- a/src/extensions/custom-view/bootstrap-table-custom-view.js
+++ b/src/extensions/custom-view/bootstrap-table-custom-view.js
@@ -5,13 +5,13 @@
 
 const Utils = $.fn.bootstrapTable.utils
 
-$.extend($.fn.bootstrapTable.defaults, {
+Utils.extend($.fn.bootstrapTable.defaults, {
   customView: false,
   showCustomView: false,
   customViewDefaultView: false
 })
 
-$.extend($.fn.bootstrapTable.defaults.icons, {
+Utils.extend($.fn.bootstrapTable.defaults.icons, {
   customViewOn: {
     bootstrap3: 'glyphicon glyphicon-list',
     bootstrap5: 'bi-list',
@@ -32,7 +32,7 @@ $.extend($.fn.bootstrapTable.defaults.icons, {
   }[$.fn.bootstrapTable.theme] || 'fa-th'
 })
 
-$.extend($.fn.bootstrapTable.defaults, {
+Utils.extend($.fn.bootstrapTable.defaults, {
   onCustomViewPostBody () {
     return false
   },
@@ -44,7 +44,7 @@ $.extend($.fn.bootstrapTable.defaults, {
   }
 })
 
-$.extend($.fn.bootstrapTable.locales, {
+Utils.extend($.fn.bootstrapTable.locales, {
   formatToggleCustomViewOn () {
     return 'Show custom view'
   },
@@ -52,11 +52,11 @@ $.extend($.fn.bootstrapTable.locales, {
     return 'Hide custom view'
   }
 })
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales)
+Utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales)
 
 $.fn.bootstrapTable.methods.push('toggleCustomView')
 
-$.extend($.fn.bootstrapTable.Constructor.EVENTS, {
+Utils.extend($.fn.bootstrapTable.Constructor.EVENTS, {
   'custom-view-post-body.bs.table': 'onCustomViewPostBody',
   'custom-view-pre-body.bs.table': 'onCustomViewPreBody',
   'toggle-custom-view.bs.table': 'onToggleCustomView'

--- a/src/extensions/defer-url/bootstrap-table-defer-url.js
+++ b/src/extensions/defer-url/bootstrap-table-defer-url.js
@@ -13,7 +13,9 @@
  * @update zhixin wen <wenzhixin2010@gmail.com>
  */
 
-$.extend($.fn.bootstrapTable.defaults, {
+const Utils = $.fn.bootstrapTable.utils
+
+Utils.extend($.fn.bootstrapTable.defaults, {
   deferUrl: undefined
 })
 

--- a/src/extensions/editable/bootstrap-table-editable.js
+++ b/src/extensions/editable/bootstrap-table-editable.js
@@ -6,7 +6,7 @@
 
 const Utils = $.fn.bootstrapTable.utils
 
-$.extend($.fn.bootstrapTable.defaults, {
+Utils.extend($.fn.bootstrapTable.defaults, {
   editable: true,
   onEditableInit () {
     return false
@@ -22,11 +22,11 @@ $.extend($.fn.bootstrapTable.defaults, {
   }
 })
 
-$.extend($.fn.bootstrapTable.columnDefaults, {
+Utils.extend($.fn.bootstrapTable.columnDefaults, {
   alwaysUseFormatter: false
 })
 
-$.extend($.fn.bootstrapTable.Constructor.EVENTS, {
+Utils.extend($.fn.bootstrapTable.Constructor.EVENTS, {
   'editable-init.bs.table': 'onEditableInit',
   'editable-save.bs.table': 'onEditableSave',
   'editable-shown.bs.table': 'onEditableShown',

--- a/src/extensions/export/bootstrap-table-export.js
+++ b/src/extensions/export/bootstrap-table-export.js
@@ -19,7 +19,7 @@ const TYPE_NAME = {
   pdf: 'PDF'
 }
 
-$.extend($.fn.bootstrapTable.defaults, {
+Utils.extend($.fn.bootstrapTable.defaults, {
   showExport: false,
   exportDataType: 'basic', // basic, all, selected
   exportTypes: ['json', 'xml', 'csv', 'txt', 'sql', 'excel'],
@@ -27,12 +27,12 @@ $.extend($.fn.bootstrapTable.defaults, {
   exportFooter: false
 })
 
-$.extend($.fn.bootstrapTable.columnDefaults, {
+Utils.extend($.fn.bootstrapTable.columnDefaults, {
   forceExport: false,
   forceHide: false
 })
 
-$.extend($.fn.bootstrapTable.defaults.icons, {
+Utils.extend($.fn.bootstrapTable.defaults.icons, {
   export: {
     bootstrap3: 'glyphicon-export icon-share',
     bootstrap5: 'bi-download',
@@ -41,16 +41,16 @@ $.extend($.fn.bootstrapTable.defaults.icons, {
   }[$.fn.bootstrapTable.theme] || 'fa-download'
 })
 
-$.extend($.fn.bootstrapTable.locales, {
+Utils.extend($.fn.bootstrapTable.locales, {
   formatExport () {
     return 'Export data'
   }
 })
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales)
+Utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales)
 
 $.fn.bootstrapTable.methods.push('exportTable')
 
-$.extend($.fn.bootstrapTable.defaults, {
+Utils.extend($.fn.bootstrapTable.defaults, {
   // eslint-disable-next-line no-unused-vars
   onExportSaved (exportedRows) {
     return false
@@ -60,7 +60,7 @@ $.extend($.fn.bootstrapTable.defaults, {
   }
 })
 
-$.extend($.fn.bootstrapTable.Constructor.EVENTS, {
+Utils.extend($.fn.bootstrapTable.Constructor.EVENTS, {
   'export-saved.bs.table': 'onExportSaved',
   'export-started.bs.table': 'onExportStarted'
 })
@@ -237,7 +237,7 @@ $.BootstrapTable = class extends $.BootstrapTable {
         options.fileName = o.exportOptions.fileName()
       }
 
-      this.$el.tableExport($.extend({
+      this.$el.tableExport(Utils.extend({
         onAfterSaveToFile: () => {
           if (o.exportFooter) {
             this.load(data)

--- a/src/extensions/filter-control/bootstrap-table-filter-control.js
+++ b/src/extensions/filter-control/bootstrap-table-filter-control.js
@@ -6,7 +6,7 @@
 import * as UtilsFilterControl from './utils.js'
 const Utils = $.fn.bootstrapTable.utils
 
-$.extend($.fn.bootstrapTable.defaults, {
+Utils.extend($.fn.bootstrapTable.defaults, {
   filterControl: false,
   filterControlVisible: true,
   filterControlMultipleSearch: false,
@@ -62,7 +62,7 @@ $.extend($.fn.bootstrapTable.defaults, {
   _usingMultipleSelect: false
 })
 
-$.extend($.fn.bootstrapTable.columnDefaults, {
+Utils.extend($.fn.bootstrapTable.columnDefaults, {
   filterControl: undefined, // input, select, datepicker
   filterControlMultipleSelect: false,
   filterControlMultipleSelectOptions: {},
@@ -77,12 +77,12 @@ $.extend($.fn.bootstrapTable.columnDefaults, {
   filterCustomSearch: undefined
 })
 
-$.extend($.fn.bootstrapTable.Constructor.EVENTS, {
+Utils.extend($.fn.bootstrapTable.Constructor.EVENTS, {
   'column-search.bs.table': 'onColumnSearch',
   'created-controls.bs.table': 'onCreatedControls'
 })
 
-$.extend($.fn.bootstrapTable.defaults.icons, {
+Utils.extend($.fn.bootstrapTable.defaults.icons, {
   filterControlSwitchHide: {
     bootstrap3: 'glyphicon-zoom-out icon-zoom-out',
     bootstrap5: 'bi-zoom-out',
@@ -95,7 +95,7 @@ $.extend($.fn.bootstrapTable.defaults.icons, {
   }[$.fn.bootstrapTable.theme] || 'fa-search-plus'
 })
 
-$.extend($.fn.bootstrapTable.locales, {
+Utils.extend($.fn.bootstrapTable.locales, {
   formatFilterControlSwitch () {
     return 'Hide/Show controls'
   },
@@ -106,9 +106,9 @@ $.extend($.fn.bootstrapTable.locales, {
     return 'Show controls'
   }
 })
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales)
+Utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales)
 
-$.extend($.fn.bootstrapTable.defaults, {
+Utils.extend($.fn.bootstrapTable.defaults, {
   formatClearSearch () {
     return 'Clear filters'
   }

--- a/src/extensions/fixed-columns/bootstrap-table-fixed-columns.js
+++ b/src/extensions/fixed-columns/bootstrap-table-fixed-columns.js
@@ -55,7 +55,7 @@ function normalizeWheel (event) {
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, {
+Utils.extend($.fn.bootstrapTable.defaults, {
   fixedColumns: false,
   fixedNumber: 0,
   fixedRightNumber: 0

--- a/src/extensions/group-by-v2/bootstrap-table-group-by.js
+++ b/src/extensions/group-by-v2/bootstrap-table-group-by.js
@@ -3,6 +3,7 @@
  * @version: v1.1.0
  */
 
+const Utils = $.fn.bootstrapTable.utils
 let initBodyCaller
 
 const groupBy = (array, f) => {
@@ -18,7 +19,7 @@ const groupBy = (array, f) => {
   return tmpGroups
 }
 
-$.extend($.fn.bootstrapTable.defaults.icons, {
+Utils.extend($.fn.bootstrapTable.defaults.icons, {
   collapseGroup: {
     bootstrap3: 'glyphicon-chevron-up',
     bootstrap5: 'bi-chevron-up',
@@ -31,7 +32,7 @@ $.extend($.fn.bootstrapTable.defaults.icons, {
   }[$.fn.bootstrapTable.theme] || 'fa-angle-down'
 })
 
-$.extend($.fn.bootstrapTable.defaults, {
+Utils.extend($.fn.bootstrapTable.defaults, {
   groupBy: false,
   groupByField: '',
   groupByFormatter: undefined,
@@ -40,7 +41,6 @@ $.extend($.fn.bootstrapTable.defaults, {
   groupByCollapsedGroups: []
 })
 
-const Utils = $.fn.bootstrapTable.utils
 const BootstrapTable = $.fn.bootstrapTable.Constructor
 const _initSort = BootstrapTable.prototype.initSort
 const _initBody = BootstrapTable.prototype.initBody

--- a/src/extensions/key-events/bootstrap-table-key-events.js
+++ b/src/extensions/key-events/bootstrap-table-key-events.js
@@ -5,7 +5,7 @@
 
 const Utils = $.fn.bootstrapTable.utils
 
-$.extend($.fn.bootstrapTable.defaults, {
+Utils.extend($.fn.bootstrapTable.defaults, {
   keyEvents: false
 })
 

--- a/src/extensions/mobile/bootstrap-table-mobile.js
+++ b/src/extensions/mobile/bootstrap-table-mobile.js
@@ -3,6 +3,7 @@
  * @update zhixin wen <wenzhixin2010@gmail.com>
  */
 
+const Utils = $.fn.bootstrapTable.utils
 const debounce = (func, wait) => {
   let timeout = 0
 
@@ -17,7 +18,7 @@ const debounce = (func, wait) => {
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, {
+Utils.extend($.fn.bootstrapTable.defaults, {
   mobileResponsive: false,
   minWidth: 562,
   minHeight: undefined,

--- a/src/extensions/multiple-sort/bootstrap-table-multiple-sort.js
+++ b/src/extensions/multiple-sort/bootstrap-table-multiple-sort.js
@@ -8,7 +8,7 @@
 let isSingleSort = false
 const Utils = $.fn.bootstrapTable.utils
 
-$.extend($.fn.bootstrapTable.defaults.icons, {
+Utils.extend($.fn.bootstrapTable.defaults.icons, {
   plus: {
     bootstrap3: 'glyphicon-plus',
     bootstrap4: 'fa-plus',
@@ -507,7 +507,7 @@ const showSortModal = that => {
 $.fn.bootstrapTable.methods.push('multipleSort')
 $.fn.bootstrapTable.methods.push('multiSort')
 
-$.extend($.fn.bootstrapTable.defaults, {
+Utils.extend($.fn.bootstrapTable.defaults, {
   showMultiSort: false,
   showMultiSortButton: true,
   multiSortStrictSort: false,
@@ -517,11 +517,11 @@ $.extend($.fn.bootstrapTable.defaults, {
   }
 })
 
-$.extend($.fn.bootstrapTable.Constructor.EVENTS, {
+Utils.extend($.fn.bootstrapTable.Constructor.EVENTS, {
   'multiple-sort.bs.table': 'onMultipleSort'
 })
 
-$.extend($.fn.bootstrapTable.locales, {
+Utils.extend($.fn.bootstrapTable.locales, {
   formatMultipleSort () {
     return 'Multiple Sort'
   },
@@ -563,7 +563,7 @@ $.extend($.fn.bootstrapTable.locales, {
   }
 })
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales)
+Utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales)
 
 const BootstrapTable = $.fn.bootstrapTable.Constructor
 const _initToolbar = BootstrapTable.prototype.initToolbar

--- a/src/extensions/page-jump-to/bootstrap-table-page-jump-to.js
+++ b/src/extensions/page-jump-to/bootstrap-table-page-jump-to.js
@@ -5,17 +5,17 @@
 
 const Utils = $.fn.bootstrapTable.utils
 
-$.extend($.fn.bootstrapTable.defaults, {
+Utils.extend($.fn.bootstrapTable.defaults, {
   showJumpTo: false,
   showJumpToByPages: 0
 })
 
-$.extend($.fn.bootstrapTable.locales, {
+Utils.extend($.fn.bootstrapTable.locales, {
   formatJumpTo () {
     return 'GO'
   }
 })
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales)
+Utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales)
 
 $.BootstrapTable = class extends $.BootstrapTable {
   initPagination (...args) {

--- a/src/extensions/pipeline/bootstrap-table-pipeline.js
+++ b/src/extensions/pipeline/bootstrap-table-pipeline.js
@@ -49,7 +49,7 @@
 
 const Utils = $.fn.bootstrapTable.utils
 
-$.extend($.fn.bootstrapTable.defaults, {
+Utils.extend($.fn.bootstrapTable.defaults, {
   usePipeline: false,
   pipelineSize: 1000,
   // eslint-disable-next-line no-unused-vars
@@ -62,7 +62,7 @@ $.extend($.fn.bootstrapTable.defaults, {
   }
 })
 
-$.extend($.fn.bootstrapTable.Constructor.EVENTS, {
+Utils.extend($.fn.bootstrapTable.Constructor.EVENTS, {
   'cached-data-hit.bs.table': 'onCachedDataHit',
   'cached-data-reset.bs.table': 'onCachedDataReset'
 })
@@ -145,7 +145,7 @@ BootstrapTable.prototype.setCurrWindow = function (offset) {
 
 BootstrapTable.prototype.drawFromCache = function (offset, limit) {
   /* draw rows from the cache using offset and limit */
-  const res = $.extend(true, {}, this.cacheRequestJSON)
+  const res = Utils.extend(true, {}, this.cacheRequestJSON)
   const drawStart = offset - this.cacheWindows[this.currWindow].lower
   const drawEnd = drawStart + limit
 
@@ -260,7 +260,7 @@ BootstrapTable.prototype.initServer = function (silent, query, url) {
 
   data = Utils.calculateObjectValue(this.options, this.options.queryParams, [params], data)
 
-  $.extend(data, query || {})
+  Utils.extend(data, query || {})
 
   // false to stop request
   if (data === false) {
@@ -272,7 +272,7 @@ BootstrapTable.prototype.initServer = function (silent, query, url) {
   }
   const self = this
 
-  request = $.extend({}, Utils.calculateObjectValue(null, this.options.ajaxOptions), {
+  request = Utils.extend({}, Utils.calculateObjectValue(null, this.options.ajaxOptions), {
     type: this.options.method,
     url: url || this.options.url,
     data: this.options.contentType === 'application/json' && this.options.method === 'post' ?
@@ -285,7 +285,7 @@ BootstrapTable.prototype.initServer = function (silent, query, url) {
       // cache results if using pipelining
       if (self.options.usePipeline) {
         // store entire request in cache
-        self.cacheRequestJSON = $.extend(true, {}, res)
+        self.cacheRequestJSON = Utils.extend(true, {}, res)
         // this gets set in load() also but needs to be set before
         // setting cacheWindows
         self.options.totalRows = res[self.options.totalField]

--- a/src/extensions/print/bootstrap-table-print.js
+++ b/src/extensions/print/bootstrap-table-print.js
@@ -48,14 +48,14 @@ function printPageBuilderDefault (table) {
   </html>`
 }
 
-$.extend($.fn.bootstrapTable.locales, {
+Utils.extend($.fn.bootstrapTable.locales, {
   formatPrint () {
     return 'Print'
   }
 })
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales)
+Utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales)
 
-$.extend($.fn.bootstrapTable.defaults, {
+Utils.extend($.fn.bootstrapTable.defaults, {
   showPrint: false,
   printAsFilteredAndSortedOnUI: true,
   printSortColumn: undefined,
@@ -65,13 +65,13 @@ $.extend($.fn.bootstrapTable.defaults, {
   }
 })
 
-$.extend($.fn.bootstrapTable.COLUMN_DEFAULTS, {
+Utils.extend($.fn.bootstrapTable.COLUMN_DEFAULTS, {
   printFilter: undefined,
   printIgnore: false,
   printFormatter: undefined
 })
 
-$.extend($.fn.bootstrapTable.defaults.icons, {
+Utils.extend($.fn.bootstrapTable.defaults.icons, {
   print: {
     bootstrap3: 'glyphicon-print icon-share',
     bootstrap5: 'bi-printer',

--- a/src/extensions/reorder-columns/bootstrap-table-reorder-columns.js
+++ b/src/extensions/reorder-columns/bootstrap-table-reorder-columns.js
@@ -4,6 +4,8 @@
  * @version: v1.2.0
  */
 
+const Utils = $.fn.bootstrapTable.utils
+
 $.akottr.dragtable.prototype._restoreState = function (persistObj) {
   let i = 0
 
@@ -59,7 +61,7 @@ const filterFn = () => {
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, {
+Utils.extend($.fn.bootstrapTable.defaults, {
   reorderableColumns: false,
   maxMovingRows: 10,
   // eslint-disable-next-line no-unused-vars
@@ -69,7 +71,7 @@ $.extend($.fn.bootstrapTable.defaults, {
   dragaccept: null
 })
 
-$.extend($.fn.bootstrapTable.Constructor.EVENTS, {
+Utils.extend($.fn.bootstrapTable.Constructor.EVENTS, {
   'reorder-column.bs.table': 'onReorderColumn'
 })
 

--- a/src/extensions/reorder-rows/bootstrap-table-reorder-rows.js
+++ b/src/extensions/reorder-rows/bootstrap-table-reorder-rows.js
@@ -3,11 +3,12 @@
  * @update zhixin wen <wenzhixin2010@gmail.com>
  */
 
+const Utils = $.fn.bootstrapTable.utils
 const rowAttr = (row, index) => ({
   id: `customId_${index}`
 })
 
-$.extend($.fn.bootstrapTable.defaults, {
+Utils.extend($.fn.bootstrapTable.defaults, {
   reorderableRows: false,
   onDragStyle: null,
   onDropStyle: null,
@@ -32,7 +33,7 @@ $.extend($.fn.bootstrapTable.defaults, {
   }
 })
 
-$.extend($.fn.bootstrapTable.Constructor.EVENTS, {
+Utils.extend($.fn.bootstrapTable.Constructor.EVENTS, {
   'reorder-row.bs.table': 'onReorderRow'
 })
 

--- a/src/extensions/resizable/bootstrap-table-resizable.js
+++ b/src/extensions/resizable/bootstrap-table-resizable.js
@@ -3,6 +3,7 @@
  * @version: v2.0.0
  */
 
+const Utils = $.fn.bootstrapTable.utils
 const isInit = that => that.$el.data('resizableColumns') !== undefined
 
 const initResizable = that => {
@@ -29,7 +30,7 @@ const reInitResizable = that => {
   initResizable(that)
 }
 
-$.extend($.fn.bootstrapTable.defaults, {
+Utils.extend($.fn.bootstrapTable.defaults, {
   resizable: false
 })
 

--- a/src/extensions/sticky-header/bootstrap-table-sticky-header.js
+++ b/src/extensions/sticky-header/bootstrap-table-sticky-header.js
@@ -6,7 +6,7 @@
 
 const Utils = $.fn.bootstrapTable.utils
 
-$.extend($.fn.bootstrapTable.defaults, {
+Utils.extend($.fn.bootstrapTable.defaults, {
   stickyHeader: false,
   stickyHeaderOffsetY: 0,
   stickyHeaderOffsetLeft: 0,

--- a/src/extensions/toolbar/bootstrap-table-toolbar.js
+++ b/src/extensions/toolbar/bootstrap-table-toolbar.js
@@ -186,7 +186,7 @@ const theme = {
   }
 }[$.fn.bootstrapTable.theme]
 
-$.extend($.fn.bootstrapTable.defaults, {
+Utils.extend($.fn.bootstrapTable.defaults, {
   advancedSearch: false,
   idForm: 'advancedSearch',
   actionForm: '',
@@ -197,15 +197,15 @@ $.extend($.fn.bootstrapTable.defaults, {
   }
 })
 
-$.extend($.fn.bootstrapTable.defaults.icons, {
+Utils.extend($.fn.bootstrapTable.defaults.icons, {
   advancedSearchIcon: theme.icons.advancedSearchIcon
 })
 
-$.extend($.fn.bootstrapTable.Constructor.EVENTS, {
+Utils.extend($.fn.bootstrapTable.Constructor.EVENTS, {
   'column-advanced-search.bs.table': 'onColumnAdvancedSearch'
 })
 
-$.extend($.fn.bootstrapTable.locales, {
+Utils.extend($.fn.bootstrapTable.locales, {
   formatAdvancedSearch () {
     return 'Advanced search'
   },
@@ -214,7 +214,7 @@ $.extend($.fn.bootstrapTable.locales, {
   }
 })
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales)
+Utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales)
 
 $.BootstrapTable = class extends $.BootstrapTable {
   initToolbar () {

--- a/src/extensions/treegrid/bootstrap-table-treegrid.js
+++ b/src/extensions/treegrid/bootstrap-table-treegrid.js
@@ -3,7 +3,9 @@
  * @update: zhixin wen <wenzhixin2010@gmail.com>
  */
 
-$.extend($.fn.bootstrapTable.defaults, {
+const Utils = $.fn.bootstrapTable.utils
+
+Utils.extend($.fn.bootstrapTable.defaults, {
   treeEnable: false,
   treeShowField: null,
   idField: 'id',
@@ -49,7 +51,7 @@ $.BootstrapTable = class extends $.BootstrapTable {
 
     for (let i = 0; i <= len; i++) {
       const node = nodes[i]
-      const defaultItem = $.extend(true, {}, item)
+      const defaultItem = Utils.extend(true, {}, item)
 
       node._level = defaultItem._level + 1
       node._parent = defaultItem

--- a/src/locale/bootstrap-table-af-ZA.js
+++ b/src/locale/bootstrap-table-af-ZA.js
@@ -100,4 +100,4 @@ $.fn.bootstrapTable.locales['af-ZA'] = $.fn.bootstrapTable.locales['af'] = {
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['af-ZA'])
+$.fn.bootstrapTable.utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['af-ZA'])

--- a/src/locale/bootstrap-table-ar-SA.js
+++ b/src/locale/bootstrap-table-ar-SA.js
@@ -100,4 +100,4 @@ $.fn.bootstrapTable.locales['ar-SA'] = $.fn.bootstrapTable.locales['ar'] = {
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['ar-SA'])
+$.fn.bootstrapTable.utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['ar-SA'])

--- a/src/locale/bootstrap-table-bg-BG.js
+++ b/src/locale/bootstrap-table-bg-BG.js
@@ -100,4 +100,4 @@ $.fn.bootstrapTable.locales['bg-BG'] = $.fn.bootstrapTable.locales['bg'] = {
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['bg-BG'])
+$.fn.bootstrapTable.utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['bg-BG'])

--- a/src/locale/bootstrap-table-ca-ES.js
+++ b/src/locale/bootstrap-table-ca-ES.js
@@ -101,4 +101,4 @@ $.fn.bootstrapTable.locales['ca-ES'] = $.fn.bootstrapTable.locales['ca'] = {
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['ca-ES'])
+$.fn.bootstrapTable.utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['ca-ES'])

--- a/src/locale/bootstrap-table-cs-CZ.js
+++ b/src/locale/bootstrap-table-cs-CZ.js
@@ -101,4 +101,4 @@ $.fn.bootstrapTable.locales['cs-CZ'] = $.fn.bootstrapTable.locales['cs'] = {
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['cs-CZ'])
+$.fn.bootstrapTable.utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['cs-CZ'])

--- a/src/locale/bootstrap-table-da-DK.js
+++ b/src/locale/bootstrap-table-da-DK.js
@@ -100,4 +100,4 @@ $.fn.bootstrapTable.locales['da-DK'] = $.fn.bootstrapTable.locales['da'] = {
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['da-DK'])
+$.fn.bootstrapTable.utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['da-DK'])

--- a/src/locale/bootstrap-table-de-DE.js
+++ b/src/locale/bootstrap-table-de-DE.js
@@ -139,4 +139,4 @@ $.fn.bootstrapTable.locales['de-DE'] = $.fn.bootstrapTable.locales['de'] = {
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['de-DE'])
+$.fn.bootstrapTable.utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['de-DE'])

--- a/src/locale/bootstrap-table-el-GR.js
+++ b/src/locale/bootstrap-table-el-GR.js
@@ -100,4 +100,4 @@ $.fn.bootstrapTable.locales['el-GR'] = $.fn.bootstrapTable.locales['el'] = {
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['el-GR'])
+$.fn.bootstrapTable.utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['el-GR'])

--- a/src/locale/bootstrap-table-en-US.js
+++ b/src/locale/bootstrap-table-en-US.js
@@ -100,4 +100,4 @@ $.fn.bootstrapTable.locales['en-US'] = $.fn.bootstrapTable.locales['en'] = {
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['en-US'])
+$.fn.bootstrapTable.utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['en-US'])

--- a/src/locale/bootstrap-table-es-AR.js
+++ b/src/locale/bootstrap-table-es-AR.js
@@ -101,4 +101,4 @@ $.fn.bootstrapTable.locales['es-AR'] = {
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['es-AR'])
+$.fn.bootstrapTable.utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['es-AR'])

--- a/src/locale/bootstrap-table-es-CL.js
+++ b/src/locale/bootstrap-table-es-CL.js
@@ -101,4 +101,4 @@ $.fn.bootstrapTable.locales['es-CL'] = {
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['es-CL'])
+$.fn.bootstrapTable.utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['es-CL'])

--- a/src/locale/bootstrap-table-es-CR.js
+++ b/src/locale/bootstrap-table-es-CR.js
@@ -101,4 +101,4 @@ $.fn.bootstrapTable.locales['es-CR'] = {
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['es-CR'])
+$.fn.bootstrapTable.utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['es-CR'])

--- a/src/locale/bootstrap-table-es-ES.js
+++ b/src/locale/bootstrap-table-es-ES.js
@@ -100,4 +100,4 @@ $.fn.bootstrapTable.locales['es-ES'] = $.fn.bootstrapTable.locales['es'] = {
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['es-ES'])
+$.fn.bootstrapTable.utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['es-ES'])

--- a/src/locale/bootstrap-table-es-MX.js
+++ b/src/locale/bootstrap-table-es-MX.js
@@ -103,4 +103,4 @@ $.fn.bootstrapTable.locales['es-MX'] = {
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['es-MX'])
+$.fn.bootstrapTable.utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['es-MX'])

--- a/src/locale/bootstrap-table-es-NI.js
+++ b/src/locale/bootstrap-table-es-NI.js
@@ -100,4 +100,4 @@ $.fn.bootstrapTable.locales['es-NI'] = {
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['es-NI'])
+$.fn.bootstrapTable.utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['es-NI'])

--- a/src/locale/bootstrap-table-es-SP.js
+++ b/src/locale/bootstrap-table-es-SP.js
@@ -100,4 +100,4 @@ $.fn.bootstrapTable.locales['es-SP'] = {
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['es-SP'])
+$.fn.bootstrapTable.utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['es-SP'])

--- a/src/locale/bootstrap-table-et-EE.js
+++ b/src/locale/bootstrap-table-et-EE.js
@@ -100,4 +100,4 @@ $.fn.bootstrapTable.locales['et-EE'] = $.fn.bootstrapTable.locales['et'] = {
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['et-EE'])
+$.fn.bootstrapTable.utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['et-EE'])

--- a/src/locale/bootstrap-table-eu-EU.js
+++ b/src/locale/bootstrap-table-eu-EU.js
@@ -100,4 +100,4 @@ $.fn.bootstrapTable.locales['eu-EU'] = $.fn.bootstrapTable.locales['eu'] = {
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['eu-EU'])
+$.fn.bootstrapTable.utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['eu-EU'])

--- a/src/locale/bootstrap-table-fa-IR.js
+++ b/src/locale/bootstrap-table-fa-IR.js
@@ -100,4 +100,4 @@ $.fn.bootstrapTable.locales['fa-IR'] = $.fn.bootstrapTable.locales['fa'] = {
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['fa-IR'])
+$.fn.bootstrapTable.utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['fa-IR'])

--- a/src/locale/bootstrap-table-fi-FI.js
+++ b/src/locale/bootstrap-table-fi-FI.js
@@ -100,4 +100,4 @@ $.fn.bootstrapTable.locales['fi-FI'] = $.fn.bootstrapTable.locales['fi'] = {
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['fi-FI'])
+$.fn.bootstrapTable.utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['fi-FI'])

--- a/src/locale/bootstrap-table-fr-BE.js
+++ b/src/locale/bootstrap-table-fr-BE.js
@@ -101,4 +101,4 @@ $.fn.bootstrapTable.locales['fr-BE'] = {
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['fr-BE'])
+$.fn.bootstrapTable.utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['fr-BE'])

--- a/src/locale/bootstrap-table-fr-CH.js
+++ b/src/locale/bootstrap-table-fr-CH.js
@@ -100,4 +100,4 @@ $.fn.bootstrapTable.locales['fr-CH'] = {
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['fr-CH'])
+$.fn.bootstrapTable.utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['fr-CH'])

--- a/src/locale/bootstrap-table-fr-FR.js
+++ b/src/locale/bootstrap-table-fr-FR.js
@@ -102,4 +102,4 @@ $.fn.bootstrapTable.locales['fr-FR'] = $.fn.bootstrapTable.locales['fr'] = {
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['fr-FR'])
+$.fn.bootstrapTable.utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['fr-FR'])

--- a/src/locale/bootstrap-table-fr-LU.js
+++ b/src/locale/bootstrap-table-fr-LU.js
@@ -101,4 +101,4 @@ $.fn.bootstrapTable.locales['fr-LU'] = {
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['fr-LU'])
+$.fn.bootstrapTable.utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['fr-LU'])

--- a/src/locale/bootstrap-table-he-IL.js
+++ b/src/locale/bootstrap-table-he-IL.js
@@ -100,4 +100,4 @@ $.fn.bootstrapTable.locales['he-IL'] = $.fn.bootstrapTable.locales['he'] = {
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['he-IL'])
+$.fn.bootstrapTable.utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['he-IL'])

--- a/src/locale/bootstrap-table-hi-IN.js
+++ b/src/locale/bootstrap-table-hi-IN.js
@@ -104,4 +104,4 @@ $.fn.bootstrapTable.locales['hi-IN'] = {
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['hi-IN'])
+$.fn.bootstrapTable.utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['hi-IN'])

--- a/src/locale/bootstrap-table-hr-HR.js
+++ b/src/locale/bootstrap-table-hr-HR.js
@@ -101,4 +101,4 @@ $.fn.bootstrapTable.locales['hr-HR'] = $.fn.bootstrapTable.locales['hr'] = {
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['hr-HR'])
+$.fn.bootstrapTable.utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['hr-HR'])

--- a/src/locale/bootstrap-table-hu-HU.js
+++ b/src/locale/bootstrap-table-hu-HU.js
@@ -100,4 +100,4 @@ $.fn.bootstrapTable.locales['hu-HU'] = $.fn.bootstrapTable.locales['hu'] = {
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['hu-HU'])
+$.fn.bootstrapTable.utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['hu-HU'])

--- a/src/locale/bootstrap-table-id-ID.js
+++ b/src/locale/bootstrap-table-id-ID.js
@@ -100,4 +100,4 @@ $.fn.bootstrapTable.locales['id-ID'] = $.fn.bootstrapTable.locales['id'] = {
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['id-ID'])
+$.fn.bootstrapTable.utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['id-ID'])

--- a/src/locale/bootstrap-table-it-IT.js
+++ b/src/locale/bootstrap-table-it-IT.js
@@ -102,4 +102,4 @@ $.fn.bootstrapTable.locales['it-IT'] = $.fn.bootstrapTable.locales['it'] = {
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['it-IT'])
+$.fn.bootstrapTable.utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['it-IT'])

--- a/src/locale/bootstrap-table-ja-JP.js
+++ b/src/locale/bootstrap-table-ja-JP.js
@@ -100,4 +100,4 @@ $.fn.bootstrapTable.locales['ja-JP'] = $.fn.bootstrapTable.locales['ja'] = {
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['ja-JP'])
+$.fn.bootstrapTable.utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['ja-JP'])

--- a/src/locale/bootstrap-table-ka-GE.js
+++ b/src/locale/bootstrap-table-ka-GE.js
@@ -100,4 +100,4 @@ $.fn.bootstrapTable.locales['ka-GE'] = $.fn.bootstrapTable.locales['ka'] = {
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['ka-GE'])
+$.fn.bootstrapTable.utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['ka-GE'])

--- a/src/locale/bootstrap-table-ko-KR.js
+++ b/src/locale/bootstrap-table-ko-KR.js
@@ -101,4 +101,4 @@ $.fn.bootstrapTable.locales['ko-KR'] = $.fn.bootstrapTable.locales['ko'] = {
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['ko-KR'])
+$.fn.bootstrapTable.utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['ko-KR'])

--- a/src/locale/bootstrap-table-lb-LU.js
+++ b/src/locale/bootstrap-table-lb-LU.js
@@ -100,4 +100,4 @@ $.fn.bootstrapTable.locales['lb-LU'] = $.fn.bootstrapTable.locales['lb'] = {
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['lb-LU'])
+$.fn.bootstrapTable.utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['lb-LU'])

--- a/src/locale/bootstrap-table-ms-MY.js
+++ b/src/locale/bootstrap-table-ms-MY.js
@@ -100,4 +100,4 @@ $.fn.bootstrapTable.locales['ms-MY'] = $.fn.bootstrapTable.locales['ms'] = {
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['ms-MY'])
+$.fn.bootstrapTable.utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['ms-MY'])

--- a/src/locale/bootstrap-table-nb-NO.js
+++ b/src/locale/bootstrap-table-nb-NO.js
@@ -100,4 +100,4 @@ $.fn.bootstrapTable.locales['nb-NO'] = $.fn.bootstrapTable.locales['nb'] = {
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['nb-NO'])
+$.fn.bootstrapTable.utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['nb-NO'])

--- a/src/locale/bootstrap-table-nl-BE.js
+++ b/src/locale/bootstrap-table-nl-BE.js
@@ -139,4 +139,4 @@ $.fn.bootstrapTable.locales['nl-BE'] = {
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['nl-BE'])
+$.fn.bootstrapTable.utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['nl-BE'])

--- a/src/locale/bootstrap-table-nl-NL.js
+++ b/src/locale/bootstrap-table-nl-NL.js
@@ -140,4 +140,4 @@ $.fn.bootstrapTable.locales['nl-NL'] = $.fn.bootstrapTable.locales['nl'] = {
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['nl-NL'])
+$.fn.bootstrapTable.utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['nl-NL'])

--- a/src/locale/bootstrap-table-pl-PL.js
+++ b/src/locale/bootstrap-table-pl-PL.js
@@ -101,4 +101,4 @@ $.fn.bootstrapTable.locales['pl-PL'] = $.fn.bootstrapTable.locales['pl'] = {
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['pl-PL'])
+$.fn.bootstrapTable.utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['pl-PL'])

--- a/src/locale/bootstrap-table-pt-BR.js
+++ b/src/locale/bootstrap-table-pt-BR.js
@@ -103,4 +103,4 @@ $.fn.bootstrapTable.locales['pt-BR'] = {
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['pt-BR'])
+$.fn.bootstrapTable.utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['pt-BR'])

--- a/src/locale/bootstrap-table-pt-PT.js
+++ b/src/locale/bootstrap-table-pt-PT.js
@@ -100,4 +100,4 @@ $.fn.bootstrapTable.locales['pt-PT'] = $.fn.bootstrapTable.locales['pt'] = {
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['pt-PT'])
+$.fn.bootstrapTable.utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['pt-PT'])

--- a/src/locale/bootstrap-table-ro-RO.js
+++ b/src/locale/bootstrap-table-ro-RO.js
@@ -100,4 +100,4 @@ $.fn.bootstrapTable.locales['ro-RO'] = $.fn.bootstrapTable.locales['ro'] = {
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['ro-RO'])
+$.fn.bootstrapTable.utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['ro-RO'])

--- a/src/locale/bootstrap-table-ru-RU.js
+++ b/src/locale/bootstrap-table-ru-RU.js
@@ -100,4 +100,4 @@ $.fn.bootstrapTable.locales['ru-RU'] = $.fn.bootstrapTable.locales['ru'] = {
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['ru-RU'])
+$.fn.bootstrapTable.utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['ru-RU'])

--- a/src/locale/bootstrap-table-sk-SK.js
+++ b/src/locale/bootstrap-table-sk-SK.js
@@ -100,4 +100,4 @@ $.fn.bootstrapTable.locales['sk-SK'] = $.fn.bootstrapTable.locales['sk'] = {
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['sk-SK'])
+$.fn.bootstrapTable.utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['sk-SK'])

--- a/src/locale/bootstrap-table-sr-Cyrl-RS.js
+++ b/src/locale/bootstrap-table-sr-Cyrl-RS.js
@@ -100,4 +100,4 @@ $.fn.bootstrapTable.locales['sr-Cyrl-RS'] = $.fn.bootstrapTable.locales['sr'] = 
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['sr-Cyrl-RS'])
+$.fn.bootstrapTable.utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['sr-Cyrl-RS'])

--- a/src/locale/bootstrap-table-sr-Latn-RS.js
+++ b/src/locale/bootstrap-table-sr-Latn-RS.js
@@ -100,4 +100,4 @@ $.fn.bootstrapTable.locales['sr-Latn-RS'] = {
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['sr-Latn-RS'])
+$.fn.bootstrapTable.utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['sr-Latn-RS'])

--- a/src/locale/bootstrap-table-sv-SE.js
+++ b/src/locale/bootstrap-table-sv-SE.js
@@ -100,4 +100,4 @@ $.fn.bootstrapTable.locales['sv-SE'] = $.fn.bootstrapTable.locales['sv'] = {
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['sv-SE'])
+$.fn.bootstrapTable.utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['sv-SE'])

--- a/src/locale/bootstrap-table-th-TH.js
+++ b/src/locale/bootstrap-table-th-TH.js
@@ -100,4 +100,4 @@ $.fn.bootstrapTable.locales['th-TH'] = $.fn.bootstrapTable.locales['th'] = {
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['th-TH'])
+$.fn.bootstrapTable.utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['th-TH'])

--- a/src/locale/bootstrap-table-tr-TR.js
+++ b/src/locale/bootstrap-table-tr-TR.js
@@ -101,4 +101,4 @@ $.fn.bootstrapTable.locales['tr-TR'] = $.fn.bootstrapTable.locales['tr'] = {
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['tr-TR'])
+$.fn.bootstrapTable.utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['tr-TR'])

--- a/src/locale/bootstrap-table-uk-UA.js
+++ b/src/locale/bootstrap-table-uk-UA.js
@@ -100,4 +100,4 @@ $.fn.bootstrapTable.locales['uk-UA'] = $.fn.bootstrapTable.locales['uk'] = {
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['uk-UA'])
+$.fn.bootstrapTable.utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['uk-UA'])

--- a/src/locale/bootstrap-table-ur-PK.js
+++ b/src/locale/bootstrap-table-ur-PK.js
@@ -100,4 +100,4 @@ $.fn.bootstrapTable.locales['ur-PK'] = $.fn.bootstrapTable.locales['ur'] = {
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['ur-PK'])
+$.fn.bootstrapTable.utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['ur-PK'])

--- a/src/locale/bootstrap-table-uz-Latn-UZ.js
+++ b/src/locale/bootstrap-table-uz-Latn-UZ.js
@@ -100,4 +100,4 @@ $.fn.bootstrapTable.locales['uz-Latn-UZ'] = $.fn.bootstrapTable.locales['uz'] = 
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['uz-Latn-UZ'])
+$.fn.bootstrapTable.utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['uz-Latn-UZ'])

--- a/src/locale/bootstrap-table-vi-VN.js
+++ b/src/locale/bootstrap-table-vi-VN.js
@@ -100,4 +100,4 @@ $.fn.bootstrapTable.locales['vi-VN'] = $.fn.bootstrapTable.locales['vi'] = {
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['vi-VN'])
+$.fn.bootstrapTable.utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['vi-VN'])

--- a/src/locale/bootstrap-table-zh-CN.js
+++ b/src/locale/bootstrap-table-zh-CN.js
@@ -100,4 +100,4 @@ $.fn.bootstrapTable.locales['zh-CN'] = $.fn.bootstrapTable.locales['zh'] = {
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['zh-CN'])
+$.fn.bootstrapTable.utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['zh-CN'])

--- a/src/locale/bootstrap-table-zh-TW.js
+++ b/src/locale/bootstrap-table-zh-TW.js
@@ -100,4 +100,4 @@ $.fn.bootstrapTable.locales['zh-TW'] = {
   }
 }
 
-$.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['zh-TW'])
+$.fn.bootstrapTable.utils.extend($.fn.bootstrapTable.defaults, $.fn.bootstrapTable.locales['zh-TW'])

--- a/src/themes/bulma/bootstrap-table-bulma.js
+++ b/src/themes/bulma/bootstrap-table-bulma.js
@@ -4,7 +4,9 @@
  * theme: https://github.com/jgthms/bulma/
  */
 
-$.extend($.fn.bootstrapTable.defaults, {
+const Utils = $.fn.bootstrapTable.utils
+
+Utils.extend($.fn.bootstrapTable.defaults, {
   classes: 'table is-bordered is-hoverable',
   buttonsPrefix: '',
   buttonsClass: 'button'

--- a/src/themes/foundation/bootstrap-table-foundation.js
+++ b/src/themes/foundation/bootstrap-table-foundation.js
@@ -4,7 +4,9 @@
  * theme: https://github.com/zurb/foundation-sites
  */
 
-$.extend($.fn.bootstrapTable.defaults, {
+const Utils = $.fn.bootstrapTable.utils
+
+Utils.extend($.fn.bootstrapTable.defaults, {
   classes: 'table hover',
   buttonsPrefix: '',
   buttonsClass: 'button'

--- a/src/themes/materialize/bootstrap-table-materialize.js
+++ b/src/themes/materialize/bootstrap-table-materialize.js
@@ -4,7 +4,9 @@
  * theme: https://materializecss.com/
  */
 
-$.extend($.fn.bootstrapTable.defaults, {
+const Utils = $.fn.bootstrapTable.utils
+
+Utils.extend($.fn.bootstrapTable.defaults, {
   classes: 'table highlight',
   buttonsPrefix: '',
   buttonsClass: 'waves-effect waves-light btn'

--- a/src/themes/semantic/bootstrap-table-semantic.js
+++ b/src/themes/semantic/bootstrap-table-semantic.js
@@ -4,7 +4,9 @@
  * theme: https://github.com/Semantic-Org/Semantic-UI
  */
 
-$.extend($.fn.bootstrapTable.defaults, {
+const Utils = $.fn.bootstrapTable.utils
+
+Utils.extend($.fn.bootstrapTable.defaults, {
   classes: 'ui selectable celled table unstackable',
   buttonsPrefix: '',
   buttonsClass: 'ui button'

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -119,6 +119,80 @@ export default {
     return that.$toolbar.find('.search input')
   },
 
+  // $.extend: https://github.com/jquery/jquery/blob/3.6.2/src/core.js#L132
+  extend (...args) {
+    let target = args[0] || {}
+    let i = 1
+    let deep = false
+    let clone
+
+    // Handle a deep copy situation
+    if (typeof target === 'boolean') {
+      deep = target
+
+      // Skip the boolean and the target
+      target = args[i] || {}
+      i++
+    }
+
+    // Handle case when target is a string or something (possible in deep copy)
+    if (typeof target !== 'object' && typeof target !== 'function') {
+      target = {}
+    }
+
+    for (; i < args.length; i++) {
+      const options = args[i]
+
+      // Ignore undefined/null values
+      if (typeof options === 'undefined' || options === null) {
+        continue
+      }
+
+      // Extend the base object
+      // eslint-disable-next-line guard-for-in
+      for (const name in options) {
+        const copy = options[name]
+
+        // Prevent Object.prototype pollution
+        // Prevent never-ending loop
+        if (name === '__proto__' || target === copy) {
+          continue
+        }
+
+        const copyIsArray = Array.isArray(copy)
+
+        // Recurse if we're merging plain objects or arrays
+        if (deep && copy && (this.isObject(copy) || copyIsArray)) {
+          const src = target[name]
+
+          if (copyIsArray && Array.isArray(src)) {
+            if (src.every(it => !this.isObject(it) && !Array.isArray(it))) {
+              target[name] = copy
+              continue
+            }
+          }
+
+          if (copyIsArray && !Array.isArray(src)) {
+            clone = []
+          } else if (!copyIsArray && !this.isObject(src)) {
+            clone = {}
+          } else {
+            clone = src
+          }
+
+          // Never move original objects, clone them
+          target[name] = this.extend(deep, clone, copy)
+
+        // Don't bring in undefined values
+        } else if (copy !== undefined) {
+          target[name] = copy
+        }
+      }
+    }
+
+    return target
+  },
+
   // it only does '%s', and return '' when arguments are undefined
   sprintf (_str, ...args) {
     let flag = true
@@ -137,8 +211,8 @@ export default {
     return flag ? str : ''
   },
 
-  isObject (val) {
-    return val instanceof Object && !Array.isArray(val)
+  isObject (obj) {
+    return typeof obj === 'object' && obj !== null && !Array.isArray(obj)
   },
 
   isEmptyObject (obj = {}) {
@@ -546,7 +620,7 @@ export default {
     if (arg === undefined) {
       return arg
     }
-    return $.extend(true, Array.isArray(arg) ? [] : {}, arg)
+    return this.extend(true, Array.isArray(arg) ? [] : {}, arg)
   },
 
   debounce (func, wait, immediate) {

--- a/src/vue/BootstrapTable.vue
+++ b/src/vue/BootstrapTable.vue
@@ -8,7 +8,7 @@ const deepCopy = arg => {
   if (arg === undefined) {
     return arg
   }
-  return $.extend(true, Array.isArray(arg) ? [] : {}, arg)
+  return $.fn.bootstrapTable.utils.extend(true, Array.isArray(arg) ? [] : {}, arg)
 }
 
 export default {


### PR DESCRIPTION
**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [x] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**

- Fix #6448
- Fix #6557
- Fix #6348

**📝Changelog**

<!-- The type of the change. --->
- [x] **Core**
- [ ] **Extensions**

- **Update:** Updated extend util instead of $.extend.
- **Update:** - Fixed overwriting the `filterOptions` after rebuild.
- **Update(export):** Fixed `exportTypes` option not working bug.

<!-- Describe changes from the user side. -->

**💡Example(s)?**
* https://live.bootstrap-table.com/code/wenzhixin/13743
* 6557
  * Before: https://live.bootstrap-table.com/code/amorebietakoUdala/13730
  * After: https://live.bootstrap-table.com/code/wenzhixin/13744

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
