### PR TITLE
Fixed not trigger sort event bug using server-side pagination

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -583,6 +583,8 @@ class BootstrapTable {
   _sort () {
     if (this.options.sidePagination === 'server' && this.options.serverSort) {
       this.options.pageNumber = 1
+
+      this.trigger('sort', this.options.sortName, this.options.sortOrder)
       this.initServer(this.options.silentSort)
       return
     }
@@ -593,7 +595,6 @@ class BootstrapTable {
     }
 
     this.trigger('sort', this.options.sortName, this.options.sortOrder)
-
     this.initSort()
     this.initBody()
   }


### PR DESCRIPTION
**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
Fix #7252

**📝Changelog**

<!-- The type of the change. --->
- [x] **Core**
- [ ] **Extensions**

Fixed not trigger sort event bug using server-side pagination.

**💡Example(s)?**
Before: https://live.bootstrap-table.com/code/merinosky/17358
After: https://live.bootstrap-table.com/code/wenzhixin/17359

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
