### PR TITLE
Update utils.js

### DIFF
--- a/src/extensions/filter-control/utils.js
+++ b/src/extensions/filter-control/utils.js
@@ -472,7 +472,7 @@ export function createControls (that, header) {
       }, that.options.searchTimeOut)
     })
 
-    header.off('change', 'select', '.fc-multipleselect').on('change', 'select', '.fc-multipleselect', ({ currentTarget, keyCode }) => {
+    header.off('change', 'select').on('change', 'select', ({ currentTarget, keyCode }) => {
       const $selectControl = $(currentTarget)
       const value = $selectControl.val()
 


### PR DESCRIPTION
**🤔Type of Request**
- [X] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**


**📝Changelog**
Removing the binding on classes "fc-multipleselect" on filter initialization. 
The jQuery syntax is wrong and therefore causes a bug in the initialization of the filter select during an ajax data load.

Plus  : where does it come from? If found no such class in the other files of the module, neither in bootstrap

<!-- The type of the change. --->
- [ ] **Core**
- [X] **Extensions**

<!-- Describe changes from the user side. -->
Select initialization after an ajax load of a table content now works.


**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [ ] Changelog is provided or not needed
