### PR TITLE
When searching do not split header field by '.' if there is such property in the item.

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1072,7 +1072,7 @@ class BootstrapTable {
           const column = this.columns[this.fieldsColumnsIndex[key]]
           let value
 
-          if (typeof key === 'string') {
+          if (typeof key === 'string' && !item.hasOwnProperty(key)) {
             value = item
             const props = key.split('.')
 


### PR DESCRIPTION
When searching do not split header field by '.' if there is such property in the item.