### PR TITLE
Fixed reorder row bug when side-pagination is server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ ChangeLog
 #### Extensions
 
 - **Update(filter-control):** Fixed inputs losing their content when using nested attributes.
+- **Update(reorder-rows):** Fixed reorder row bug when side-pagination is server.
 
 ### 1.21.3
 

--- a/src/extensions/reorder-rows/bootstrap-table-reorder-rows.js
+++ b/src/extensions/reorder-rows/bootstrap-table-reorder-rows.js
@@ -116,6 +116,10 @@ $.BootstrapTable = class extends $.BootstrapTable {
 
     this.initSearch()
 
+    if (this.options.sidePagination === 'server') {
+      this.data = [...this.options.data]
+    }
+
     // Call the user defined function
     this.options.onReorderRowsDrop(droppedRow)
 


### PR DESCRIPTION
**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
Fix #6698 

**📝Changelog**

<!-- The type of the change. --->
- [ ] **Core**
- [x] **Extensions**

Fixed reorder row bug when side-pagination is server

**💡Example(s)?**
* Bug: https://live.bootstrap-table.com/code/fish-fly/14844
* Fixed: https://live.bootstrap-table.com/code/fish-fly/14845

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
