### PR TITLE
fix(reorder-columns): resolve incorrect column values order

### DIFF
--- a/src/extensions/reorder-columns/bootstrap-table-reorder-columns.js
+++ b/src/extensions/reorder-columns/bootstrap-table-reorder-columns.js
@@ -136,7 +136,9 @@ $.BootstrapTable = class extends $.BootstrapTable {
         const sortOrder = {}
 
         table.el.find('th').each((i, el) => {
-          if ('field' in el.dataset) {
+          if (el.dataset.field !== undefined) {
+            sortOrder[el.dataset.field] = i
+          }
             sortOrder[$(el).data('field')] = i
           }
         })

--- a/src/extensions/reorder-columns/bootstrap-table-reorder-columns.js
+++ b/src/extensions/reorder-columns/bootstrap-table-reorder-columns.js
@@ -139,7 +139,6 @@ $.BootstrapTable = class extends $.BootstrapTable {
           if (el.dataset.field !== undefined) {
             sortOrder[el.dataset.field] = i
           }
-            sortOrder[$(el).data('field')] = i
           }
         })
 

--- a/src/extensions/reorder-columns/bootstrap-table-reorder-columns.js
+++ b/src/extensions/reorder-columns/bootstrap-table-reorder-columns.js
@@ -139,7 +139,6 @@ $.BootstrapTable = class extends $.BootstrapTable {
           if (el.dataset.field !== undefined) {
             sortOrder[el.dataset.field] = i
           }
-          }
         })
 
         this.columnsSortOrder = sortOrder

--- a/src/extensions/reorder-columns/bootstrap-table-reorder-columns.js
+++ b/src/extensions/reorder-columns/bootstrap-table-reorder-columns.js
@@ -136,7 +136,9 @@ $.BootstrapTable = class extends $.BootstrapTable {
         const sortOrder = {}
 
         table.el.find('th').each((i, el) => {
-          sortOrder[$(el).data('field')] = i
+          if ('field' in el.dataset) {
+            sortOrder[$(el).data('field')] = i
+          }
         })
 
         this.columnsSortOrder = sortOrder


### PR DESCRIPTION
**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
<!-- Please prefix each issue number with  "Fix #"  (e.g. Fix #200)  -->

**📝Changelog**
fix(reorder-columns): resolve incorrect column values order with detail-view

Fixed an issue in the "reorder-columns" extension where columns had incorrect values when `data-detail-view` was set to true. The problem occurred because the code attempted to access a non-existent `field` property in the detail-view column. Added a check to ensure the `field` property exists before assigning the value.

<!-- The type of the change. --->
- [ ] **Core**
- [x] **Extensions**

<!-- Describe changes from the user side. -->

**💡Example(s)?**
<!-- Please use our online Editor (https://live.bootstrap-table.com/) to create example(s) (Before and after your changes).
On our Wiki (https://github.com/wenzhixin/bootstrap-table/wiki/Online-Editor-Explanation) you can read how to use the editor.-->
Here is an example of the problem:
- Before: https://live.bootstrap-table.com/code/Vinidamiaop/18108
- After: https://live.bootstrap-table.com/code/Vinidamiaop/18112

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
