### PR TITLE
[filter-control] Always return the same control container target

### DIFF
--- a/src/extensions/filter-control/utils.js
+++ b/src/extensions/filter-control/utils.js
@@ -17,10 +17,6 @@ export function getControlContainer (that) {
     return $(`${that.options.filterControlContainer}`)
   }
 
-  if (that.options.height && that._initialized) {
-    return that.$tableContainer.find('.fixed-table-header table thead')
-  }
-
   return that.$header
 }
 


### PR DESCRIPTION
**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
<!-- Please prefix each issue number with  "Fix #"  (e.g. Fix #200)  -->
Fix #7171.

**📝Changelog**
In the `filter-control` `getControlContainer` function, always return the same target control container, regardless of whether the `height` (fixed-header) option is enabled, and regardless of the filter control `_initialized` state when it is.

<!-- The type of the change. --->
- [ ] **Core**
- [x] **Extensions**

<!-- Describe changes from the user side. -->

**💡Example(s)?**
<!-- Please use our online Editor (https://live.bootstrap-table.com/) to create example(s) (Before and after your changes).
On our Wiki (https://github.com/wenzhixin/bootstrap-table/wiki/Online-Editor-Explanation) you can read how to use the editor.-->
  * **Before** - https://live.bootstrap-table.com/code/jayaddison/18021
  * **After** - https://live.bootstrap-table.com/code/jayaddison/18022

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->

Edit: untick the reviewer checkboxes that I'd filled by mistake.