### PR TITLE
Added copyRowsHandler option to handle the copy rows data

### DIFF
--- a/site/docs/extensions/copy-rows.md
+++ b/site/docs/extensions/copy-rows.md
@@ -28,7 +28,7 @@ This extension adds functionality for copying selected rows to the clipboard. Cu
 
 - **Detail:**
 
-   Set `true` to show the copy button. This button copy the contents of the selected rows to the clipboard.
+  Set `true` to show the copy button. This button copy the contents of the selected rows to the clipboard.
 
 - **Default:** `false`
 
@@ -52,7 +52,7 @@ This extension adds functionality for copying selected rows to the clipboard. Cu
 
 - **Detail:**
 
-   This newline will be inserted in-between the row values when copying.
+  This newline will be inserted in-between the row values when copying.
 
 - **Default:** `'\n'`
 
@@ -64,9 +64,23 @@ This extension adds functionality for copying selected rows to the clipboard. Cu
 
 - **Detail:**
 
-   Set `true` to copy with hidden columns.
+  Set `true` to copy with hidden columns.
 
 - **Default:** `false`
+
+### copyRowsHandler
+
+- **Attribute:** `data-copy-rows-handler
+
+- **type:** `Function`
+
+- **Detail:**
+
+  Before copying rows, handle the copying rows data. The parameters object contains:
+
+  * `text`: the copy rows data.
+
+- **Default:** `function(text) { return text }`
 
 ## Column options
 
@@ -90,7 +104,7 @@ This extension adds functionality for copying selected rows to the clipboard. Cu
 
 - **Detail:**
 
-  Set `true` to copy the raw value instead the formatted one.   
+  Set `true` to copy the raw value instead the formatted one.
   If no formatter is used, this option has no effect.
 
 - **Default:** `false`

--- a/src/extensions/copy-rows/bootstrap-table-copy-rows.js
+++ b/src/extensions/copy-rows/bootstrap-table-copy-rows.js
@@ -40,7 +40,10 @@ Object.assign($.fn.bootstrapTable.defaults, {
   showCopyRows: false,
   copyWithHidden: false,
   copyDelimiter: ', ',
-  copyNewline: '\n'
+  copyNewline: '\n',
+  copyRowsHandler (text) {
+    return text
+  }
 })
 
 Object.assign($.fn.bootstrapTable.columnDefaults, {
@@ -80,26 +83,31 @@ $.BootstrapTable = class extends $.BootstrapTable {
   copyColumnsToClipboard () {
     const rows = []
 
-    $.each(this.getSelections(), (index, row) => {
+    for (const row of this.getSelections()) {
       const cols = []
 
-      $.each(this.options.columns[0], (indy, column) => {
+      this.options.columns[0].forEach((column, index) => {
         if (
           column.field !== this.header.stateField &&
           (!this.options.copyWithHidden || this.options.copyWithHidden && column.visible) &&
           !column.ignoreCopy
         ) {
           if (row[column.field] !== null) {
-            const columnValue = column.rawCopy ? row[column.field] : Utils.calculateObjectValue(column, this.header.formatters[indy], [row[column.field], row, index], row[column.field])
+            const columnValue = column.rawCopy ? row[column.field] :
+              Utils.calculateObjectValue(column, this.header.formatters[index], [row[column.field], row, index], row[column.field])
 
             cols.push(columnValue)
           }
         }
       })
       rows.push(cols.join(this.options.copyDelimiter))
-    })
+    }
 
-    copyText(rows.join(this.options.copyNewline))
+    let text = rows.join(this.options.copyNewline)
+
+    text = Utils.calculateObjectValue(this.options, this.options.copyRowsHandler, [text], text)
+
+    copyText(text)
   }
 
   updateSelected () {


### PR DESCRIPTION
**🤔Type of Request**
- [ ] **Bug fix**
- [x] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
Fix #7221

**📝Changelog**

<!-- The type of the change. --->
- [ ] **Core**
- [x] **Extensions**

Added `copyRowsHandler` option to handle the copy rows data.

**💡Example(s)?**
https://live.bootstrap-table.com/code/wenzhixin/17274

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
