### PR TITLE
Removed title from Columns button outer div

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -670,7 +670,7 @@ class BootstrapTable {
         html: () => {
           const html = []
 
-          html.push(`<div class="keep-open ${this.constants.classes.buttonsDropdown}" title="${opts.formatColumns()}">
+          html.push(`<div class="keep-open ${this.constants.classes.buttonsDropdown}">
             <button class="${this.constants.buttonsClass} dropdown-toggle" type="button" ${this.constants.dataToggle}="dropdown"
             aria-label="${opts.formatColumns()}" title="${opts.formatColumns()}">
             ${opts.showButtonIcons ? Utils.sprintf(this.constants.html.icon, opts.iconsPrefix, opts.icons.columns) : ''}


### PR DESCRIPTION
**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**

No issue available.

**📝Changelog**

<!-- The type of the change. --->
- [x] **Core**
- [ ] **Extensions**

<!-- Describe changes from the user side. -->

As can be seen in the example https://examples.bootstrap-table.com/#options/basic-columns.html when opening the Columns dropdown and keeping the mouse on one of the fields , it will show the unwanted "Columns" title.
This because it is on the whole div dropdown.

<img width="187" alt="image" src="https://github.com/wenzhixin/bootstrap-table/assets/197004/04749041-4047-45ea-b82c-b548bafdf918">

It is sufficient to have the title attribute with value "Columns" only on the actual button displayed in the toolbar (which already have it). 

**💡Example(s)?**

See [this](https://live.bootstrap-table.com/code/marceloverdijk/15626) example with the fix applied, which does only show the title for the button, but not for the whole anymore.

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [ ] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
