### PR TITLE
Allow uniqueId to be a mix of numbers and strings.

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -2662,12 +2662,12 @@ class BootstrapTable {
       }
 
       if (typeof rowUniqueId === 'string') {
-        id = id.toString()
+        id = _id.toString()
       } else if (typeof rowUniqueId === 'number') {
         if (Number(rowUniqueId) === rowUniqueId && rowUniqueId % 1 === 0) {
-          id = parseInt(id, 10)
+          id = parseInt(_id, 10)
         } else if (rowUniqueId === Number(rowUniqueId) && rowUniqueId !== 0) {
-          id = parseFloat(id)
+          id = parseFloat(_id)
         }
       }
 


### PR DESCRIPTION
If some rows have the uniqueId as a number and some rows have it as a string, the code would try to convert the id being searched to a number, which would result in a NaN if it was a string. This would then fail to match any rows.
The proper fix is to always use the original _id value to convert to the appropriate type for the comparison.

**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
<!-- Please prefix each issue number with  "Fix #"  (e.g. Fix #200)  -->

**📝Changelog**

<!-- The type of the change. --->
- [x] **Core**
- [ ] **Extensions**

<!-- Describe changes from the user side. -->

**💡Example(s)?**
<!-- Please use our online Editor (https://live.bootstrap-table.com/) to create example(s) (Before and after your changes).
     On our Wiki (https://github.com/wenzhixin/bootstrap-table/wiki/Online-Editor-Explanation) you can read how to use the editor.-->

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
