### PR TITLE
Set `aria-sort` attribute on sortable headers

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -2117,10 +2117,17 @@ class BootstrapTable {
   }
 
   getCaret () {
+    const { sortName, sortOrder } = this.options
+    const ariaSort = sortOrder === 'asc' ? 'ascending' : 'descending'
+
     this.$header.find('th').each((i, th) => {
-      $(th).find('.sortable').removeClass('desc asc')
-        .addClass($(th).data('field') === this.options.sortName ?
-          this.options.sortOrder : 'both')
+      const isActive = $(th).data('field') === sortName
+
+      $(th)
+        .attr('aria-sort', isActive ? ariaSort : null)
+        .find('.sortable')
+        .removeClass('desc asc')
+        .addClass(isActive ? sortOrder : 'both')
     })
   }
 


### PR DESCRIPTION
This will improve accessibility of sortable tables in that screen readers will be able to dictate the current sort order of columns as the user navigates through them.  Tested with JAWS.

The attribute should be set to "ascending" or "descending" only on the column that is currently sorted.

See https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-sort for an explanation of this attribute.

**🤔Type of Request**
- [ ] **Bug fix**
- [ ] **New feature**
- [x] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
<!-- Please prefix each issue number with  "Fix #"  (e.g. Fix #200)  -->

**📝Changelog**

<!-- The type of the change. --->
- [x] **Core**
- [ ] **Extensions**

<!-- Describe changes from the user side. -->

**💡Example(s)?**
<!-- Please use our online Editor (https://live.bootstrap-table.com/) to create example(s) (Before and after your changes).
On our Wiki (https://github.com/wenzhixin/bootstrap-table/wiki/Online-Editor-Explanation) you can read how to use the editor.-->

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
