### PR TITLE
Ignore the catch error when table calls dragtable.destroy

### DIFF
--- a/src/extensions/reorder-columns/bootstrap-table-reorder-columns.js
+++ b/src/extensions/reorder-columns/bootstrap-table-reorder-columns.js
@@ -123,8 +123,8 @@ $.BootstrapTable = class extends $.BootstrapTable {
   makeColumnsReorderable (order = null) {
     try {
       $(this.$el).dragtable('destroy')
-    } catch (e) {
-      console.error(e)
+    } catch {
+      // ignore
     }
     $(this.$el).dragtable({
       maxMovingRows: this.options.maxMovingRows,


### PR DESCRIPTION
**🤔Type of Request**
- [ ] **Bug fix**
- [ ] **New feature**
- [x] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
Fix #7718

**📝Changelog**

<!-- The type of the change. --->
- [ ] **Core**
- [x] **Extensions**

Ignore the catch error when table calls dragtable.destroy

**💡Example(s)?**

https://live.bootstrap-table.com/code/wenzhixin/18713

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
