### PR TITLE
Possibility to modify/process loaded data before rendering into the t…

### DIFF
--- a/site/docs/api/events.md
+++ b/site/docs/api/events.md
@@ -215,9 +215,9 @@ $('#table').on('event-name.bs.table', function (e, arg1, arg2, ...) {
 
 - **Detail:**
 
-  It fires when remote data is loaded successfully. The parameters contain:
+  It fires when remote data is loaded successfully, before the data rendered in the table. The parameters contain:
 
-  * `data`: the remote data.
+  * `data`: the remote data. It can be modified (processed) in this event handler before actual loading into the table.
   * `status`: the status code of `jqXHR`.
   * `jqXHR`: jqXHR object, which is a super set of the XMLHTTPRequest object. For more information, see the [jqXHR Type](http://api.jquery.com/Types/#jqXHR).
 

--- a/site/docs/api/events.md
+++ b/site/docs/api/events.md
@@ -215,9 +215,9 @@ $('#table').on('event-name.bs.table', function (e, arg1, arg2, ...) {
 
 - **Detail:**
 
-  It fires when remote data is loaded successfully, before the data rendered in the table. The parameters contain:
+  It fires when remote data is loaded successfully. The parameters contain:
 
-  * `data`: the remote data. It can be modified (processed) in this event handler before actual loading into the table.
+  * `data`: the remote data.
   * `status`: the status code of `jqXHR`.
   * `jqXHR`: jqXHR object, which is a super set of the XMLHTTPRequest object. For more information, see the [jqXHR Type](http://api.jquery.com/Types/#jqXHR).
 

--- a/site/docs/api/events.md
+++ b/site/docs/api/events.md
@@ -217,7 +217,7 @@ $('#table').on('event-name.bs.table', function (e, arg1, arg2, ...) {
 
   It fires when remote data is loaded successfully. The parameters contain:
 
-  * `data`: the remote data loaded into the table. (Note: this data cannot be modified once it’s loaded into the table. If you need to process received data before using it in the table, use [responseHandler](/docs/api/table-options/#responsehandler) option instead.)
+  * `data`: the remote data loaded into the table. (Note: this data cannot be modified once it’s loaded into the table. If you need to process received data before using it in the table, write your custom [responseHandler](/docs/api/table-options/#responsehandler) instead.)
   * `status`: the status code of `jqXHR`.
   * `jqXHR`: jqXHR object, which is a super set of the XMLHTTPRequest object. For more information, see the [jqXHR Type](http://api.jquery.com/Types/#jqXHR).
 

--- a/site/docs/api/events.md
+++ b/site/docs/api/events.md
@@ -217,7 +217,7 @@ $('#table').on('event-name.bs.table', function (e, arg1, arg2, ...) {
 
   It fires when remote data is loaded successfully. The parameters contain:
 
-  * `data`: the remote data.
+  * `data`: the remote data loaded into the table. (Note: this data cannot be modified once it’s loaded into the table. If you need to process received data before using it in the table, use [responseHandler](/docs/api/table-options/#responsehandler) option instead.)
   * `status`: the status code of `jqXHR`.
   * `jqXHR`: jqXHR object, which is a super set of the XMLHTTPRequest object. For more information, see the [jqXHR Type](http://api.jquery.com/Types/#jqXHR).
 

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -2065,8 +2065,10 @@ class BootstrapTable {
           this._paginationLoaded = this.data.length === res.length
         }
 
-        this.load(res)
+        // 'load-success' event handler allows to process data (clean up, convert, sort, etc), before it will be actually loaded into the table.
         this.trigger('load-success', res, jqXHR && jqXHR.status, jqXHR)
+        this.load(res)
+
         if (!silent) {
           this.hideLoading()
         }

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -2065,10 +2065,8 @@ class BootstrapTable {
           this._paginationLoaded = this.data.length === res.length
         }
 
-        // 'load-success' event handler allows to process data (clean up, convert, sort, etc), before it will be actually loaded into the table.
-        this.trigger('load-success', res, jqXHR && jqXHR.status, jqXHR)
         this.load(res)
-
+        this.trigger('load-success', res, jqXHR && jqXHR.status, jqXHR)
         if (!silent) {
           this.hideLoading()
         }


### PR DESCRIPTION
The update allows to modify the data before it will be rendered into the table.

Previously I did all data processing on the backend on the stage of producing the JSON. However it significantly cheaper for overall performance to process data on the front-end, when it needed. Do all required clean up, type/format conversions, sorting etc, after the receiving the JSON but before it will be actually loaded into the table.

I'm sure that it will not make any issues for developers who already using `onLoadSuccess` event handler. There is no asynchronous operations between the event and actual loading, rendering occurs after completion of entire 'success' handler on HTTP request. However, if there are any other reasons to call 'load-success' _before_ the actual `load()`, then it worth to add something like `onBeforeLoadSuccess` event, which will allow to modify data before its actual load.

**🤔Type of Request**
- [ ] **Bug fix**
- [ ] **New feature**
- [X] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
<!-- Please prefix each issue number with  "Fix #"  (e.g. Fix #200)  -->

**📝Changelog**

<!-- The type of the change. --->
- [X] **Core**
- [ ] **Extensions**

<!-- Describe changes from the user side. -->

**💡Example(s)?**
<!-- Please use our online Editor (https://live.bootstrap-table.com/) to create example(s) (Before and after your changes).
On our Wiki (https://github.com/wenzhixin/bootstrap-table/wiki/Online-Editor-Explanation) you can read how to use the editor.-->

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
