### PR TITLE
Fix rows reorder when pagination is applied.

### DIFF
--- a/src/extensions/reorder-rows/bootstrap-table-reorder-rows.js
+++ b/src/extensions/reorder-rows/bootstrap-table-reorder-rows.js
@@ -97,6 +97,8 @@ $.BootstrapTable = class extends $.BootstrapTable {
 
   onDrop (table) {
     this.$draggingTd.css('cursor', '')
+    const pageNum = $(table).bootstrapTable('getOptions').pageNumber;
+    const pageSize = $(table).bootstrapTable('getOptions').pageSize;
     const newData = []
 
     for (let i = 0; i < table.tBodies[0].rows.length; i++) {
@@ -109,7 +111,7 @@ $.BootstrapTable = class extends $.BootstrapTable {
     const draggingRow = this.data[this.draggingIndex]
     const droppedIndex = newData.indexOf(this.data[this.draggingIndex])
     const droppedRow = this.data[droppedIndex]
-    const index = this.options.data.indexOf(this.data[droppedIndex])
+    const index = ((pageNum - 1)*pageSize) + this.options.data.indexOf(this.data[droppedIndex])
 
     this.options.data.splice(this.options.data.indexOf(draggingRow), 1)
     this.options.data.splice(index, 0, draggingRow)

--- a/src/extensions/reorder-rows/bootstrap-table-reorder-rows.js
+++ b/src/extensions/reorder-rows/bootstrap-table-reorder-rows.js
@@ -112,7 +112,7 @@ $.BootstrapTable = class extends $.BootstrapTable {
     const draggingRow = this.data[this.draggingIndex]
     const droppedIndex = newData.indexOf(this.data[this.draggingIndex])
     const droppedRow = this.data[droppedIndex]
-    const index = ((pageNum - 1)*pageSize) + this.options.data.indexOf(this.data[droppedIndex])
+    const index = (pageNum - 1) * pageSize + this.options.data.indexOf(this.data[droppedIndex])
 
     this.options.data.splice(this.options.data.indexOf(draggingRow), 1)
     this.options.data.splice(index, 0, draggingRow)

--- a/src/extensions/reorder-rows/bootstrap-table-reorder-rows.js
+++ b/src/extensions/reorder-rows/bootstrap-table-reorder-rows.js
@@ -97,7 +97,6 @@ $.BootstrapTable = class extends $.BootstrapTable {
 
   onDrop (table) {
     this.$draggingTd.css('cursor', '')
-    const pageNum = $(table).bootstrapTable('getOptions').pageNumber;
     const pageNum = this.options.pageNumber
     const pageSize = this.options.pageSize
     const newData = []

--- a/src/extensions/reorder-rows/bootstrap-table-reorder-rows.js
+++ b/src/extensions/reorder-rows/bootstrap-table-reorder-rows.js
@@ -98,7 +98,8 @@ $.BootstrapTable = class extends $.BootstrapTable {
   onDrop (table) {
     this.$draggingTd.css('cursor', '')
     const pageNum = $(table).bootstrapTable('getOptions').pageNumber;
-    const pageSize = $(table).bootstrapTable('getOptions').pageSize;
+    const pageNum = this.options.pageNumber
+    const pageSize = this.options.pageSize
     const newData = []
 
     for (let i = 0; i < table.tBodies[0].rows.length; i++) {


### PR DESCRIPTION
When the pagination is activated and the rows are reordered on pages other than the first one, the order was not taking into account the page number and the page size. This commit changes the index at which the row needs to be inserted by accounting for the page size and page number.

**🤔Type of Request**
- [x] **Bug fix**


**📝Changelog**

<!-- The type of the change. --->
- [x] **Extensions**
