### PR TITLE
Fixed insertRow bug after on last row of table

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -2587,6 +2587,11 @@ class BootstrapTable {
     const row = this.data[params.index]
     const originalIndex = this.options.data.indexOf(row)
 
+    if (originalIndex === -1) {
+      this.append([params.row])
+      return
+    }
+
     this.data.splice(params.index, 0, params.row)
     this.options.data.splice(originalIndex, 0, params.row)
     this.initSearch()

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -2,7 +2,13 @@ export default {
   getBootstrapVersion () {
     let bootstrapVersion = 5
 
-    try {
+    if (typeof window !== 'undefined' && window.bootstrap?.Tooltip?.VERSION) {
+      const rawVersion = window.bootstrap.Tooltip.VERSION
+
+      if (rawVersion !== undefined) {
+        bootstrapVersion = parseInt(rawVersion, 10)
+      }
+    } else if (typeof $ !== 'undefined' && $.fn?.dropdown?.Constructor?.VERSION) {
       const rawVersion = $.fn.dropdown.Constructor.VERSION
 
       // Only try to parse VERSION if it is defined.
@@ -10,19 +16,6 @@ export default {
       if (rawVersion !== undefined) {
         bootstrapVersion = parseInt(rawVersion, 10)
       }
-    } catch (e) {
-      console.error(e)
-    }
-
-    try {
-      // eslint-disable-next-line no-undef
-      const rawVersion = bootstrap.Tooltip.VERSION
-
-      if (rawVersion !== undefined) {
-        bootstrapVersion = parseInt(rawVersion, 10)
-      }
-    } catch (e) {
-      console.error(e)
     }
 
     return bootstrapVersion


### PR DESCRIPTION
**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
Fix #7628

**📝Changelog**

<!-- The type of the change. --->
- [x] **Core**
- [ ] **Extensions**

Fixed insertRow bug after on the last row of the table

**💡Example(s)?**
Before: https://live.bootstrap-table.com/code/EgorTrutnev/18412
After: https://live.bootstrap-table.com/code/wenzhixin/18474

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
