### PR TITLE
Update bootstrap-table-editable.js, field missing, parameters must be [value, row, index, field]

### DIFF
--- a/src/extensions/editable/bootstrap-table-editable.js
+++ b/src/extensions/editable/bootstrap-table-editable.js
@@ -63,7 +63,7 @@ $.BootstrapTable = class extends $.BootstrapTable {
       column.formatter = column.formatter || (value => value)
       column._formatter = column._formatter ? column._formatter : column.formatter
       column.formatter = (value, row, index, field) => {
-        let result = Utils.calculateObjectValue(column, column._formatter, [value, row, index], value)
+        let result = Utils.calculateObjectValue(column, column._formatter, [value, row, index, field], value)
 
         result = typeof result === 'undefined' || result === null ? this.options.undefinedText : result
         if (this.options.uniqueId !== undefined && !column.alwaysUseFormatter) {


### PR DESCRIPTION
field missing, parameters must be [value, row, index, field]

**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
<!-- Please prefix each issue number with  "Fix #"  (e.g. Fix #200)  -->

**📝Changelog**

<!-- The type of the change. --->
- [ ] **Core**
- [x] **Extensions**

<!-- Describe changes from the user side. -->

**💡Example(s)?**
<!-- Please use our online Editor (https://live.bootstrap-table.com/) to create example(s) (Before and after your changes).
On our Wiki (https://github.com/wenzhixin/bootstrap-table/wiki/Online-Editor-Explanation) you can read how to use the editor.-->

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
