### PR TITLE
Column-specific footerStyle added

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -75,6 +75,7 @@ export interface BootstrapTableColumn {
   cellStyle?: any;
   searchable?: boolean;
   footerFormatter?: any;
+  footerStyle?: any;
   formatter?: any;
   checkboxEnabled?: boolean;
   field?: any;

--- a/site/docs/api/column-options.md
+++ b/site/docs/api/column-options.md
@@ -238,6 +238,33 @@ The column options is defined in `jQuery.fn.bootstrapTable.columnDefaults`.
 
 - **Example:** [Footer Formatter](https://examples.bootstrap-table.com/#column-options/footer-formatter.html)
 
+## footerStyle
+
+- **Attribute:** `data-footer-style`
+
+- **Type:** `Function`
+
+- **Detail:**
+
+  The footer style formatter function, takes one parameter:
+
+  * `column`: the column object.
+
+  Support `classes` or `css`. Example usage:
+
+  {% highlight javascript %}
+  function footerStyle(column) {
+    return {
+      css: { 'font-weight': 'normal' },
+      classes: 'my-class'
+    }
+  }
+  {% endhighlight %}
+
+- **Default:** `{}`
+
+- **Example:** [Footer Style](https://examples.bootstrap-table.com/#options/footer-style.html)
+
 ## formatter
 
 - **Attribute:** `data-formatter`

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -2292,7 +2292,7 @@ class BootstrapTable {
       falign = Utils.sprintf('text-align: %s; ', column.falign ? column.falign : column.align)
       valign = Utils.sprintf('vertical-align: %s; ', column.valign)
 
-      style = Utils.calculateObjectValue(null, this.options.footerStyle, [column])
+      style = Utils.calculateObjectValue(null, column.footerStyle || this.options.footerStyle, [column])
 
       if (style && style.css) {
         for (const [key, value] of Object.entries(style.css)) {

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -447,6 +447,7 @@ const COLUMN_DEFAULTS = {
   searchable: true,
   formatter: undefined,
   footerFormatter: undefined,
+  footerStyle: undefined,
   detailFormatter: undefined,
   searchFormatter: true,
   searchHighlightFormatter: false,


### PR DESCRIPTION
**🤔Type of Request**
- [ ] **Bug fix**
- [x] **New feature**
- [x] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
No
<!-- Please prefix each issue number with  "Fix #"  (e.g. Fix #200)  -->

**📝Changelog**
Makes the footerStyle property available on columns, as an override of the table footerStyle property

<!-- The type of the change. --->
- [x] **Core**
- [ ] **Extensions**

<!-- Describe changes from the user side. -->
Our team uses bootstrap-table on a variety of pages, so we've taken to making global formatters to use wherever. This works great for cell formatters (date, currency, etc...), footer formatters (sums mostly), and cell styles (colors, backgrounds).
These three properties are defined at the column level. The footerStyle property is an outlier, being defined for the entire table. 

The column being passed to the callback as an argument feels like a workaround to apply different styles to different columns. It makes it difficult to create global formatters that include column-specific styles, because the column-specific logic has to be part of the function, and not the definition of the table. I hope I'm managing to convey the idea correctly.

This small ajustment allows defining the footerStyle on the column.

Naturally, the property can still be defined on the whole table, and this change will not break existing tables. This pull requests simply makes the property available on columns, in which case it'll override the global style formatter.

**💡Example(s)?**
Using both table-level and column-level footer styles: https://live.bootstrap-table.com/code/Blue3957/16322
<!-- Please use our online Editor (https://live.bootstrap-table.com/) to create example(s) (Before and after your changes).
     On our Wiki (https://github.com/wenzhixin/bootstrap-table/wiki/Online-Editor-Explanation) you can read how to use the editor.-->

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
