### PR TITLE
Fix inputs losing their content when using nested attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ ChangeLog
 - **Update:** Fixed Maximum call stack size exceeded error.
 - **Update:** Fixed getData bug with hidden rows.
 
+#### Extensions
+
+- **Update(filter-control):** Fixed inputs losing their content when using nested attributes.
+
 ### 1.21.3
 
 #### Core

--- a/src/extensions/filter-control/utils.js
+++ b/src/extensions/filter-control/utils.js
@@ -146,7 +146,7 @@ export function cacheValues (that) {
 
   searchControls.each(function () {
     let $field = $(this)
-    const fieldClass = getElementClass($field)
+    const fieldClass = escapeID(getElementClass($field))
 
     if (that.options.height && !that.options.filterControlContainer) {
       $field = that.$el.find(`.fixed-table-header .${fieldClass}`)
@@ -360,7 +360,7 @@ export function createControls (that, header) {
 
     if (
       !column.visible &&
-      !(that.options.filterControlContainer && $(`.bootstrap-table-filter-control-${column.field}`).length >= 1)
+      !(that.options.filterControlContainer && $(`.bootstrap-table-filter-control-${escapeID(column.field)}`).length >= 1)
     ) {
       return
     }
@@ -369,7 +369,7 @@ export function createControls (that, header) {
       html.push('<div class="no-filter-control"></div>')
     } else if (that.options.filterControlContainer) {
       // Use a filter control container instead of th
-      const $filterControls = $(`.bootstrap-table-filter-control-${column.field}`)
+      const $filterControls = $(`.bootstrap-table-filter-control-${escapeID(column.field)}`)
 
       $.each($filterControls, (_, filterControl) => {
         const $filterControl = $(filterControl)
@@ -523,7 +523,7 @@ export function createControls (that, header) {
     if (header.find('.date-filter-control').length > 0) {
       $.each(that.columns, (i, { filterDefault, filterControl, field, filterDatepickerOptions }) => {
         if (filterControl !== undefined && filterControl.toLowerCase() === 'datepicker') {
-          const $datepicker = header.find(`.date-filter-control.bootstrap-table-filter-control-${field}`)
+          const $datepicker = header.find(`.date-filter-control.bootstrap-table-filter-control-${escapeID(field)}`)
 
           if (filterDefault) {
             $datepicker.value(filterDefault)


### PR DESCRIPTION
**🤔Type of Request**
- [X] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
Fix #6184

**📝Changelog**
Wrap filter-control field names in escapeID() when they are used as a selector.

- [ ] **Core**
- [X] **Extensions**

<!-- Describe changes from the user side. -->
When using nested attributes in table data (containing a dot `.`) filter-control's inputs and selects will not lose their content after filtering.

**💡Example(s)?**
<!-- Please use our online Editor (https://live.bootstrap-table.com/) to create example(s) (Before and after your changes).
     On our Wiki (https://github.com/wenzhixin/bootstrap-table/wiki/Online-Editor-Explanation) you can read how to use the editor.-->
https://live.bootstrap-table.com/code/martinbarilik/11619

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
