### PR TITLE
Fix set all parameters of sorter function from multi-sort extension

### DIFF
--- a/src/extensions/multiple-sort/bootstrap-table-multiple-sort.js
+++ b/src/extensions/multiple-sort/bootstrap-table-multiple-sort.js
@@ -715,8 +715,8 @@ BootstrapTable.prototype.onMultipleSort = function () {
       const order = that.options.sortPriority[i].sortOrder === 'desc' ? -1 : 1
       let aa = Utils.getItemField(a, fieldName)
       let bb = Utils.getItemField(b, fieldName)
-      const value1 = $.fn.bootstrapTable.utils.calculateObjectValue(that.header, sorterName, [aa, bb])
-      const value2 = $.fn.bootstrapTable.utils.calculateObjectValue(that.header, sorterName, [bb, aa])
+      const value1 = $.fn.bootstrapTable.utils.calculateObjectValue(that.header, sorterName, [aa, bb, a, b])
+      const value2 = $.fn.bootstrapTable.utils.calculateObjectValue(that.header, sorterName, [bb, aa, b, a])
 
       if (value1 !== undefined && value2 !== undefined) {
         arr1.push(order * value1)


### PR DESCRIPTION
**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
Fix #7213 

**📝Changelog**
Add missing parameters to sorter function from multi-sort extension

<!-- The type of the change. --->
- [ ] **Core**
- [x] **Extensions**

<!-- Describe changes from the user side. -->

**💡Example(s)?**
No need, its all according to the documentation.

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
