### PR TITLE
Fixed export-saved event error when exportDataType is all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ ChangeLog
 
 #### Extensions
 
+- **Update(editable):** Fixed `export-saved` event error when `exportDataType` is `all`.
 - **Update(filter-control):** Fixed `searchAccentNeutralise` option not work.
 
 ### 1.22.1

--- a/src/extensions/export/bootstrap-table-export.js
+++ b/src/extensions/export/bootstrap-table-export.js
@@ -274,15 +274,17 @@ $.BootstrapTable = class extends $.BootstrapTable {
 
       this.$el.one(eventName, () => {
         setTimeout(() => {
+          const data = this.getData()
+
           doExport(() => {
             this.options.virtualScroll = virtualScroll
             this.togglePagination()
           })
+          this.trigger('export-saved', data)
         }, 0)
       })
       this.options.virtualScroll = false
       this.togglePagination()
-      this.trigger('export-saved', this.getData())
     } else if (o.exportDataType === 'selected') {
       let data = this.getData()
       let selectedData = this.getSelections()


### PR DESCRIPTION
**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
Fix #6743

**📝Changelog**

<!-- The type of the change. --->
- [ ] **Core**
- [x] **Extensions**

Fixed `export-saved` event error when `exportDataType` is `all`

**💡Example(s)?**
Before: https://live.bootstrap-table.com/code/chavus/14984
After: https://live.bootstrap-table.com/code/wenzhixin/15809

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
