### PR TITLE
Added searchable table option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ ChangeLog
 
 #### Core
 
+- **New:** Added searchable table option to enable sending searchable (columns) parameters.
 - **Update:** Fixed Maximum call stack size exceeded error.
 - **Update:** Fixed getData bug with hidden rows.
 - **Update:** Added support for `select` form to the `searchSelector` option.

--- a/site/docs/api/table-options.md
+++ b/site/docs/api/table-options.md
@@ -1196,10 +1196,25 @@ The table options are defined in `jQuery.fn.bootstrapTable.defaults`.
   Notes:
   - If you want to use a custom search input, use the [searchSelector](https://bootstrap-table.com/docs/api/table-options/#searchSelector).
   - You can also search via regex using the [regexSearch](https://bootstrap-table.com/docs/api/table-options/#regexSearch) option.
+  - If you want to send searchable params to server-side pagination, use the [searchable](https://bootstrap-table.com/docs/api/table-options/#searchable) option.
 
 - **Default:** `false`
 
 - **Example:** [Table Search](https://examples.bootstrap-table.com/#options/table-search.html)
+
+## searchable
+
+- **Attribute:** `data-searchable`
+
+- **Type:** `Boolean`
+
+- **Detail:**
+
+  Set `true` to send [searchable params](https://bootstrap-table.com/docs/api/column-options/#searchable) to the server while using server-side pagination.
+
+- **Default:** `false`
+
+- **Example:** [Searchable](https://examples.bootstrap-table.com/#options/searchable.html)
 
 ## searchAccentNeutralise
 

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1977,6 +1977,7 @@ class BootstrapTable {
     if (
       this.options.search &&
       this.options.sidePagination === 'server' &&
+      this.options.searchable &&
       this.columns.filter(column => column.searchable).length
     ) {
       params.searchable = []

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -179,6 +179,7 @@ const DEFAULTS = {
   paginationPagesBySide: 1, // Number of pages on each side (right, left) of the current page.
   paginationUseIntermediate: false, // Calculate intermediate pages for quick access
   search: false,
+  searchable: false,
   searchHighlight: false,
   searchOnEnterKey: false,
   strictSearch: false,


### PR DESCRIPTION
After the change in #6573, the latest version now sends searchable params to server-side pagination by default.
<img width="156" alt="image" src="https://user-images.githubusercontent.com/8064215/228093183-6cf4ee9f-91fe-41b3-9466-8bb0ae448f43.png">

This will cause unknown errors such as 400 (Bad Request). 

In previous versions <= `v1.23.2`, there was no such behavior.
<img width="149" alt="image" src="https://user-images.githubusercontent.com/8064215/228094327-08dd82c6-93dc-46c3-9323-aa94c313b594.png">

According to the instructions in the documentation and to maintain the original behavior, we need to disable this feature by default, and then set it to `true` to turn it on if necessary. 

So the `searchable` option (consistent with the column option) was added to control it.

---

**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
Fix #6573 

Added `searchable` table option to disable sending searchable params by default.

<!-- The type of the change. --->
- [x] **Core**
- [ ] **Extensions**

<!-- Describe changes from the user side. -->

**💡Example(s)?**
* 1.23.3: https://live.bootstrap-table.com/example/welcome.html
* <= 1.23.2: https://live.bootstrap-table.com/code/fish-fly/14835
* Fixed: https://live.bootstrap-table.com/code/fish-fly/14836 


**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
