### PR TITLE
feature/7260

### DIFF
--- a/site/docs/extensions/filter-control.md
+++ b/site/docs/extensions/filter-control.md
@@ -105,6 +105,18 @@ toc: true
 
 - **Default:** `,`
 
+### filterControlSearchClear
+
+- **Attribute:** `data-filter-control-search-clear`
+
+- **type:** `bool`
+
+- **Detail:**
+
+  Set to `true` to clear the filter control filters using the table option [showSearchButton](/docs/api/table-options/#showsearchbutton).
+
+- **Default:** `true`
+
 ### searchOnEnterKey
 
 - **Attribute:** `data-search-on-enter-key`
@@ -113,7 +125,7 @@ toc: true
 
 - **Detail:**
 
-  Set to true to fire the search action when the user presses the enter key.
+  Set to `true` to fire the search action when the user presses the enter key.
 
 - **Default:** `false`
 
@@ -249,7 +261,7 @@ toc: true
 
 - **Detail:**
 
-  Set to true if you want to use the starts with search mode.
+  Set to `true` if you want to use the starts with search mode.
 
 - **Default:** `false`
 
@@ -261,7 +273,7 @@ toc: true
 
 - **Detail:**
 
-  Set to true if you want to use the strict search mode.
+  Set to `true` if you want to use the strict search mode.
 
 - **Default:** `false`
 

--- a/src/extensions/filter-control/bootstrap-table-filter-control.js
+++ b/src/extensions/filter-control/bootstrap-table-filter-control.js
@@ -11,6 +11,7 @@ Object.assign($.fn.bootstrapTable.defaults, {
   filterControlVisible: true,
   filterControlMultipleSearch: false,
   filterControlMultipleSearchDelimiter: ',',
+  filterControlSearchClear: true,
   // eslint-disable-next-line no-unused-vars
   onColumnSearch (field, text) {
     return false
@@ -399,7 +400,7 @@ $.BootstrapTable = class extends $.BootstrapTable {
   }
 
   resetSearch (text) {
-    if (this.options.filterControl && this.options.showSearchClearButton) {
+    if (this.options.filterControl && this.options.filterControlSearchClear && this.options.showSearchClearButton) {
       this.clearFilterControl()
     }
     super.resetSearch(text)


### PR DESCRIPTION
**🤔Type of Request**
- [ ] **Bug fix**
- [x] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
<!-- Please prefix each issue number with  "Fix #"  (e.g. Fix #200)  -->
Fix #7260 

**📝Changelog**
Added a new table option `filterControlSearchClear` to the filter-control extension, which allows to stop clearing the filter-control filters using the table option `showSearchButton`.

<!-- The type of the change. --->
- [ ] **Core**
- [x] **Extensions**

<!-- Describe changes from the user side. -->

**💡Example(s)?**
<!-- Please use our online Editor (https://live.bootstrap-table.com/) to create example(s) (Before and after your changes).
On our Wiki (https://github.com/wenzhixin/bootstrap-table/wiki/Online-Editor-Explanation) you can read how to use the editor.-->
Before: https://live.bootstrap-table.com/code/UtechtDustin/17730
After: https://live.bootstrap-table.com/code/UtechtDustin/17729

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
