### PR TITLE
Added support for `class` attribute in toolbar buttons.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ ChangeLog
 #### Core
 
 - **New:** Added `sortBy` method.
+- **Update** Added support for `class` attribute in toolbar buttons.
 
 #### Extensions
 

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -747,6 +747,7 @@ class BootstrapTable {
         }
       } else {
         let buttonClass = this.constants.buttonsClass
+
         if (buttonConfig.hasOwnProperty('attributes') && buttonConfig.attributes.class) {
           buttonClass += ` ${buttonConfig.attributes.class}`
         }

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -746,10 +746,10 @@ class BootstrapTable {
           buttonHtml = buttonConfig.html
         }
       } else {
-        if (buttonConfig.hasOwnProperty('attributes')) {
-          let buttonClass = buttonConfig.attributes.class || ''
+        let buttonClass = this.constants.buttonsClass
+        if (buttonConfig.hasOwnProperty('attributes') && buttonConfig.attributes.class) {
+          buttonClass += ` ${buttonConfig.attributes.class}`
         }
-        buttonClass += ` ${this.constants.buttonsClass}`
         buttonHtml = `<button class="${buttonClass}" type="button" name="${buttonName}"`
 
         if (buttonConfig.hasOwnProperty('attributes')) {

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -754,6 +754,9 @@ class BootstrapTable {
 
         if (buttonConfig.hasOwnProperty('attributes')) {
           for (const [attributeName, value] of Object.entries(buttonConfig.attributes)) {
+            if (attributeName === 'class') {
+              continue
+            }
             buttonHtml += ` ${attributeName}="${value}"`
           }
         }

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -746,7 +746,11 @@ class BootstrapTable {
           buttonHtml = buttonConfig.html
         }
       } else {
-        buttonHtml = `<button class="${this.constants.buttonsClass}" type="button" name="${buttonName}"`
+        if (buttonConfig.hasOwnProperty('attributes')) {
+          let buttonClass = buttonConfig.attributes.class || ''
+        }
+        buttonClass += ` ${this.constants.buttonsClass}`
+        buttonHtml = `<button class="${buttonClass}" type="button" name="${buttonName}"`
 
         if (buttonConfig.hasOwnProperty('attributes')) {
           for (const [attributeName, value] of Object.entries(buttonConfig.attributes)) {


### PR DESCRIPTION
**🤔Type of Request**
- [ ] **Bug fix**
- [ ] **New feature**
- [x] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**

**📝Changelog**

<!-- The type of the change. --->
- [x] **Core**
- [ ] **Extensions**

<!-- Describe changes from the user side. -->

E.g. when having a custom button like:

```
      buttons: {
        filters: {
          text: 'Show filters',
          icon: 'bi-funnel',
          event: () => alert('Show filters'),
          attributes: {
            title: 'Show filters',
            class: 'd-lg-none',
          },
        },
      },
```

The `class` attribute would have been ignored (as it would add 2 class attributes to the html effectively).

This PR adds the defined `class` attribute correctly to the button html.

**💡Example(s)?**

https://live.bootstrap-table.com/code/marceloverdijk/15596

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
