### PR TITLE
Fixed searchAccentNeutralise option not work in filter-control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 ChangeLog
 ---------
 
+### 1.22.2
+
+#### Extensions
+
+- **Update(filter-control):** Fixed `searchAccentNeutralise` option not work.
+
 ### 1.22.1
 
 #### Core

--- a/src/extensions/filter-control/bootstrap-table-filter-control.js
+++ b/src/extensions/filter-control/bootstrap-table-filter-control.js
@@ -298,6 +298,10 @@ $.BootstrapTable = class extends $.BootstrapTable {
       value = Utils.removeHTML(value.toString().toLowerCase())
     }
 
+    if (this.options.searchAccentNeutralise) {
+      value = Utils.normalizeAccent(value)
+    }
+
     if (
       column.filterStrictSearch ||
       column.filterControl === 'select' && column.passed.filterStrictSearch !== false


### PR DESCRIPTION
**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
Fix #6865 

**📝Changelog**

<!-- The type of the change. --->
- [ ] **Core**
- [x] **Extensions**

Fixed `searchAccentNeutralise` option not work in filter-control

**💡Example(s)?**

Before: https://live.bootstrap-table.com/code/mgonzalez-dev/15721
After: https://live.bootstrap-table.com/code/wenzhixin/15790

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
