### PR TITLE
Fixed moment of sort trigger

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -577,8 +577,6 @@ class BootstrapTable {
   }
 
   _sort () {
-    this.trigger('sort', this.options.sortName, this.options.sortOrder)
-
     if (this.options.sidePagination === 'server' && this.options.serverSort) {
       this.options.pageNumber = 1
       this.initServer(this.options.silentSort)
@@ -589,6 +587,8 @@ class BootstrapTable {
       this.options.pageNumber = 1
       this.initPagination()
     }
+
+    this.trigger('sort', this.options.sortName, this.options.sortOrder)
 
     this.initSort()
     this.initBody()


### PR DESCRIPTION
**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**

I noticed the 'sort' event was triggered a bit to early.

In my case I have `this.options.sortResetPage = true` which resets the page after sorting.
As the event was triggered before this when listening to the event the `this.options.pageNumber` was not yet updated.

**📝Changelog**

<!-- The type of the change. --->
- [x] **Core**
- [ ] **Extensions**

<!-- Describe changes from the user side. -->

**💡Example(s)?**
<!-- Please use our online Editor (https://live.bootstrap-table.com/) to create example(s) (Before and after your changes).
     On our Wiki (https://github.com/wenzhixin/bootstrap-table/wiki/Online-Editor-Explanation) you can read how to use the editor.-->

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [ ] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
