### PR TITLE
Extension editable, dropdown display the value instead of label

### DIFF
--- a/src/extensions/editable/bootstrap-table-editable.js
+++ b/src/extensions/editable/bootstrap-table-editable.js
@@ -58,7 +58,7 @@ $.BootstrapTable = class extends $.BootstrapTable {
         }
       }
 
-      const formatterIsSet = column.formatter ? true : false;
+      const formatterIsSet = column.formatter ? true : false
 
       $.each(this.options, processDataOptions)
 
@@ -97,7 +97,7 @@ $.BootstrapTable = class extends $.BootstrapTable {
           data-name="${column.field}"
           data-pk="${row[this.options.idField]}"
           data-value="${value || ''}"
-          ${editableDataMarkup}>${formatterIsSet?result:""}</a>` // expand all data-editable-XXX
+          ${editableDataMarkup}>${formatterIsSet ? result : ''}</a>` // expand all data-editable-XXX
       }
     })
   }

--- a/src/extensions/editable/bootstrap-table-editable.js
+++ b/src/extensions/editable/bootstrap-table-editable.js
@@ -58,6 +58,8 @@ $.BootstrapTable = class extends $.BootstrapTable {
         }
       }
 
+      const formatterIsSet = column.formatter ? true : false;
+
       $.each(this.options, processDataOptions)
 
       column.formatter = column.formatter || (value => value)
@@ -95,7 +97,7 @@ $.BootstrapTable = class extends $.BootstrapTable {
           data-name="${column.field}"
           data-pk="${row[this.options.idField]}"
           data-value="${value || ''}"
-          ${editableDataMarkup}>${result}</a>` // expand all data-editable-XXX
+          ${editableDataMarkup}>${formatterIsSet?result:""}</a>` // expand all data-editable-XXX
       }
     })
   }


### PR DESCRIPTION
**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
Fix #7081 - Extension editable, dropdown display the value instead of label

**📝Changelog**

<!-- The type of the change. --->
- [ ] **Core**
- [x] **Extensions**

- Editable extension: fixing the problem that editable of type select display the value instead of label in bootstrap table

<!-- Describe changes from the user side. -->

**💡Example(s)?**
<!-- Please use our online Editor (https://live.bootstrap-table.com/) to create example(s) (Before and after your changes).
On our Wiki (https://github.com/wenzhixin/bootstrap-table/wiki/Online-Editor-Explanation) you can read how to use the editor.-->

The problem described by #7081 was caused by PR #6400 which adds a content to `<A>` tag generated by formatter for editable. This PR adds the content to that `<A>` tag only when the column has a formatter. Otherwise it left the tag empty as it was before #6400

The examples for the original problem are in the #7081:

- Version 1.21.4 - working - https://live.bootstrap-table.com/code/kkozlik/16542
- Version 1.22.1 - broken - https://live.bootstrap-table.com/code/kkozlik/16541
- my fix - working again - https://live.bootstrap-table.com/code/kkozlik/17890
- Also example proving the problem that was solved by #6400 still works: https://live.bootstrap-table.com/code/kkozlik/17887

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
