### PR TITLE
Fix multiple-sort row data index sync issue

### DIFF
--- a/src/extensions/multiple-sort/bootstrap-table-multiple-sort.js
+++ b/src/extensions/multiple-sort/bootstrap-table-multiple-sort.js
@@ -726,6 +726,9 @@ BootstrapTable.prototype.onMultipleSort = function () {
   this.data.sort((a, b) => arrayCmp(a, b))
 
   this.initBody()
+  if (this.options.maintainMetaData) {
+    this.updateRows()
+  }
   this.assignSortableArrows()
   this.trigger('multiple-sort')
 }


### PR DESCRIPTION
Fixes #5506

## Problem
When using multiple-sort, rows are visually sorted correctly, but click events (`click-row.bs.table`, `click-cell.bs.table`) return stale data from before the sort.

## Root Cause
After `this.data.sort()` reorders the array, `initBody()` re-renders rows with new indices (0, 1, 2...). However, the `data-index` attributes in the DOM now point to wrong positions in the sorted array. When click events fire, they use these outdated indices to retrieve data.

## Solution
Call `updateRows()` after `initBody()` when `maintainMetaData` is enabled. This syncs the DOM `data-index` attributes with the current data array positions, ensuring click events retrieve the correct row data.

## Testing
Tested with the original reproduction case from issue #5506. After sorting, clicking cells now returns the correct sorted row data.

Contribution by Gittensor, learn more at https://gittensor.io/