### PR TITLE
Refactoring - Extract buttonRendering from main initToolbar()

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -608,6 +608,51 @@ class BootstrapTable {
     this.initBody()
   }
 
+  renderButton (buttonName, buttonConfig) {
+    let buttonHtml
+
+    if (buttonConfig.hasOwnProperty('html')) {
+      if (typeof buttonConfig.html === 'function') {
+        buttonHtml = buttonConfig.html()
+      } else if (typeof buttonConfig.html === 'string') {
+        buttonHtml = buttonConfig.html
+      }
+    } else {
+      let buttonClass = this.constants.buttonsClass
+
+      if (buttonConfig.hasOwnProperty('attributes') && buttonConfig.attributes.class) {
+        buttonClass += ` ${buttonConfig.attributes.class}`
+      }
+      buttonHtml = `<button class="${buttonClass}" type="button" name="${buttonName}"`
+
+      if (buttonConfig.hasOwnProperty('attributes')) {
+        for (const [attributeName, value] of Object.entries(buttonConfig.attributes)) {
+          if (attributeName === 'class') {
+            continue
+          }
+
+          const attribute = attributeName === 'title' ?
+            this.options.buttonsAttributeTitle : attributeName
+
+          buttonHtml += ` ${attribute}="${value}"`
+        }
+      }
+
+      buttonHtml += '>'
+
+      if (opts.showButtonIcons && buttonConfig.hasOwnProperty('icon')) {
+        buttonHtml += `${Utils.sprintf(this.constants.html.icon, opts.iconsPrefix, buttonConfig.icon)} `
+      }
+
+      if (opts.showButtonText && buttonConfig.hasOwnProperty('text')) {
+        buttonHtml += buttonConfig.text
+      }
+
+      buttonHtml += '</button>'
+    }
+    return buttonHtml
+  }
+
   initToolbar () {
     const opts = this.options
     let html = []
@@ -751,49 +796,7 @@ class BootstrapTable {
     const buttonsHtml = {}
 
     for (const [buttonName, buttonConfig] of Object.entries(this.buttons)) {
-      let buttonHtml
-
-      if (buttonConfig.hasOwnProperty('html')) {
-        if (typeof buttonConfig.html === 'function') {
-          buttonHtml = buttonConfig.html()
-        } else if (typeof buttonConfig.html === 'string') {
-          buttonHtml = buttonConfig.html
-        }
-      } else {
-        let buttonClass = this.constants.buttonsClass
-
-        if (buttonConfig.hasOwnProperty('attributes') && buttonConfig.attributes.class) {
-          buttonClass += ` ${buttonConfig.attributes.class}`
-        }
-        buttonHtml = `<button class="${buttonClass}" type="button" name="${buttonName}"`
-
-        if (buttonConfig.hasOwnProperty('attributes')) {
-          for (const [attributeName, value] of Object.entries(buttonConfig.attributes)) {
-            if (attributeName === 'class') {
-              continue
-            }
-
-            const attribute = attributeName === 'title' ?
-              this.options.buttonsAttributeTitle : attributeName
-
-            buttonHtml += ` ${attribute}="${value}"`
-          }
-        }
-
-        buttonHtml += '>'
-
-        if (opts.showButtonIcons && buttonConfig.hasOwnProperty('icon')) {
-          buttonHtml += `${Utils.sprintf(this.constants.html.icon, opts.iconsPrefix, buttonConfig.icon)} `
-        }
-
-        if (opts.showButtonText && buttonConfig.hasOwnProperty('text')) {
-          buttonHtml += buttonConfig.text
-        }
-
-        buttonHtml += '</button>'
-      }
-
-      buttonsHtml[buttonName] = buttonHtml
+      buttonsHtml[buttonName] = renderButton(buttonName, buttonConfig)
       const optionName = `show${buttonName.charAt(0).toUpperCase()}${buttonName.substring(1)}`
       const showOption = opts[optionName]
 


### PR DESCRIPTION
**🤔Type of Request**
- [ ] **Bug fix**
- [ ] **New feature**
- [x] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
<!-- Please prefix each issue number with  "Fix #"  (e.g. Fix #200)  -->

While trying to simply reverse the display order of when `columns` vs `search` was appended to the DOM in initToolbar, I found it difficult as everything was appending to `html`.

Minor refactor to split out a specific sub rendering behaviour to its own thing - more could be done, just doing one chunk at a time.

**📝Changelog**

<!-- The type of the change. --->
- [x] **Core**
- [ ] **Extensions**

<!-- Describe changes from the user side. -->

**💡Example(s)?**
<!-- Please use our online Editor (https://live.bootstrap-table.com/) to create example(s) (Before and after your changes).
On our Wiki (https://github.com/wenzhixin/bootstrap-table/wiki/Online-Editor-Explanation) you can read how to use the editor.-->

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
