### PR TITLE
Fix bug where totalRows is not integer in formatter

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -1257,11 +1257,17 @@ class BootstrapTable {
     }
 
     if (this.paginationParts.includes('pageInfo') || this.paginationParts.includes('pageInfoShort')) {
-      const totalRows = this.options.totalRows +
-        (this.options.sidePagination === 'client' &&
+      let totalRows = this.options.totalRows
+
+      if (
+        this.options.sidePagination === 'client' &&
         this.options.paginationLoadMore &&
         !this._paginationLoaded &&
-        this.totalPages > 1 ? ' +' : '')
+        this.totalPages > 1
+      ) {
+        totalRows += ' +'
+      }
+
       const paginationInfo = this.paginationParts.includes('pageInfoShort') ?
         opts.formatDetailPagination(totalRows) :
         opts.formatShowingRows(this.pageFrom, this.pageTo, totalRows, opts.totalNotFiltered)


### PR DESCRIPTION
**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
Fix #7678 

**📝Changelog**

<!-- The type of the change. --->
- [x] **Core**
- [ ] **Extensions**

Fix bug where `totalRows` is not integer in formatted

**Examples**

Before: https://live.bootstrap-table.com/code/wenzhixin/18702
After: https://live.bootstrap-table.com/code/wenzhixin/18703

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
