### PR TITLE
fix(column-reordering): fixed issue with reordered columns and cookies

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1562,7 +1562,7 @@ class BootstrapTable {
     }
 
     const tds = this.header.fields.map((field, j) => {
-      const column = this.columns[j]
+      const column = this.options.columns[0][j]
       const value_ = Utils.getItemField(item, field, this.options.escape, column.escape)
       let value = ''
       const attrs = {

--- a/src/extensions/cookie/bootstrap-table-cookie.js
+++ b/src/extensions/cookie/bootstrap-table-cookie.js
@@ -407,9 +407,38 @@ $.BootstrapTable = class extends $.BootstrapTable {
 
   initHeader (...args) {
     if (this.options.reorderableColumns && this.options.cookie) {
+      if (this.columnsSortOrder) {
+        this.options.columns[0] = this.reorderColumnsFromCookies(this.columnsSortOrder, this.options.columns[0])
+      }
       this.columnsSortOrder = JSON.parse(UtilsCookie.getCookie(this, UtilsCookie.cookieIds.reorderColumns))
     }
     super.initHeader(...args)
+  }
+
+  reorderColumnsFromCookies (reorderedColumns) {
+    const reorderedList = []
+    const notInReorderedList = []
+    const reorderedKeys = Object.keys(reorderedColumns)
+
+    this.options.columns[0].forEach(column => {
+      if (reorderedKeys.includes(column.field)) {
+        const fieldIndex = reorderedColumns[column.field] - 1
+
+        reorderedList[fieldIndex] = column
+      } else {
+        notInReorderedList.push(column)
+      }
+    })
+
+    let finalList = [...reorderedList, ...notInReorderedList]
+
+    finalList = finalList.map((item, index) => {
+      item.fieldIndex = index
+      item.colspanIndex = index
+      return item
+    })
+
+    return finalList
   }
 
   persistReorderColumnsState (that) {


### PR DESCRIPTION
**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
<!-- Please prefix each issue number with  "Fix #"  (e.g. Fix #200)  -->
Fix #5827

**📝Changelog**
Addressed an issue where column values were incorrectly aligned after reloading the page with reordered columns saved in cookies. Updated the data retrieval logic to respect the new column order by adjusting the fields to match the correct columns based on the saved order, ensuring accurate data display.

<!-- The type of the change. --->
- [ ] **Core**
- [x] **Extensions**

<!-- Describe changes from the user side. -->

**💡Example(s)?**
<!-- Please use our online Editor (https://live.bootstrap-table.com/) to create example(s) (Before and after your changes).
On our Wiki (https://github.com/wenzhixin/bootstrap-table/wiki/Online-Editor-Explanation) you can read how to use the editor.-->
https://live.bootstrap-table.com/code/bschootcovadis/8602

Steps to reproduce:

1. Move headers
2. Check row values
3. Refresh page

Headers are set correct, rows with the data are not correct

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
