### PR TITLE
Feature/5757

### DIFF
--- a/site/docs/api/table-options.md
+++ b/site/docs/api/table-options.md
@@ -509,10 +509,25 @@ The table options are defined in `jQuery.fn.bootstrapTable.defaults`.
 - **Detail:**
 
   Escapes a string for insertion into HTML, replacing &, <, >, ", `, and ' characters.
+  To disable it for the column titles check the `escapeTitle` option.
 
 - **Default:** `false`
 
 - **Example:** [Table Escape](https://examples.bootstrap-table.com/#options/table-escape.html)
+
+## escapeTitle
+
+- **Attribute:** `data-escape-title`
+
+- **Type:** `Boolean`
+
+- **Detail:**
+
+  Toggles if the `escape` option should be applied to the column titles.
+
+- **Default:** `true`
+
+- **Example:** [Table Escape title](https://examples.bootstrap-table.com/#options/table-escape-title.html)
 
 ## filterOptions
 

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -355,7 +355,7 @@ class BootstrapTable {
         html.push(Utils.sprintf('<div class="th-inner %s">',
           this.options.sortable && column.sortable ? `sortable${columnHalign === 'center' ? ' sortable-center' : ''} both` : ''))
 
-        let text = this.options.escape ? Utils.escapeHTML(column.title) : column.title
+        let text = this.options.escape && this.options.escapeTitle ? Utils.escapeHTML(column.title) : column.title
 
         const title = text
 
@@ -3347,7 +3347,7 @@ class BootstrapTable {
     }
 
     this.columns[this.fieldsColumnsIndex[params.field]].title =
-      this.options.escape ? Utils.escapeHTML(params.title) : params.title
+      this.options.escape && this.options.escapeTitle ? Utils.escapeHTML(params.title) : params.title
 
     if (this.columns[this.fieldsColumnsIndex[params.field]].visible) {
       this.$header.find('th[data-field]').each((i, el) => {

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -210,6 +210,7 @@ const DEFAULTS = {
   showFullscreen: false,
   smartDisplay: true,
   escape: false,
+  escapeTitle: true,
   filterOptions: {
     filterAlgorithm: 'and'
   },


### PR DESCRIPTION
Ref https://github.com/wenzhixin/bootstrap-table-examples/pull/473

**🤔Type of Request**
- [ ] **Bug fix**
- [x] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
<!-- Please prefix each issue number with  "Fix #"  (e.g. Fix #200)  -->
Fix #5757

**📝Changelog**

<!-- The type of the change. --->
- [x] **Core**
- [ ] **Extensions**

<!-- Describe changes from the user side. -->
Added a new table option `escapeTitle` to toggle the`escape` option for the column titles.

**💡Example(s)?**
<!-- Please use our online Editor (https://live.bootstrap-table.com/) to create example(s) (Before and after your changes).
     On our Wiki (https://github.com/wenzhixin/bootstrap-table/wiki/Online-Editor-Explanation) you can read how to use the editor.-->
Before: https://live.bootstrap-table.com/code/UtechtDustin/13782
After: https://live.bootstrap-table.com/code/UtechtDustin/13783

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
