### PR TITLE
Escape apostrophe manually

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -407,6 +407,11 @@ export default {
     return false
   },
 
+  escapeApostrophe (value) {
+    return value.toString()
+      .replace(/'/g, '&#39;')
+  },
+
   escapeHTML (text) {
     if (!text) {
       return text
@@ -524,7 +529,7 @@ export default {
 
         const field = columns[x].field
 
-        row[field] = $el.html().trim()
+        row[field] = this.escapeApostrophe($el.html().trim())
         // save td's id, class and data-* attributes
         row[`_${field}_id`] = $el.attr('id')
         row[`_${field}_class`] = $el.attr('class')


### PR DESCRIPTION
**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
<!-- Please prefix each issue number with  "Fix #"  (e.g. Fix #200)  -->
Fix #6594 
**📝Changelog**

<!-- The type of the change. --->
- [x] **Core**
- [ ] **Extensions**

Fixed an issue with apostrophe's when the table was initialized via html.
<!-- Describe changes from the user side. -->

**💡Example(s)?**
<!-- Please use our online Editor (https://live.bootstrap-table.com/) to create example(s) (Before and after your changes).
     On our Wiki (https://github.com/wenzhixin/bootstrap-table/wiki/Online-Editor-Explanation) you can read how to use the editor.-->
Search for `'` 
Before: https://live.bootstrap-table.com/code/jnosek/13917
After: https://live.bootstrap-table.com/code/UtechtDustin/14258

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
