### PR TITLE
Fix #7975 - problem with grouping rows

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -2487,6 +2487,7 @@ class BootstrapTable {
     if (
       (
         this.searchText ||
+        this.options.groupBy ||
         this.options.customSearch ||
         this.options.sortName !== undefined ||
         this.enableCustomSort || // Fix #4616: this.enableCustomSort is for extensions

--- a/src/extensions/group-by-v2/bootstrap-table-group-by.js
+++ b/src/extensions/group-by-v2/bootstrap-table-group-by.js
@@ -62,7 +62,7 @@ BootstrapTable.prototype.initSort = function (...args) {
           this.data
         ])
       } else {
-        this.options.data.sort((a, b) => {
+        this.data.sort((a, b) => {
           const groupByFields = this.getGroupByFields()
           const fieldValuesA = []
           const fieldValuesB = []


### PR DESCRIPTION
**🤔Type of Request**
- [x] **Bug fix**

**🔗Resolves an issue?**
Fix #7975

**📝Changelog**

<!-- The type of the change. --->
- [x] **Core**
- [x] **Extensions**

<!-- Describe changes from the user side. -->
Group-by-v2 extensions now sort `this.data` array instead of `this.options.data`.

Core function `getData` returns `this.data` also when groupBy extension is used. Without this change the grouping did not worked fine in case `sortName` is not set.

**💡Example(s)?**
<!-- Please use our online Editor (https://live.bootstrap-table.com/) to create example(s) (Before and after your changes).
On our Wiki (https://github.com/wenzhixin/bootstrap-table/wiki/Online-Editor-Explanation) you can read how to use the editor.-->

The example of fix is prepared here: https://live.bootstrap-table.com/code/kkozlik/19017
But there is some problem with online editor using github branch. I believe the source is set correctly here, but it do not show any result. Even my older examples stopped work.

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
