### PR TITLE
Handle undefined values when searching fields

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1080,7 +1080,7 @@ class BootstrapTable {
             const props = key.split('.')
 
             for (let i = 0; i < props.length; i++) {
-              if (value[props[i]] !== null) {
+              if (value[props[i]] != null) {
                 value = value[props[i]]
               } else {
                 value = null

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1080,6 +1080,7 @@ class BootstrapTable {
             const props = key.split('.')
 
             for (let i = 0; i < props.length; i++) {
+              // eslint-disable-next-line eqeqeq
               if (value[props[i]] != null) {
                 value = value[props[i]]
               } else {

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1080,17 +1080,11 @@ class BootstrapTable {
             const props = key.split('.')
 
             for (let i = 0; i < props.length; i++) {
-              // eslint-disable-next-line eqeqeq
               if (value[props[i]] === null || value[props[i]] === undefined) {
                 value = null
                 break
               } else {
                 value = value[props[i]]
-              }
-                value = value[props[i]]
-              } else {
-                value = null
-                break
               }
             }
           } else {

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1081,7 +1081,12 @@ class BootstrapTable {
 
             for (let i = 0; i < props.length; i++) {
               // eslint-disable-next-line eqeqeq
-              if (value[props[i]] != null) {
+              if (value[props[i]] === null || value[props[i]] === undefined) {
+                value = null
+                break
+              } else {
+                value = value[props[i]]
+              }
                 value = value[props[i]]
               } else {
                 value = null


### PR DESCRIPTION
**🤔Type of Request**
- [ ] **Bug fix**
- [ ] **New feature**
- [x] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**📝Changelog**

<!-- The type of the change. --->
- [x] **Core**
- [ ] **Extensions**

When using dotted fields for columns, a search will now correctly handle undefined values instead of throwing an error if they're encountered while navigating through objects with the dotted fields.

**💡Example(s)?**

https://live.bootstrap-table.com/code/nwalters512/17939

Try searching for USD; observe that the following error is logged to the console:

```
bootstrap-table.min.js:10 Uncaught TypeError: Cannot read properties of undefined (reading 'value')
    at bootstrap-table.min.js:10:53552
    at Array.filter (<anonymous>)
    at t.value (bootstrap-table.min.js:10:53149)
    at t.value (bootstrap-table.min.js:10:51731)
    at bootstrap-table.min.js:10:49468
```

This error should not appear after this change.

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
