### PR TITLE
fix: Loop Stops Processing Rows When Column is Missing

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -2514,7 +2514,7 @@ class BootstrapTable {
           const column = this.columns[this.fieldsColumnsIndex[key]]
 
           if (!column) {
-            return
+            continue
           }
 
           row[key] = Utils.calculateObjectValue(column, this.header.formatters[column.fieldIndex], [value, row, row.index, column.field], value)

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -2509,7 +2509,7 @@ class BootstrapTable {
     }
 
     if (params && params.formatted) {
-      data.forEach(row => {
+      return data.map(row => {
         for (const [key, value] of Object.entries(row)) {
           const column = this.columns[this.fieldsColumnsIndex[key]]
 
@@ -2517,7 +2517,8 @@ class BootstrapTable {
             continue
           }
 
-          row[key] = Utils.calculateObjectValue(column, this.header.formatters[column.fieldIndex], [value, row, row.index, column.field], value)
+          return Utils.calculateObjectValue(column, this.header.formatters[column.fieldIndex],
+            [value, row, row.index, column.field], value)
         }
       })
     }


### PR DESCRIPTION
This pull request fixes a bug  where the loop would exit early when a column is not found, instead of continuing to the next iteration. The current implementation uses return, which stops processing further columns for the current row. This fix changes return to continue to ensure that all columns are processed correctly.

**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**

This bug fix ensures that all columns are processed for each row, even if a specific column is not found in the columns array. This is critical for cases where some columns may not be present but should not disrupt the processing of the remaining columns.

**📝Changelog**

<!-- The type of the change. --->
- [x] **Core**
- [ ] **Extensions**

<!-- Describe changes from the user side. -->

This could lead to incomplete data formatting and potential issues in the table display. With this fix, the loop continues to process all remaining columns, providing a more robust and reliable data handling experience.

**💡Example(s)?**
Before:
https://live.bootstrap-table.com/code/sokolovskiy0103/17796
After:
https://live.bootstrap-table.com/code/sokolovskiy0103/17798

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
