### PR TITLE
Fixed documentation of deprecated cookie

### DIFF
--- a/site/docs/extensions/cookie.md
+++ b/site/docs/extensions/cookie.md
@@ -178,9 +178,9 @@ toc: true
 
 - **Detail:**
 
-   Set this array with the table properties (sortOrder, sortName, sortPriority, pageNumber, pageList, hiddenColumns, columns, searchText, filterControl) that you want to save
+   Set this array with the table properties (sortOrder, sortName, sortPriority, pageNumber, pageList, hiddenColumns, searchText, filterControl) that you want to save
 
-- **Default:** `['bs.table.sortOrder', 'bs.table.sortName', 'bs.table.sortPriority', 'bs.table.pageNumber', 'bs.table.pageList', 'bs.table.hiddenColumns', 'bs.table.columns', 'bs.table.searchText', 'bs.table.filterControl', 'bs.table.cardView']`
+- **Default:** `['bs.table.sortOrder', 'bs.table.sortName', 'bs.table.sortPriority', 'bs.table.pageNumber', 'bs.table.pageList', 'bs.table.hiddenColumns', 'bs.table.searchText', 'bs.table.filterControl', 'bs.table.cardView']`
 
 ## Methods
 
@@ -209,6 +209,5 @@ toc: true
 * Sort order
 * Sort name
 * Multiple Sort order
-* Visible columns
 * Hidden columns
 * Card view state


### PR DESCRIPTION
This PR removes documentation of the old (deprecated) cookie `columns`.
The real cookie logic should be removed in the next minor version as described here: https://github.com/wenzhixin/bootstrap-table/blob/develop/src/extensions/cookie/bootstrap-table-cookie.js#L507-L509

**🤔Type of Request**
- [ ] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [x] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
<!-- Please prefix each issue number with  "Fix #"  (e.g. Fix #200)  -->
Fix #6599

**📝Changelog**

<!-- The type of the change. --->
- [ ] **Core**
- [x] **Extensions**

Removed documentation of deprecated cookies.
<!-- Describe changes from the user side. -->

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
