### PR TITLE
Add scope attribute support for table headers

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -198,9 +198,9 @@ class BootstrapTable {
           title: $th.html(),
           class: $th.attr('class'),
           titleTooltip: $th.attr('title'),
-          scope: $th.attr('scope') ? $th.attr('scope') : undefined,
           rowspan: $th.attr('rowspan') ? +$th.attr('rowspan') : undefined,
-          colspan: $th.attr('colspan') ? +$th.attr('colspan') : undefined
+          colspan: $th.attr('colspan') ? +$th.attr('colspan') : undefined,
+          scope: $th.attr('scope') ? $th.attr('scope') : undefined
         }, $th.data()))
       })
       columns.push(column)
@@ -371,8 +371,8 @@ class BootstrapTable {
           Utils.sprintf(' style="%s"', halign + style + csses.join('; ') || undefined),
           Utils.sprintf(' rowspan="%s"', column.rowspan),
           Utils.sprintf(' colspan="%s"', column.colspan),
-          Utils.sprintf(' data-field="%s"', column.field),
           Utils.sprintf(' scope="%s"', column.scope),
+          Utils.sprintf(' data-field="%s"', column.field),
           // If `column` is not the first element of `this.options.columns[0]`, then className 'data-not-first-th' should be added.
           j === 0 && i > 0 ? ' data-not-first-th' : '',
           data_.length > 0 ? data_.join(' ') : '',

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -198,7 +198,7 @@ class BootstrapTable {
           title: $th.html(),
           class: $th.attr('class'),
           titleTooltip: $th.attr('title'),
-          scope: $th.attr('scope'),
+          scope: $th.attr('scope') ? $th.attr('scope') : undefined,
           rowspan: $th.attr('rowspan') ? +$th.attr('rowspan') : undefined,
           colspan: $th.attr('colspan') ? +$th.attr('colspan') : undefined
         }, $th.data()))

--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -198,6 +198,7 @@ class BootstrapTable {
           title: $th.html(),
           class: $th.attr('class'),
           titleTooltip: $th.attr('title'),
+          scope: $th.attr('scope'),
           rowspan: $th.attr('rowspan') ? +$th.attr('rowspan') : undefined,
           colspan: $th.attr('colspan') ? +$th.attr('colspan') : undefined
         }, $th.data()))
@@ -371,6 +372,7 @@ class BootstrapTable {
           Utils.sprintf(' rowspan="%s"', column.rowspan),
           Utils.sprintf(' colspan="%s"', column.colspan),
           Utils.sprintf(' data-field="%s"', column.field),
+          Utils.sprintf(' scope="%s"', column.scope),
           // If `column` is not the first element of `this.options.columns[0]`, then className 'data-not-first-th' should be added.
           j === 0 && i > 0 ? ' data-not-first-th' : '',
           data_.length > 0 ? data_.join(' ') : '',


### PR DESCRIPTION
Preserve and render the 'scope' attribute from th elements to improve table accessibility for screen readers.

**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
Fix #7780 

**📝Changelog**

<!-- The type of the change. --->
- [x] **Core**
- [ ] **Extensions**

**💡Example(s)?**
https://live.bootstrap-table.com/code/djhvscf/18817

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [ ] Changelog is provided or not needed