### PR TITLE
fix: Rendering exceptions caused by errors in some cases

### DIFF
--- a/src/extensions/fixed-columns/bootstrap-table-fixed-columns.js
+++ b/src/extensions/fixed-columns/bootstrap-table-fixed-columns.js
@@ -265,7 +265,7 @@ $.BootstrapTable = class extends $.BootstrapTable {
       this.$fixedBody = initFixedBody(this.$fixedColumns, this.$fixedHeader)
     }
 
-    if (this.needFixedColumns && this.options.fixedRightNumber && this.$fixedColumnsRight && this.$fixedHeaderRight) {
+    if (this.needFixedColumns && this.options.fixedRightNumber && this.$fixedColumnsRight) {
       this.$fixedBodyRight = initFixedBody(this.$fixedColumnsRight, this.$fixedHeaderRight)
       this.$fixedBodyRight.scrollLeft(this.$fixedBodyRight.find('table').width())
       this.$fixedBodyRight.css('overflow-y', this.options.height ? 'auto' : 'hidden')

--- a/src/extensions/fixed-columns/bootstrap-table-fixed-columns.js
+++ b/src/extensions/fixed-columns/bootstrap-table-fixed-columns.js
@@ -197,7 +197,7 @@ $.BootstrapTable = class extends $.BootstrapTable {
       this.$fixedColumns.find('.fixed-table-loading').hide()
     }
 
-    if (this.needFixedColumns && this.options.fixedRightNumber) {
+    if (this.needFixedColumns && this.options.fixedRightNumber && this.$fixedColumnsRight) {
       this.$fixedColumnsRight.find('.fixed-table-loading').hide()
     }
   }
@@ -226,7 +226,7 @@ $.BootstrapTable = class extends $.BootstrapTable {
       this.$fixedColumns.html('').css('width', '')
     }
 
-    if (this.needFixedColumns && this.options.fixedRightNumber) {
+    if (this.needFixedColumns && this.options.fixedRightNumber && this.$fixedColumnsRight) {
       this.$fixedHeaderRight = initFixedHeader(this.$fixedColumnsRight, true)
       this.$fixedHeaderRight.scrollLeft(this.$fixedHeaderRight.find('table').width())
     } else if (this.$fixedColumnsRight) {
@@ -265,7 +265,7 @@ $.BootstrapTable = class extends $.BootstrapTable {
       this.$fixedBody = initFixedBody(this.$fixedColumns, this.$fixedHeader)
     }
 
-    if (this.needFixedColumns && this.options.fixedRightNumber) {
+    if (this.needFixedColumns && this.options.fixedRightNumber && this.$fixedColumnsRight && this.$fixedHeaderRight) {
       this.$fixedBodyRight = initFixedBody(this.$fixedColumnsRight, this.$fixedHeaderRight)
       this.$fixedBodyRight.scrollLeft(this.$fixedBodyRight.find('table').width())
       this.$fixedBodyRight.css('overflow-y', this.options.height ? 'auto' : 'hidden')
@@ -336,7 +336,7 @@ $.BootstrapTable = class extends $.BootstrapTable {
       }
     }
 
-    if (this.needFixedColumns && this.options.fixedNumber) {
+    if (this.needFixedColumns && this.options.fixedNumber && this.$fixedBody) {
       this.$fixedBody.find('tr').hover(e => {
         toggleHover(e, true)
       }, e => {


### PR DESCRIPTION
On some H5 pages, switching and refreshing the display format of the table can cause this error, specifically this$ Fixed ColumnsRight is undefined.

**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
<!-- Please prefix each issue number with  "Fix #"  (e.g. Fix #200)  -->
no

**📝Changelog**

<!-- The type of the change. --->
- [ ] **Core**
- [x] **Extensions**

<!-- Describe changes from the user side. -->

**💡Example(s)?**
<!-- Please use our online Editor (https://live.bootstrap-table.com/) to create example(s) (Before and after your changes).
On our Wiki (https://github.com/wenzhixin/bootstrap-table/wiki/Online-Editor-Explanation) you can read how to use the editor.-->

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
