### PR TITLE
Fixed column is undefined bug in updateFieldGroup when using refreshOptions

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -303,6 +303,10 @@ export default {
             const underColumns = allColumns.filter(col => col.fieldIndex === i)
             const column = underColumns[underColumns.length - 1]
 
+            if (!column) {
+              continue
+            }
+
             if (underColumns.length > 1) {
               for (let j = 0; j < underColumns.length - 1; j++) {
                 underColumns[j].visible = column.visible


### PR DESCRIPTION
**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
Fix #7588

**📝Changelog**

<!-- The type of the change. --->
- [x] **Core**
- [ ] **Extensions**

Fixed column is `undefined` bug in `updateFieldGroup` when using `refreshOptions`.

**💡Example(s)?**
Before: https://live.bootstrap-table.com/code/amiart/18312
After: https://live.bootstrap-table.com/code/wenzhixin/18316

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
