### PR TITLE
Fixed selector scope issues with multiple tables

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -2134,7 +2134,7 @@ class BootstrapTable {
 
     this.$el.css('margin-top', -this.$header.outerHeight())
 
-    const focused = $(':focus')
+    const focused = this.$tableHeader.find(':focus')
 
     if (focused.length > 0) {
       const $th = focused.parents('th')

--- a/src/extensions/filter-control/bootstrap-table-filter-control.js
+++ b/src/extensions/filter-control/bootstrap-table-filter-control.js
@@ -526,7 +526,7 @@ $.BootstrapTable = class extends $.BootstrapTable {
 
     // Controls in fixed header
     if (this.options.height) {
-      const $fixedControls = $('.fixed-table-header table thead').find('.filter-control, .no-filter-control')
+      const $fixedControls = this.$tableContainer.find('.fixed-table-header table thead').find('.filter-control, .no-filter-control')
 
       $fixedControls.toggle(this.options.filterControlVisible)
       UtilsFilterControl.fixHeaderCSS(this)

--- a/src/extensions/filter-control/utils.js
+++ b/src/extensions/filter-control/utils.js
@@ -18,7 +18,7 @@ export function getControlContainer (that) {
   }
 
   if (that.options.height && that._initialized) {
-    return $('.fixed-table-header table thead')
+    return that.$tableContainer.find('.fixed-table-header table thead')
   }
 
   return that.$header
@@ -590,7 +590,7 @@ export function syncHeaders (that) {
   if (!that.options.height) {
     return
   }
-  const fixedHeader = $('.fixed-table-header table thead')
+  const fixedHeader = that.$tableContainer.find('.fixed-table-header table thead')
 
   if (fixedHeader.length === 0) {
     return
@@ -600,7 +600,7 @@ export function syncHeaders (that) {
     if (element.classList[0] !== 'bs-checkbox') {
       const $element = $(element)
       const $field = $element.data('field')
-      const $fixedField = $(`th[data-field='${$field}']`).not($element)
+      const $fixedField = that.$tableContainer.find(`th[data-field='${$field}']`).not($element)
 
       const input = $element.find('input')
       const fixedInput = $fixedField.find('input')


### PR DESCRIPTION
**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
<!-- Please prefix each issue number with  "Fix #"  (e.g. Fix #200)  -->
Partial fix for #6561
There is still an issue that the selected options are not synced, which means the option is always empty and as described in the issue we can't select the empty value.
@djhvscf  could you check that ?

**📝Changelog**

<!-- The type of the change. --->
- [ ] **Core**
- [x] **Extensions**

<!-- Describe changes from the user side. -->
Fixed selector scope issues with multiple tables

**💡Example(s)?**
<!-- Please use our online Editor (https://live.bootstrap-table.com/) to create example(s) (Before and after your changes).
     On our Wiki (https://github.com/wenzhixin/bootstrap-table/wiki/Online-Editor-Explanation) you can read how to use the editor.-->
Before:
1. https://live.bootstrap-table.com/code/shigure-j/13748
2. https://live.bootstrap-table.com/code/shigure-j/13749

After:

1. https://live.bootstrap-table.com/code/UtechtDustin/13770
2. https://live.bootstrap-table.com/code/UtechtDustin/13771

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
