### PR TITLE
Fixed filter order by column option

### DIFF
--- a/src/extensions/filter-control/utils.js
+++ b/src/extensions/filter-control/utils.js
@@ -333,7 +333,7 @@ export function initFilterSelectControls (that) {
       }
 
       if (that.options.sortSelectOptions) {
-        sortSelectControl(selectControl, 'asc', that.options)
+        sortSelectControl(selectControl, column.filterOrderBy, that.options)
       }
     }
   })


### PR DESCRIPTION
**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
<!-- Please prefix each issue number with  "Fix #"  (e.g. Fix #200)  -->
Fix #6992 

**📝Changelog**

<!-- The type of the change. --->
- [ ] **Core**
- [x] **Extensions**

Fixed bug for option `filterOrderBy` that prevented the option from being usable
<!-- Describe changes from the user side. -->

**💡Example(s)?**
Before: https://live.bootstrap-table.com/code/UtechtDustin/16251
After: https://live.bootstrap-table.com/code/UtechtDustin/16252

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
