### PR TITLE
Fix #5713 set caret position to the end of input value

### DIFF
--- a/dist/extensions/filter-control/bootstrap-table-filter-control.js
+++ b/dist/extensions/filter-control/bootstrap-table-filter-control.js
@@ -4394,6 +4394,10 @@
             callbacks.push(fieldToFocusCallback);
           }
         }
+        // fix #5713
+        if ($this[0] === document.activeElement) {
+          setCaretPosition($this[0], $this[0].value.length);
+        }
       });
 
       // Callback call.


### PR DESCRIPTION
**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
<!-- Please prefix each issue number with  "Fix #"  (e.g. Fix #200)  -->
Fix #5713 

**📝Changelog**

<!-- The type of the change. --->
- [ ] **Core**
- [x] **Extensions**

<!-- Describe changes from the user side. -->

**💡Example(s)?**
<!-- Please use our online Editor (https://live.bootstrap-table.com/) to create example(s) (Before and after your changes).
     On our Wiki (https://github.com/wenzhixin/bootstrap-table/wiki/Online-Editor-Explanation) you can read how to use the editor.-->

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
