### PR TITLE
Fix #7174 / Check if sticky header extension enabled in matchPositionX

### DIFF
--- a/src/extensions/sticky-header/bootstrap-table-sticky-header.js
+++ b/src/extensions/sticky-header/bootstrap-table-sticky-header.js
@@ -148,6 +148,10 @@ $.BootstrapTable = class extends $.BootstrapTable {
   }
 
   matchPositionX () {
+    if (!this.options.stickyHeader) {
+      return
+    }
+
     this.$stickyContainer.scrollLeft(this.$tableBody.scrollLeft())
   }
 }


### PR DESCRIPTION
**🤔Type of Request**
- [X] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
Fix #7174

**📝Changelog**

- [ ] **Core**
- [X] **Extensions**

- Fixes issue if sticky-header extension is loaded but has not been enabled for a table

**💡Example(s)?**
<!-- Please use our online Editor (https://live.bootstrap-table.com/) to create example(s) (Before and after your changes).
On our Wiki (https://github.com/wenzhixin/bootstrap-table/wiki/Online-Editor-Explanation) you can read how to use the editor.-->

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] Changelog is provided or not needed
