### PR TITLE
Add DOMHelper utility for jQuery removal

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "vue": "^3.5.24"
   },
   "scripts": {
-    "lint:js": "eslint src",
+    "lint:js": "eslint src tests",
     "lint:css": "stylelint src/**/*.scss",
     "lint:spell": "cspell lint --no-progress 'src/**/*.{js,json,vue,scss}' 'site/**/*.md' '*.md'",
     "lint:editor": "editorconfig-checker -exclude dist",

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -1,0 +1,598 @@
+/**
+ * Bootstrap Table DOM Manipulation Utility Library
+ * Provides jQuery-style DOM manipulation APIs using native JavaScript
+ *
+ * Security Notice:
+ * - The `create()` method uses innerHTML to parse HTML strings. Always sanitize user input
+ *   before passing it to create() to prevent XSS attacks.
+ * - The `html()` method sets innerHTML directly. Use the `text()` method for user-provided content.
+ * - The `attr()` method allows setting arbitrary attributes including event handlers.
+ *   Avoid setting event handler attributes (onclick, onerror, etc.) with user-controlled data.
+ */
+
+class DOMHelper {
+  /**
+   * Element selector
+   * @param {string|Element} selector - CSS selector or DOM element
+   * @param {Element} context - Search context, defaults to document
+   * @returns {Element|null} First matched element
+   */
+  static $ (selector, context = document) {
+    if (typeof selector === 'string') {
+      return context.querySelector(selector)
+    }
+    if (selector instanceof Element) {
+      return selector
+    }
+    return null
+  }
+
+  /**
+   * Element selector (multiple)
+   * @param {string|Element|NodeList} selector - CSS selector, DOM element, or NodeList
+   * @param {Element} context - Search context, defaults to document
+   * @returns {Element[]} Array of all matched elements. Note: if selector is an Element, returns [Element]
+   */
+  static $$ (selector, context = document) {
+    if (typeof selector === 'string') {
+      return Array.from(context.querySelectorAll(selector))
+    }
+    if (selector instanceof NodeList) {
+      return Array.from(selector)
+    }
+    if (selector instanceof Element) {
+      return [selector]
+    }
+    return []
+  }
+
+  /**
+   * Create DOM element
+   * @param {string} html - HTML string. Note: This method uses innerHTML and can execute scripts.
+   *                        Always sanitize user input before passing it to this method.
+   * @returns {Element|null} Created DOM element. Returns null if html is empty, not a string,
+   *                         or contains only whitespace.
+   */
+  static create (html) {
+    if (typeof html !== 'string') return null
+
+    const trimmed = html.trim()
+
+    if (!trimmed) return null
+
+    const template = document.createElement('template')
+
+    template.innerHTML = trimmed
+    return template.content.firstChild
+  }
+
+  /**
+   * Add CSS class
+   * @param {Element|string} element - DOM element or selector
+   * @param {string} className - Class name to add (space-separated for multiple classes)
+   * @returns {Element|null} The element itself
+   */
+  static addClass (element, className) {
+    if (typeof element === 'string') element = this.$(element)
+    if (!element || !element.classList) return element
+    if (!className) return element
+
+    const classes = className.split(' ').filter(c => c)
+
+    element.classList.add(...classes)
+    return element
+  }
+
+  /**
+   * Remove CSS class
+   * @param {Element|string} element - DOM element or selector
+   * @param {string} className - Class name to remove (space-separated for multiple classes)
+   * @returns {Element|null} The element itself
+   */
+  static removeClass (element, className) {
+    if (typeof element === 'string') element = this.$(element)
+    if (!element || !element.classList) return element
+    if (!className) return element
+
+    const classes = className.split(' ').filter(c => c)
+
+    element.classList.remove(...classes)
+    return element
+  }
+
+  /**
+   * Toggle CSS class
+   * @param {Element|string} element - DOM element or selector
+   * @param {string} className - Class name to toggle (space-separated for multiple classes)
+   * @returns {Element|null} The element itself
+   */
+  static toggleClass (element, className) {
+    if (typeof element === 'string') element = this.$(element)
+    if (!element || !element.classList) return element
+    if (!className) return element
+
+    const classes = className.split(' ').filter(c => c)
+
+    classes.forEach(cls => element.classList.toggle(cls))
+    return element
+  }
+
+  /**
+   * Check if element has CSS class
+   * @param {Element|string} element - DOM element or selector
+   * @param {string} className - Class name to check
+   * @returns {boolean} Whether the class exists
+   */
+  static hasClass (element, className) {
+    if (typeof element === 'string') element = this.$(element)
+    if (!element || !element.classList) return false
+    if (!className) return false
+
+    return element.classList.contains(className)
+  }
+
+  /**
+   * Get or set attribute
+   * @param {Element|string} element - DOM element or selector
+   * @param {string} name - Attribute name. Warning: Avoid setting event handler attributes
+   *                        (onclick, onerror, etc.) with user-controlled data to prevent XSS.
+   * @param {string} [value] - Attribute value (omit to get)
+   * @returns {Element|null} Element when setting, or string|null when getting attribute
+   */
+  static attr (element, name, value) {
+    if (typeof element === 'string') element = this.$(element)
+    if (!element) return value === undefined ? null : element
+
+    if (value === undefined) {
+      return element.getAttribute(name)
+    }
+    element.setAttribute(name, value)
+    return element
+  }
+
+  /**
+   * Remove attribute
+   * @param {Element|string} element - DOM element or selector
+   * @param {string} name - Attribute name
+   * @returns {Element|null} The element itself
+   */
+  static removeAttr (element, name) {
+    if (typeof element === 'string') element = this.$(element)
+    if (!element) return element
+
+    element.removeAttribute(name)
+    return element
+  }
+
+  /**
+   * Get or set data attribute
+   * @param {Element|string} element - DOM element or selector
+   * @param {string} key - Data key name
+   * @param {string} [value] - Data value (omit to get)
+   * @returns {(string|undefined) when getting (value omitted); (Element|null|undefined) when setting (value provided)}
+   * Returns the data attribute value (string or undefined) when getting, or the element (or null/undefined if not found) when setting.
+   */
+  static data (element, key, value) {
+    if (typeof element === 'string') element = this.$(element)
+    if (!element) return value === undefined ? undefined : element
+
+    if (value === undefined) {
+      return element.dataset[key]
+    }
+    element.dataset[key] = value
+    return element
+  }
+
+  /**
+   * Append child element
+   * @param {Element|string} parent - Parent element or selector
+   * @param {Element|string} child - Child element or HTML string
+   * @returns {Element|null} Parent element
+   */
+  static append (parent, child) {
+    if (typeof parent === 'string') parent = this.$(parent)
+    if (typeof child === 'string') child = this.create(child)
+
+    if (parent && child) {
+      parent.appendChild(child)
+    }
+    return parent
+  }
+
+  /**
+   * Prepend child element
+   * @param {Element|string} parent - Parent element or selector
+   * @param {Element|string} child - Child element or HTML string
+   * @returns {Element|null} Parent element
+   */
+  static prepend (parent, child) {
+    if (typeof parent === 'string') parent = this.$(parent)
+    if (typeof child === 'string') child = this.create(child)
+
+    if (parent && child) {
+      parent.insertBefore(child, parent.firstChild)
+    }
+    return parent
+  }
+
+  /**
+   * Insert element after target
+   * @param {Element|string} newElement - Element to insert
+   * @param {Element|string} targetElement - Target element
+   * @returns {Element|null} Inserted element
+   */
+  static insertAfter (newElement, targetElement) {
+    if (typeof targetElement === 'string') targetElement = this.$(targetElement)
+    if (typeof newElement === 'string') newElement = this.create(newElement)
+
+    if (targetElement && newElement && targetElement.parentNode) {
+      targetElement.parentNode.insertBefore(newElement, targetElement.nextSibling)
+    }
+    return newElement
+  }
+
+  /**
+   * Insert element before target
+   * @param {Element|string} newElement - Element to insert
+   * @param {Element|string} targetElement - Target element
+   * @returns {Element|null} Inserted element
+   */
+  static insertBefore (newElement, targetElement) {
+    if (typeof targetElement === 'string') targetElement = this.$(targetElement)
+    if (typeof newElement === 'string') newElement = this.create(newElement)
+
+    if (targetElement && newElement && targetElement.parentNode) {
+      targetElement.parentNode.insertBefore(newElement, targetElement)
+    }
+    return newElement
+  }
+
+  /**
+   * Find child elements
+   * @param {Element|string} element - Parent element or selector
+   * @param {string} selector - CSS selector
+   * @returns {Element[]} Array of matched child elements
+   */
+  static find (element, selector) {
+    if (typeof element === 'string') element = this.$(element)
+    if (!element) return []
+
+    return Array.from(element.querySelectorAll(selector))
+  }
+
+  /**
+   * Find first matching child element
+   * @param {Element|string} element - Parent element or selector
+   * @param {string} selector - CSS selector
+   * @returns {Element|null} First matched child element
+   */
+  static findFirst (element, selector) {
+    if (typeof element === 'string') element = this.$(element)
+    if (!element) return null
+
+    return element.querySelector(selector)
+  }
+
+  /**
+   * Get or set style
+   * @param {Element|string} element - DOM element or selector
+   * @param {string|Object} property - Property name or property object
+   * @param {string} [value] - Style value (when property is string)
+   * @returns {Element|string|null} Element when setting, style value when getting
+   */
+  static css (element, property, value) {
+    if (typeof element === 'string') element = this.$(element)
+    if (!element) {
+      return null
+    }
+
+    if (typeof property === 'object') {
+      // Batch set styles
+      Object.assign(element.style, property)
+      return element
+    }
+    if (value === undefined) {
+      // Get style
+      return getComputedStyle(element)[property]
+    }
+    // Set style
+    element.style[property] = value
+
+    return element
+  }
+
+  /**
+   * Get element width
+   * @param {Element|string} element - DOM element or selector
+   * @returns {number} Element width
+   */
+  static width (element) {
+    if (typeof element === 'string') element = this.$(element)
+    if (!element) return 0
+
+    return element.offsetWidth
+  }
+
+  /**
+   * Get element height
+   * @param {Element|string} element - DOM element or selector
+   * @returns {number} Element height
+   */
+  static height (element) {
+    if (typeof element === 'string') element = this.$(element)
+    if (!element) return 0
+
+    return element.offsetHeight
+  }
+
+  /**
+   * Get element outer width (including border, optionally including margin)
+   * @param {Element|string} element - DOM element or selector
+   * @param {boolean} [includeMargin=false] - Whether to include margin
+   * @returns {number} Element outer width
+   */
+  static outerWidth (element, includeMargin = false) {
+    if (typeof element === 'string') element = this.$(element)
+    if (!element) return 0
+
+    let width = element.offsetWidth
+
+    if (includeMargin) {
+      const style = getComputedStyle(element)
+      const marginLeft = parseInt(style.marginLeft, 10) || 0
+      const marginRight = parseInt(style.marginRight, 10) || 0
+
+      width += marginLeft + marginRight
+    }
+    return width
+  }
+
+  /**
+   * Get element outer height (including border, optionally including margin)
+   * @param {Element|string} element - DOM element or selector
+   * @param {boolean} [includeMargin=false] - Whether to include margin
+   * @returns {number} Element outer height
+   */
+  static outerHeight (element, includeMargin = false) {
+    if (typeof element === 'string') element = this.$(element)
+    if (!element) return 0
+
+    let height = element.offsetHeight
+
+    if (includeMargin) {
+      const style = getComputedStyle(element)
+      const marginTop = parseInt(style.marginTop, 10) || 0
+      const marginBottom = parseInt(style.marginBottom, 10) || 0
+
+      height += marginTop + marginBottom
+    }
+    return height
+  }
+
+  /**
+   * Get or set element value
+   * @param {Element|string} element - DOM element or selector
+   * @param {string} [value] - Value (omit to get)
+   * @returns {Element|string|null} Element when setting, current value when getting
+   */
+  static val (element, value) {
+    if (typeof element === 'string') element = this.$(element)
+    if (!element) return value === undefined ? null : element
+
+    if (value === undefined) {
+      return element.value
+    }
+    element.value = value
+    return element
+  }
+
+  /**
+   * Get or set HTML content
+   * @param {Element|string} element - DOM element or selector
+   * @param {string} [content] - HTML content (omit to get). Warning: This method uses innerHTML
+   *                             and can execute scripts. Use text() for user-provided content.
+   * @returns {Element|string|null} Element when setting, HTML content when getting
+   */
+  static html (element, content) {
+    if (typeof element === 'string') element = this.$(element)
+    if (!element) return content === undefined ? null : element
+
+    if (content === undefined) {
+      return element.innerHTML
+    }
+    element.innerHTML = content
+    return element
+  }
+
+  /**
+   * Get or set text content
+   * @param {Element|string} element - DOM element or selector
+   * @param {string} [content] - Text content (omit to get)
+   * @returns {Element|string|null} Element when setting, text content when getting
+   */
+  static text (element, content) {
+    if (typeof element === 'string') element = this.$(element)
+    if (!element) return content === undefined ? null : element
+
+    if (content === undefined) {
+      return element.textContent
+    }
+    element.textContent = content
+    return element
+  }
+
+  /**
+   * Remove element
+   * @param {Element|string} element - DOM element or selector
+   * @returns {Element|null} Removed element
+   */
+  static remove (element) {
+    if (typeof element === 'string') element = this.$(element)
+    if (!element || !element.parentNode) return element
+
+    element.parentNode.removeChild(element)
+    return element
+  }
+
+  /**
+   * Empty element content
+   * @param {Element|string} element - DOM element or selector
+   * @returns {Element|null} Emptied element
+   */
+  static empty (element) {
+    if (typeof element === 'string') element = this.$(element)
+    if (!element) return element
+
+    element.innerHTML = ''
+    return element
+  }
+
+  /**
+   * Iterate over element collection
+   * @param {Element[]|NodeList|string} elements - Element collection or selector
+   * @param {Function} callback - Callback function with params (index, element)
+   * @returns {Element[]} Element collection
+   */
+  static each (elements, callback) {
+    if (typeof elements === 'string') {
+      elements = this.$$(elements)
+    } else if (elements instanceof NodeList) {
+      elements = Array.from(elements)
+    } else if (!Array.isArray(elements)) {
+      elements = [elements]
+    }
+
+    elements.forEach((element, index) => {
+      callback.call(element, index, element)
+    })
+    return elements
+  }
+
+  /**
+   * Get parent element
+   * @param {Element|string} element - DOM element or selector
+   * @param {string} [selector] - Parent element selector (optional)
+   * @returns {Element|null} Parent element
+   */
+  static parent (element, selector) {
+    if (typeof element === 'string') element = this.$(element)
+    if (!element) return null
+
+    let parent = element.parentElement
+
+    if (selector) {
+      while (parent && !parent.matches(selector)) {
+        parent = parent.parentElement
+      }
+    }
+    return parent
+  }
+
+  /**
+   * Get child elements
+   * @param {Element|string} element - DOM element or selector
+   * @param {string} [selector] - Child element selector (optional)
+   * @returns {Element[]} Array of child elements
+   */
+  static children (element, selector) {
+    if (typeof element === 'string') element = this.$(element)
+    if (!element) return []
+
+    let children = Array.from(element.children)
+
+    if (selector) {
+      children = children.filter(child => child.matches(selector))
+    }
+    return children
+  }
+
+  /**
+   * Get next sibling element
+   * @param {Element|string} element - DOM element or selector
+   * @param {string} [selector] - Sibling element selector (optional)
+   * @returns {Element|null} Next sibling element
+   */
+  static next (element, selector) {
+    if (typeof element === 'string') element = this.$(element)
+    if (!element) return null
+
+    let next = element.nextElementSibling
+
+    if (selector) {
+      while (next && !next.matches(selector)) {
+        next = next.nextElementSibling
+      }
+    }
+    return next
+  }
+
+  /**
+   * Get previous sibling element
+   * @param {Element|string} element - DOM element or selector
+   * @param {string} [selector] - Sibling element selector (optional)
+   * @returns {Element|null} Previous sibling element
+   */
+  static prev (element, selector) {
+    if (typeof element === 'string') element = this.$(element)
+    if (!element) return null
+
+    let prev = element.previousElementSibling
+
+    if (selector) {
+      while (prev && !prev.matches(selector)) {
+        prev = prev.previousElementSibling
+      }
+    }
+    return prev
+  }
+
+  /**
+   * Get element position relative to document
+   * @param {Element|string} element - DOM element or selector
+   * @returns {Object} Position info {top, left, width, height}
+   */
+  static offset (element) {
+    if (typeof element === 'string') element = this.$(element)
+    if (!element) return { top: 0, left: 0, width: 0, height: 0 }
+
+    const rect = element.getBoundingClientRect()
+
+    return {
+      top: rect.top + window.scrollY,
+      left: rect.left + window.scrollX,
+      width: rect.width,
+      height: rect.height
+    }
+  }
+
+  /**
+   * Get element position relative to parent
+   * @param {Element|string} element - DOM element or selector
+   * @returns {Object} Position info {top, left}
+   */
+  static position (element) {
+    if (typeof element === 'string') element = this.$(element)
+    if (!element) return { top: 0, left: 0 }
+
+    return {
+      top: element.offsetTop,
+      left: element.offsetLeft
+    }
+  }
+
+  /**
+   * Check if element matches selector
+   * @param {Element|string} element - DOM element or selector
+   * @param {string} selector - CSS selector
+   * @returns {boolean} Whether it matches
+   */
+  static is (element, selector) {
+    if (typeof element === 'string') element = this.$(element)
+    if (!element) return false
+
+    return element.matches(selector)
+  }
+}
+
+// Export DOMHelper class
+export default DOMHelper

--- a/tests/integration/dom.test.js
+++ b/tests/integration/dom.test.js
@@ -1,0 +1,494 @@
+/**
+ * Integration tests for DOMHelper utility
+ * Tests DOMHelper integration with real DOM scenarios
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest'
+import DOMHelper from '@/utils/dom.js'
+
+// Setup test environment
+beforeEach(() => {
+  // Clear document body before each test
+  document.body.innerHTML = ''
+})
+
+describe('DOMHelper Integration Tests', () => {
+  describe('Complex DOM operations', () => {
+    it('should build complex DOM structure', () => {
+      // Build a table structure similar to Bootstrap Table
+      const container = DOMHelper.create('<div class="bootstrap-table"></div>')
+
+      DOMHelper.append(document.body, container)
+
+      const toolbar = DOMHelper.create('<div class="fixed-table-toolbar"></div>')
+
+      DOMHelper.append(container, toolbar)
+
+      const tableContainer = DOMHelper.create('<div class="fixed-table-container"></div>')
+
+      DOMHelper.append(container, tableContainer)
+
+      const header = DOMHelper.create('<div class="fixed-table-header"><table></table></div>')
+      const body = DOMHelper.create('<div class="fixed-table-body"><table><tbody></tbody></table></div>')
+
+      DOMHelper.append(tableContainer, header)
+      DOMHelper.append(tableContainer, body)
+
+      // Verify structure
+      expect(DOMHelper.$('.bootstrap-table')).toBeTruthy()
+      expect(DOMHelper.$('.fixed-table-toolbar')).toBeTruthy()
+      expect(DOMHelper.$('.fixed-table-container')).toBeTruthy()
+      expect(DOMHelper.$('.fixed-table-header')).toBeTruthy()
+      expect(DOMHelper.$('.fixed-table-body')).toBeTruthy()
+      expect(DOMHelper.$('.fixed-table-header table')).toBeTruthy()
+      expect(DOMHelper.$('.fixed-table-body table')).toBeTruthy()
+      expect(DOMHelper.$('.fixed-table-body tbody')).toBeTruthy()
+    })
+
+    it('should handle dynamic content creation', () => {
+      const container = DOMHelper.create('<div id="dynamic-container"></div>')
+
+      DOMHelper.append(document.body, container)
+
+      // Add multiple elements dynamically
+      for (let i = 1; i <= 5; i++) {
+        const item = DOMHelper.create('<div class="item"></div>')
+
+        // Set attributes and text content safely
+        DOMHelper.attr(item, 'data-index', String(i))
+        DOMHelper.text(item, `Item ${i}`)
+
+        DOMHelper.append(container, item)
+      }
+
+      // Verify all items were added
+      const items = DOMHelper.$$('#dynamic-container .item')
+
+      expect(items).toHaveLength(5)
+
+      // Verify data attributes
+      DOMHelper.each(items, (index, element) => {
+        expect(DOMHelper.data(element, 'index')).toBe(String(index + 1))
+      })
+    })
+
+    it('should manipulate table structure', () => {
+      // Create table
+      const table = DOMHelper.create('<table id="test-table"></table>')
+
+      DOMHelper.append(document.body, table)
+
+      // Create thead
+      const thead = DOMHelper.create('<thead><tr></tr></thead>')
+
+      DOMHelper.append(table, thead)
+
+      // Add headers
+      const headers = ['ID', 'Name', 'Age']
+      const headerRow = DOMHelper.$('thead tr', table)
+
+      headers.forEach(text => {
+        const th = DOMHelper.create('<th></th>')
+
+        DOMHelper.text(th, text) // Safe text content setting
+
+        DOMHelper.append(headerRow, th)
+      })
+
+      // Create tbody
+      const tbody = DOMHelper.create('<tbody></tbody>')
+
+      DOMHelper.append(table, tbody)
+
+      // Add rows
+      const data = [
+        { id: 1, name: 'John', age: 25 },
+        { id: 2, name: 'Jane', age: 30 },
+        { id: 3, name: 'Bob', age: 35 }
+      ]
+
+      data.forEach(row => {
+        const tr = DOMHelper.create('<tr></tr>')
+
+        DOMHelper.append(tbody, tr)
+
+        // Create cells safely by setting text content instead of HTML injection
+        const idCell = DOMHelper.create('<td></td>')
+        const nameCell = DOMHelper.create('<td></td>')
+        const ageCell = DOMHelper.create('<td></td>')
+
+        DOMHelper.text(idCell, String(row.id))
+        DOMHelper.text(nameCell, row.name)
+        DOMHelper.text(ageCell, String(row.age))
+
+        DOMHelper.append(tr, idCell)
+        DOMHelper.append(tr, nameCell)
+        DOMHelper.append(tr, ageCell)
+      })
+
+      // Verify table structure
+      expect(DOMHelper.$$('#test-table thead th')).toHaveLength(3)
+      expect(DOMHelper.$$('#test-table tbody tr')).toHaveLength(3)
+      expect(DOMHelper.$('#test-table tbody tr:first-child td:first-child').textContent).toBe('1')
+      expect(DOMHelper.$('#test-table tbody tr:last-child td:last-child').textContent).toBe('35')
+    })
+  })
+
+  describe('Event-driven DOM operations', () => {
+    it('should support DOM operations in event handlers', () => {
+      const container = DOMHelper.create('<div id="event-container"></div>')
+      const button = DOMHelper.create('<button id="add-item">Add Item</button>')
+      const list = DOMHelper.create('<ul id="item-list"></ul>')
+
+      DOMHelper.append(document.body, container)
+      DOMHelper.append(container, button)
+      DOMHelper.append(container, list)
+
+      // Mock click event
+      let clickCount = 0
+
+      button.addEventListener('click', () => {
+        clickCount++
+        const item = DOMHelper.create('<li></li>')
+
+        DOMHelper.text(item, `Item ${clickCount}`) // Safe text content setting
+
+        DOMHelper.append(list, item)
+      })
+
+      // Simulate clicks
+      button.click()
+      button.click()
+      button.click()
+
+      // Verify items were added
+      const items = DOMHelper.$$('#item-list li')
+
+      expect(items).toHaveLength(3)
+      expect(items[0].textContent).toBe('Item 1')
+      expect(items[2].textContent).toBe('Item 3')
+    })
+
+    it('should handle DOM updates based on user input', () => {
+      const container = DOMHelper.create('<div id="form-container"></div>')
+      const input = DOMHelper.create('<input id="text-input" type="text" placeholder="Enter text">')
+      const display = DOMHelper.create('<div id="display"></div>')
+
+      DOMHelper.append(document.body, container)
+      DOMHelper.append(container, input)
+      DOMHelper.append(container, display)
+
+      // Mock input event
+      input.addEventListener('input', e => {
+        const text = e.target.value
+
+        if (text) {
+          // Create HTML safely to avoid XSS
+          const p = DOMHelper.create('<p></p>')
+          const strong = DOMHelper.create('<strong></strong>')
+
+          DOMHelper.text(strong, text) // Safe text content setting
+
+          const span = DOMHelper.create('<span></span>')
+
+          DOMHelper.text(span, 'You typed: ')
+          DOMHelper.append(p, span)
+          DOMHelper.append(p, strong)
+
+          DOMHelper.empty(display)
+          DOMHelper.append(display, p)
+          DOMHelper.addClass(display, 'has-content')
+        } else {
+          DOMHelper.html(display, '')
+          DOMHelper.removeClass(display, 'has-content')
+        }
+      })
+
+      // Simulate input
+      DOMHelper.val(input, 'Hello World')
+      input.dispatchEvent(new Event('input'))
+
+      // Verify display was updated
+      expect(DOMHelper.$('#display p')).toBeTruthy()
+      expect(DOMHelper.$('#display strong').textContent).toBe('Hello World')
+      expect(DOMHelper.hasClass(display, 'has-content')).toBe(true)
+
+      // Clear input
+      DOMHelper.val(input, '')
+      input.dispatchEvent(new Event('input'))
+
+      // Verify display was cleared
+      expect(DOMHelper.html(display)).toBe('')
+      expect(DOMHelper.hasClass(display, 'has-content')).toBe(false)
+    })
+  })
+
+  describe('Performance considerations', () => {
+    it('should handle large number of elements efficiently', () => {
+      const container = DOMHelper.create('<div id="large-container"></div>')
+
+      DOMHelper.append(document.body, container)
+
+      // Create fragment for better performance
+      const fragment = document.createDocumentFragment()
+
+      // Add 1000 elements safely
+      for (let i = 0; i < 1000; i++) {
+        const item = DOMHelper.create('<div class="item"></div>')
+
+        // Set attributes and text content safely
+        DOMHelper.attr(item, 'data-id', String(i))
+        DOMHelper.text(item, `Item ${i}`)
+
+        fragment.appendChild(item)
+      }
+
+      // Append all at once
+      container.appendChild(fragment)
+
+      // Verify all elements were added
+      const items = DOMHelper.$$('#large-container .item')
+
+      expect(items).toHaveLength(1000)
+
+      // Test finding specific elements
+      const item500 = DOMHelper.$('#large-container [data-id="500"]')
+
+      expect(item500).toBeTruthy()
+      expect(item500.textContent).toBe('Item 500')
+    })
+
+    it('should batch DOM operations for better performance', () => {
+      const container = DOMHelper.create('<div id="batch-container"></div>')
+
+      DOMHelper.append(document.body, container)
+
+      // Add initial elements safely
+      for (let i = 0; i < 100; i++) {
+        const item = DOMHelper.create('<div class="item"></div>')
+
+        // Set attributes and text content safely
+        DOMHelper.attr(item, 'id', `item-${i}`)
+        DOMHelper.text(item, `Item ${i}`)
+
+        DOMHelper.append(container, item)
+      }
+
+      // Batch update all elements
+      const items = DOMHelper.$$('#batch-container .item')
+
+      DOMHelper.each(items, (index, element) => {
+        DOMHelper.addClass(element, 'processed')
+        DOMHelper.css(element, 'color', index % 2 === 0 ? 'blue' : 'green')
+        DOMHelper.data(element, 'processed', 'true')
+      })
+
+      // Verify batch updates
+      expect(DOMHelper.$$('#batch-container .processed')).toHaveLength(100)
+      expect(DOMHelper.data(DOMHelper.$('#item-50'), 'processed')).toBe('true')
+    })
+  })
+
+  describe('Complex interactions', () => {
+    it('should handle nested DOM operations', () => {
+      // Create nested structure
+      const main = DOMHelper.create('<div id="main"></div>')
+
+      DOMHelper.append(document.body, main)
+
+      // Level 1
+      const level1 = DOMHelper.create('<div class="level-1"><h2>Level 1</h2></div>')
+
+      DOMHelper.append(main, level1)
+
+      // Level 2
+      const level2 = DOMHelper.create('<div class="level-2"><h3>Level 2</h3></div>')
+
+      DOMHelper.append(level1, level2)
+
+      // Level 3 with items
+      const level3 = DOMHelper.create('<div class="level-3"><ul></ul></div>')
+      const ul = DOMHelper.$('ul', level3)
+
+      for (let i = 1; i <= 3; i++) {
+        const li = DOMHelper.create('<li></li>')
+
+        DOMHelper.text(li, `Sub-item ${i}`) // Safe text content setting
+        DOMHelper.append(ul, li)
+      }
+      DOMHelper.append(level2, level3)
+
+      // Verify nested structure
+      expect(DOMHelper.$('#main .level-1')).toBeTruthy()
+      expect(DOMHelper.$('#main .level-2')).toBeTruthy()
+      expect(DOMHelper.$('#main .level-3')).toBeTruthy()
+      expect(DOMHelper.$$('#main .level-3 li')).toHaveLength(3)
+
+      // Test complex selectors
+      const firstLi = DOMHelper.$('#main .level-1 .level-2 .level-3 li:first-child')
+
+      expect(firstLi.textContent).toBe('Sub-item 1')
+    })
+
+    it('should support dynamic styling based on state', () => {
+      const container = DOMHelper.create('<div id="state-container"></div>')
+
+      DOMHelper.append(document.body, container)
+
+      // Create interactive elements
+      const buttons = ['primary', 'secondary', 'success', 'warning', 'danger']
+
+      buttons.forEach(type => {
+        const button = DOMHelper.create('<button class="btn" data-type=""></button>')
+
+        // Set attributes and text content safely
+        DOMHelper.addClass(button, `btn-${type}`)
+        DOMHelper.attr(button, 'data-type', type)
+        DOMHelper.text(button, type)
+
+        DOMHelper.append(container, button)
+
+        // Add click handler to toggle active state
+        button.addEventListener('click', () => {
+          // Remove active from all buttons
+          DOMHelper.$$('#state-container .btn').forEach(btn => {
+            DOMHelper.removeClass(btn, 'active')
+          })
+
+          // Add active to clicked button
+          DOMHelper.addClass(button, 'active')
+
+          // Update display based on active button
+          const display = DOMHelper.$('#button-display')
+
+          if (display) {
+            DOMHelper.text(display, `Active button: ${type}`)
+            DOMHelper.attr(display, 'data-active-type', type)
+          }
+        })
+      })
+
+      // Add display element
+      const display = DOMHelper.create('<div id="button-display">No button selected</div>')
+
+      DOMHelper.append(container, display)
+
+      // Simulate button clicks
+      const successButton = DOMHelper.$('[data-type="success"]')
+
+      successButton.click()
+
+      // Verify state changes
+      expect(DOMHelper.hasClass(successButton, 'active')).toBe(true)
+      expect(DOMHelper.$('#button-display').textContent).toBe('Active button: success')
+      expect(DOMHelper.attr(DOMHelper.$('#button-display'), 'data-active-type')).toBe('success')
+    })
+  })
+
+  describe('Form manipulation', () => {
+    it('should handle complex form operations', () => {
+      const form = DOMHelper.create('<form id="test-form"></form>')
+
+      DOMHelper.append(document.body, form)
+
+      // Add form fields
+      const fields = [
+        { type: 'text', name: 'username', label: 'Username', value: '' },
+        { type: 'email', name: 'email', label: 'Email', value: '' },
+        { type: 'password', name: 'password', label: 'Password', value: '' },
+        { type: 'checkbox', name: 'remember', label: 'Remember me', checked: false },
+        { type: 'select', name: 'country', label: 'Country', options: ['US', 'UK', 'Canada'] }
+      ]
+
+      fields.forEach(field => {
+        const fieldGroup = DOMHelper.create('<div class="form-group"></div>')
+        const label = DOMHelper.create('<label></label>')
+
+        // Set label text safely
+        DOMHelper.text(label, field.label)
+        DOMHelper.append(fieldGroup, label)
+
+        if (field.type === 'select') {
+          const select = DOMHelper.create('<select></select>')
+
+          // Set attributes safely
+          DOMHelper.attr(select, 'name', field.name)
+
+          field.options.forEach(option => {
+            const optionElement = DOMHelper.create('<option></option>')
+
+            DOMHelper.attr(optionElement, 'value', option)
+            DOMHelper.text(optionElement, option) // Safe text content setting
+            DOMHelper.append(select, optionElement)
+          })
+          DOMHelper.append(fieldGroup, select)
+        } else if (field.type === 'checkbox') {
+          const input = DOMHelper.create('<input type="checkbox">')
+
+          // Set attributes safely
+          DOMHelper.attr(input, 'name', field.name)
+          if (field.checked) {
+            DOMHelper.attr(input, 'checked', 'checked')
+          }
+
+          DOMHelper.append(fieldGroup, input)
+        } else {
+          const input = DOMHelper.create('<input>')
+
+          // Set attributes safely
+          DOMHelper.attr(input, 'type', field.type)
+          DOMHelper.attr(input, 'name', field.name)
+          if (field.value) {
+            DOMHelper.attr(input, 'value', field.value)
+          }
+
+          DOMHelper.append(fieldGroup, input)
+        }
+
+        DOMHelper.append(form, fieldGroup)
+      })
+
+      // Verify form structure
+      expect(DOMHelper.$$('#test-form .form-group')).toHaveLength(5)
+      expect(DOMHelper.$('input[name="username"]')).toBeTruthy()
+      expect(DOMHelper.$('select[name="country"]')).toBeTruthy()
+      expect(DOMHelper.$$('#test-form select option')).toHaveLength(3)
+
+      // Fill form
+      DOMHelper.val(DOMHelper.$('input[name="username"]'), 'john_doe')
+      DOMHelper.val(DOMHelper.$('input[name="email"]'), 'john@example.com')
+      DOMHelper.val(DOMHelper.$('input[name="password"]'), 'secret123')
+      DOMHelper.attr(DOMHelper.$('input[name="remember"]'), 'checked', 'checked')
+      DOMHelper.val(DOMHelper.$('select[name="country"]'), 'UK')
+
+      // Verify form values
+      expect(DOMHelper.val(DOMHelper.$('input[name="username"]'))).toBe('john_doe')
+      expect(DOMHelper.val(DOMHelper.$('input[name="email"]'))).toBe('john@example.com')
+      expect(DOMHelper.val(DOMHelper.$('select[name="country"]'))).toBe('UK')
+    })
+  })
+
+  describe('Browser compatibility simulation', () => {
+    it('should handle elements with special characters in IDs', () => {
+      const element = DOMHelper.create('<div id="special.id.with[brackets]">Special ID</div>')
+
+      DOMHelper.append(document.body, element)
+
+      // Should be able to select with escaped selector or by attribute
+      const byAttribute = DOMHelper.$('[id="special.id.with[brackets]"]')
+
+      expect(byAttribute).toBeTruthy()
+      expect(byAttribute.textContent).toBe('Special ID')
+    })
+
+    it('should handle elements with unicode content', () => {
+      const element = DOMHelper.create('<div>Unicode: 中文 Español Français 日本語 한국어 العربية</div>')
+
+      DOMHelper.append(document.body, element)
+
+      expect(DOMHelper.text(element)).toContain('中文')
+      expect(DOMHelper.text(element)).toContain('日本語')
+      expect(DOMHelper.text(element)).toContain('العربية')
+    })
+  })
+})

--- a/tests/utils/dom.test.js
+++ b/tests/utils/dom.test.js
@@ -1,0 +1,694 @@
+/**
+ * Unit tests for DOMHelper utility
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest'
+import DOMHelper from '@/utils/dom.js'
+
+// Setup test environment
+beforeEach(() => {
+  // Clear document body before each test
+  document.body.innerHTML = ''
+})
+
+describe('DOMHelper', () => {
+  describe('Selector methods', () => {
+    it('should select single element with $', () => {
+      document.body.innerHTML = '<div id="test">Test</div>'
+      const element = DOMHelper.$('#test')
+
+      expect(element).toBeTruthy()
+      expect(element.id).toBe('test')
+      expect(element.textContent).toBe('Test')
+    })
+
+    it('should return null when element not found with $', () => {
+      const element = DOMHelper.$('#nonexistent')
+
+      expect(element).toBeNull()
+    })
+
+    it('should return element itself when passing element to $', () => {
+      const element = document.createElement('div')
+      const result = DOMHelper.$(element)
+
+      expect(result).toBe(element)
+    })
+
+    it('should return null for invalid input to $', () => {
+      expect(DOMHelper.$(null)).toBeNull()
+      expect(DOMHelper.$(undefined)).toBeNull()
+      expect(DOMHelper.$(123)).toBeNull()
+      expect(DOMHelper.$({})).toBeNull()
+      expect(DOMHelper.$([])).toBeNull()
+      expect(DOMHelper.$(true)).toBeNull()
+      expect(DOMHelper.$(false)).toBeNull()
+    })
+
+    it('should select multiple elements with $$', () => {
+      document.body.innerHTML = '<div class="item">1</div><div class="item">2</div><div class="item">3</div>'
+      const elements = DOMHelper.$$('.item')
+
+      expect(elements).toHaveLength(3)
+      expect(elements[0].textContent).toBe('1')
+      expect(elements[1].textContent).toBe('2')
+      expect(elements[2].textContent).toBe('3')
+    })
+
+    it('should return empty array when no elements found with $$', () => {
+      const elements = DOMHelper.$$('.nonexistent')
+
+      expect(elements).toHaveLength(0)
+    })
+
+    it('should handle context parameter', () => {
+      const container = document.createElement('div')
+
+      container.innerHTML = '<div id="inside">Inside</div>'
+      document.body.innerHTML = '<div id="outside">Outside</div>'
+      document.body.appendChild(container)
+
+      const insideElement = DOMHelper.$('#inside', container)
+
+      expect(insideElement.textContent).toBe('Inside')
+    })
+  })
+
+  describe('Element creation', () => {
+    it('should create element from HTML string', () => {
+      const element = DOMHelper.create('<div class="created">Created</div>')
+
+      expect(element).toBeTruthy()
+      expect(element.className).toBe('created')
+      expect(element.textContent).toBe('Created')
+    })
+
+    it('should handle complex HTML structure', () => {
+      const element = DOMHelper.create('<p><span>Text</span></p>')
+
+      expect(element.tagName.toLowerCase()).toBe('p')
+      expect(element.querySelector('span').textContent).toBe('Text')
+    })
+
+    it('should return null for empty HTML string', () => {
+      const element = DOMHelper.create('')
+
+      expect(element).toBeNull()
+    })
+
+    it('should return null for whitespace-only HTML string', () => {
+      const element = DOMHelper.create('   \n\t  ')
+
+      expect(element).toBeNull()
+    })
+
+    it('should return null for non-string input', () => {
+      expect(DOMHelper.create(null)).toBeNull()
+      expect(DOMHelper.create(undefined)).toBeNull()
+      expect(DOMHelper.create(123)).toBeNull()
+      expect(DOMHelper.create({})).toBeNull()
+      expect(DOMHelper.create([])).toBeNull()
+    })
+  })
+
+  describe('Class manipulation', () => {
+    beforeEach(() => {
+      document.body.innerHTML = '<div id="test"></div>'
+    })
+
+    it('should add single class', () => {
+      const element = DOMHelper.$('#test')
+
+      DOMHelper.addClass(element, 'new-class')
+      expect(element.classList.contains('new-class')).toBe(true)
+    })
+
+    it('should add multiple classes', () => {
+      const element = DOMHelper.$('#test')
+
+      DOMHelper.addClass(element, 'class1 class2 class3')
+      expect(element.classList.contains('class1')).toBe(true)
+      expect(element.classList.contains('class2')).toBe(true)
+      expect(element.classList.contains('class3')).toBe(true)
+    })
+
+    it('should add class using selector', () => {
+      DOMHelper.addClass('#test', 'selector-class')
+      expect(DOMHelper.$('#test').classList.contains('selector-class')).toBe(true)
+    })
+
+    it('should remove single class', () => {
+      const element = DOMHelper.$('#test')
+
+      element.className = 'class1 class2 class3'
+      DOMHelper.removeClass(element, 'class2')
+      expect(element.classList.contains('class1')).toBe(true)
+      expect(element.classList.contains('class2')).toBe(false)
+      expect(element.classList.contains('class3')).toBe(true)
+    })
+
+    it('should remove multiple classes', () => {
+      const element = DOMHelper.$('#test')
+
+      element.className = 'class1 class2 class3 class4'
+      DOMHelper.removeClass(element, 'class2 class4')
+      expect(element.classList.contains('class1')).toBe(true)
+      expect(element.classList.contains('class2')).toBe(false)
+      expect(element.classList.contains('class3')).toBe(true)
+      expect(element.classList.contains('class4')).toBe(false)
+    })
+
+    it('should toggle class', () => {
+      const element = DOMHelper.$('#test')
+
+      DOMHelper.toggleClass(element, 'toggle-class')
+      expect(element.classList.contains('toggle-class')).toBe(true)
+      DOMHelper.toggleClass(element, 'toggle-class')
+      expect(element.classList.contains('toggle-class')).toBe(false)
+    })
+
+    it('should toggle multiple classes', () => {
+      const element = DOMHelper.$('#test')
+
+      // Add multiple classes at once
+      DOMHelper.toggleClass(element, 'class1 class2 class3')
+      expect(element.classList.contains('class1')).toBe(true)
+      expect(element.classList.contains('class2')).toBe(true)
+      expect(element.classList.contains('class3')).toBe(true)
+
+      // Toggle one class off, others should remain
+      DOMHelper.toggleClass(element, 'class1')
+      expect(element.classList.contains('class1')).toBe(false)
+      expect(element.classList.contains('class2')).toBe(true)
+      expect(element.classList.contains('class3')).toBe(true)
+    })
+
+    it('should handle empty strings and extra spaces in toggleClass', () => {
+      const element = DOMHelper.$('#test')
+
+      DOMHelper.toggleClass(element, '  class1   class2  ')
+      expect(element.classList.contains('class1')).toBe(true)
+      expect(element.classList.contains('class2')).toBe(true)
+    })
+
+    it('should check if element has class', () => {
+      const element = DOMHelper.$('#test')
+
+      element.className = 'has-class'
+      expect(DOMHelper.hasClass(element, 'has-class')).toBe(true)
+      expect(DOMHelper.hasClass(element, 'no-class')).toBe(false)
+    })
+
+    it('should handle null/undefined className gracefully', () => {
+      const element = DOMHelper.$('#test')
+
+      // addClass should handle null/undefined className
+      expect(DOMHelper.addClass(element, null)).toBe(element)
+      expect(DOMHelper.addClass(element, undefined)).toBe(element)
+      expect(DOMHelper.addClass(element, '')).toBe(element)
+      expect(element.className).toBe('')
+
+      // removeClass should handle null/undefined className
+      expect(DOMHelper.removeClass(element, null)).toBe(element)
+      expect(DOMHelper.removeClass(element, undefined)).toBe(element)
+      expect(DOMHelper.removeClass(element, '')).toBe(element)
+      expect(element.className).toBe('')
+
+      // toggleClass should handle null/undefined className
+      expect(DOMHelper.toggleClass(element, null)).toBe(element)
+      expect(DOMHelper.toggleClass(element, undefined)).toBe(element)
+      expect(DOMHelper.toggleClass(element, '')).toBe(element)
+      expect(element.className).toBe('')
+
+      // hasClass should handle null/undefined className
+      expect(DOMHelper.hasClass(element, null)).toBe(false)
+      expect(DOMHelper.hasClass(element, undefined)).toBe(false)
+      expect(DOMHelper.hasClass(element, '')).toBe(false)
+    })
+  })
+
+  describe('Attribute manipulation', () => {
+    beforeEach(() => {
+      document.body.innerHTML = '<div id="test"></div>'
+    })
+
+    it('should get attribute value', () => {
+      const element = DOMHelper.$('#test')
+
+      element.setAttribute('data-test', 'value')
+      expect(DOMHelper.attr(element, 'data-test')).toBe('value')
+    })
+
+    it('should set attribute value', () => {
+      const element = DOMHelper.$('#test')
+
+      DOMHelper.attr(element, 'data-test', 'new-value')
+      expect(element.getAttribute('data-test')).toBe('new-value')
+    })
+
+    it('should return null for non-existent attribute', () => {
+      const element = DOMHelper.$('#test')
+
+      expect(DOMHelper.attr(element, 'non-existent')).toBeNull()
+    })
+
+    it('should remove attribute', () => {
+      const element = DOMHelper.$('#test')
+
+      element.setAttribute('data-test', 'value')
+      DOMHelper.removeAttr(element, 'data-test')
+      expect(element.hasAttribute('data-test')).toBe(false)
+    })
+  })
+
+  describe('Data manipulation', () => {
+    beforeEach(() => {
+      document.body.innerHTML = '<div id="test"></div>'
+    })
+
+    it('should get data value', () => {
+      const element = DOMHelper.$('#test')
+
+      element.dataset.test = 'value'
+      expect(DOMHelper.data(element, 'test')).toBe('value')
+    })
+
+    it('should set data value', () => {
+      const element = DOMHelper.$('#test')
+
+      DOMHelper.data(element, 'test', 'new-value')
+      expect(element.dataset.test).toBe('new-value')
+    })
+
+    it('should return undefined for non-existent data', () => {
+      const element = DOMHelper.$('#test')
+
+      expect(DOMHelper.data(element, 'nonexistent')).toBeUndefined()
+    })
+  })
+
+  describe('DOM manipulation', () => {
+    beforeEach(() => {
+      document.body.innerHTML = '<div id="parent"><div id="child">Child</div></div>'
+    })
+
+    it('should append child', () => {
+      const parent = DOMHelper.$('#parent')
+      const newChild = DOMHelper.create('<div id="new-child">New Child</div>')
+
+      DOMHelper.append(parent, newChild)
+      expect(parent.children.length).toBe(2)
+      expect(parent.querySelector('#new-child')).toBeTruthy()
+    })
+
+    it('should append child using HTML string', () => {
+      const parent = DOMHelper.$('#parent')
+
+      DOMHelper.append(parent, '<div id="html-child">HTML Child</div>')
+      expect(parent.children.length).toBe(2)
+      expect(parent.querySelector('#html-child').textContent).toBe('HTML Child')
+    })
+
+    it('should prepend child', () => {
+      const parent = DOMHelper.$('#parent')
+      const newChild = DOMHelper.create('<div id="prepend-child">Prepend</div>')
+
+      DOMHelper.prepend(parent, newChild)
+      expect(parent.children.length).toBe(2)
+      expect(parent.firstChild.id).toBe('prepend-child')
+    })
+
+    it('should insert after element', () => {
+      const child = DOMHelper.$('#child')
+      const newElement = DOMHelper.create('<div id="after">After</div>')
+
+      DOMHelper.insertAfter(newElement, child)
+      expect(child.nextElementSibling.id).toBe('after')
+    })
+
+    it('should insert before element', () => {
+      const child = DOMHelper.$('#child')
+      const newElement = DOMHelper.create('<div id="before">Before</div>')
+
+      DOMHelper.insertBefore(newElement, child)
+      expect(child.previousElementSibling.id).toBe('before')
+    })
+
+    it('should find child elements', () => {
+      const parent = DOMHelper.$('#parent')
+
+      parent.innerHTML = '<div class="item">1</div><div class="item">2</div><span>Not Item</span>'
+      const items = DOMHelper.find(parent, '.item')
+
+      expect(items).toHaveLength(2)
+    })
+
+    it('should find first matching child element', () => {
+      const parent = DOMHelper.$('#parent')
+
+      parent.innerHTML = '<div class="item">1</div><div class="item">2</div>'
+      const firstItem = DOMHelper.findFirst(parent, '.item')
+
+      expect(firstItem.textContent).toBe('1')
+    })
+
+    it('should remove element', () => {
+      const child = DOMHelper.$('#child')
+
+      DOMHelper.remove(child)
+      expect(DOMHelper.$('#child')).toBeNull()
+      expect(DOMHelper.$('#parent').children.length).toBe(0)
+    })
+
+    it('should empty element', () => {
+      const parent = DOMHelper.$('#parent')
+
+      DOMHelper.empty(parent)
+      expect(parent.children.length).toBe(0)
+      expect(parent.innerHTML).toBe('')
+    })
+  })
+
+  describe('Style manipulation', () => {
+    beforeEach(() => {
+      document.body.innerHTML = '<div id="test"></div>'
+    })
+
+    it('should get style value', () => {
+      const element = DOMHelper.$('#test')
+
+      element.style.display = 'none'
+      const display = DOMHelper.css(element, 'display')
+
+      expect(display).toBe('none')
+    })
+
+    it('should set single style', () => {
+      const element = DOMHelper.$('#test')
+
+      DOMHelper.css(element, 'display', 'block')
+      expect(element.style.display).toBe('block')
+    })
+
+    it('should set multiple styles', () => {
+      const element = DOMHelper.$('#test')
+
+      DOMHelper.css(element, {
+        display: 'block',
+        color: 'red',
+        fontSize: '16px'
+      })
+      expect(element.style.display).toBe('block')
+      expect(element.style.color).toBe('red')
+      expect(element.style.fontSize).toBe('16px')
+    })
+  })
+
+  describe('Dimension methods', () => {
+    beforeEach(() => {
+      document.body.innerHTML = '<div id="test" style="width: 100px; height: 50px; padding: 10px; margin: 20px; border: 2px solid black;"></div>'
+    })
+
+    it('should get element width', () => {
+      const element = DOMHelper.$('#test')
+      const width = DOMHelper.width(element)
+
+      expect(typeof width).toBe('number')
+      expect(width).toBeGreaterThanOrEqual(0)
+    })
+
+    it('should get element height', () => {
+      const element = DOMHelper.$('#test')
+      const height = DOMHelper.height(element)
+
+      expect(typeof height).toBe('number')
+      expect(height).toBeGreaterThanOrEqual(0)
+    })
+
+    it('should get outer width', () => {
+      const element = DOMHelper.$('#test')
+      const outerWidth = DOMHelper.outerWidth(element)
+
+      expect(typeof outerWidth).toBe('number')
+      expect(outerWidth).toBeGreaterThanOrEqual(0)
+    })
+
+    it('should get outer width with margin', () => {
+      const element = DOMHelper.$('#test')
+      const outerWidthWithMargin = DOMHelper.outerWidth(element, true)
+      const outerWidthWithoutMargin = DOMHelper.outerWidth(element, false)
+
+      expect(typeof outerWidthWithMargin).toBe('number')
+      expect(outerWidthWithMargin).toBeGreaterThanOrEqual(outerWidthWithoutMargin)
+    })
+
+    it('should get outer height', () => {
+      const element = DOMHelper.$('#test')
+      const outerHeight = DOMHelper.outerHeight(element)
+
+      expect(typeof outerHeight).toBe('number')
+      expect(outerHeight).toBeGreaterThanOrEqual(0)
+    })
+
+    it('should get outer height with margin', () => {
+      const element = DOMHelper.$('#test')
+      const outerHeightWithMargin = DOMHelper.outerHeight(element, true)
+      const outerHeightWithoutMargin = DOMHelper.outerHeight(element, false)
+
+      expect(typeof outerHeightWithMargin).toBe('number')
+      expect(outerHeightWithMargin).toBeGreaterThanOrEqual(outerHeightWithoutMargin)
+    })
+  })
+
+  describe('Content methods', () => {
+    beforeEach(() => {
+      document.body.innerHTML = '<div id="test"></div><input id="input" type="text" value="initial">'
+    })
+
+    it('should get and set value', () => {
+      const input = DOMHelper.$('#input')
+
+      expect(DOMHelper.val(input)).toBe('initial')
+      DOMHelper.val(input, 'new value')
+      expect(input.value).toBe('new value')
+    })
+
+    it('should get and set HTML content', () => {
+      const element = DOMHelper.$('#test')
+
+      DOMHelper.html(element, '<span>HTML Content</span>')
+      expect(element.innerHTML).toBe('<span>HTML Content</span>')
+      expect(DOMHelper.html(element)).toBe('<span>HTML Content</span>')
+    })
+
+    it('should get and set text content', () => {
+      const element = DOMHelper.$('#test')
+
+      DOMHelper.text(element, 'Text Content')
+      expect(element.textContent).toBe('Text Content')
+      expect(DOMHelper.text(element)).toBe('Text Content')
+    })
+  })
+
+  describe('Traversal methods', () => {
+    beforeEach(() => {
+      document.body.innerHTML = `
+        <div class="container">
+          <div id="parent">
+            <span class="sibling-before">Before</span>
+            <div id="target" class="target">Target</div>
+            <span class="sibling-after">After</span>
+            <div class="child">Child 1</div>
+            <div class="child">Child 2</div>
+          </div>
+        </div>
+      `
+    })
+
+    it('should get parent element', () => {
+      const target = DOMHelper.$('#target')
+      const parent = DOMHelper.parent(target)
+
+      expect(parent.id).toBe('parent')
+    })
+
+    it('should get parent element with selector', () => {
+      const target = DOMHelper.$('#target')
+      const container = DOMHelper.parent(target, '.container')
+
+      expect(container.className).toBe('container')
+    })
+
+    it('should get children elements', () => {
+      const parent = DOMHelper.$('#parent')
+      const children = DOMHelper.children(parent)
+
+      expect(children).toHaveLength(5)
+    })
+
+    it('should get children elements with selector', () => {
+      const parent = DOMHelper.$('#parent')
+      const children = DOMHelper.children(parent, '.child')
+
+      expect(children).toHaveLength(2)
+    })
+
+    it('should get next sibling', () => {
+      const target = DOMHelper.$('#target')
+      const next = DOMHelper.next(target)
+
+      expect(next.className).toBe('sibling-after')
+    })
+
+    it('should get next sibling with selector', () => {
+      const target = DOMHelper.$('#target')
+      const nextChild = DOMHelper.next(target, '.child')
+
+      expect(nextChild.className).toBe('child')
+    })
+
+    it('should get previous sibling', () => {
+      const target = DOMHelper.$('#target')
+      const prev = DOMHelper.prev(target)
+
+      expect(prev.className).toBe('sibling-before')
+    })
+
+    it('should iterate over elements', () => {
+      const children = DOMHelper.$$('.child')
+      const texts = []
+
+      DOMHelper.each(children, (_, element) => {
+        texts.push(element.textContent)
+      })
+      expect(texts).toEqual(['Child 1', 'Child 2'])
+    })
+
+    it('should iterate over elements with selector', () => {
+      const texts = []
+
+      DOMHelper.each('.child', (_, element) => {
+        texts.push(element.textContent)
+      })
+      expect(texts).toEqual(['Child 1', 'Child 2'])
+    })
+
+    it('should handle single element input', () => {
+      const element = DOMHelper.$('#parent')
+      const texts = []
+
+      DOMHelper.each(element, (_, el) => {
+        texts.push(el.tagName)
+      })
+      expect(texts).toEqual(['DIV'])
+    })
+
+    it('should handle NodeList input', () => {
+      const nodeList = document.querySelectorAll('.child')
+      const texts = []
+
+      DOMHelper.each(nodeList, (_, element) => {
+        texts.push(element.textContent)
+      })
+      expect(texts).toEqual(['Child 1', 'Child 2'])
+    })
+
+    it('should handle array input', () => {
+      const elements = [DOMHelper.$('.child'), DOMHelper.$('.child:last-child')]
+      const texts = []
+
+      DOMHelper.each(elements, (_, element) => {
+        texts.push(element.textContent)
+      })
+      expect(texts).toEqual(['Child 1', 'Child 2'])
+    })
+
+    it('should handle non-iterable object by wrapping in array', () => {
+      const singleElement = DOMHelper.$('.child')
+      const texts = []
+
+      DOMHelper.each(singleElement, (_, element) => {
+        texts.push(element.textContent)
+      })
+      expect(texts).toEqual(['Child 1'])
+    })
+  })
+
+  describe('Position methods', () => {
+    beforeEach(() => {
+      document.body.innerHTML = '<div id="test" style="position: absolute; top: 100px; left: 200px; width: 50px; height: 30px;"></div>'
+    })
+
+    it('should get element position relative to parent', () => {
+      const element = DOMHelper.$('#test')
+      const position = DOMHelper.position(element)
+
+      expect(position).toHaveProperty('top')
+      expect(position).toHaveProperty('left')
+      expect(typeof position.top).toBe('number')
+      expect(typeof position.left).toBe('number')
+    })
+
+    it('should get element offset relative to document', () => {
+      const element = DOMHelper.$('#test')
+      const offset = DOMHelper.offset(element)
+
+      expect(offset).toHaveProperty('top')
+      expect(offset).toHaveProperty('left')
+      expect(offset).toHaveProperty('width')
+      expect(offset).toHaveProperty('height')
+      expect(typeof offset.top).toBe('number')
+      expect(typeof offset.left).toBe('number')
+      expect(typeof offset.width).toBe('number')
+      expect(typeof offset.height).toBe('number')
+    })
+  })
+
+  describe('Utility methods', () => {
+    beforeEach(() => {
+      document.body.innerHTML = '<div id="test" class="my-class"></div>'
+    })
+
+    it('should check if element matches selector', () => {
+      const element = DOMHelper.$('#test')
+
+      expect(DOMHelper.is(element, '#test')).toBe(true)
+      expect(DOMHelper.is(element, '.my-class')).toBe(true)
+      expect(DOMHelper.is(element, 'div')).toBe(true)
+      expect(DOMHelper.is(element, '.nonexistent')).toBe(false)
+    })
+  })
+
+  describe('Error handling', () => {
+    it('should handle null/undefined elements gracefully', () => {
+      expect(DOMHelper.addClass(null, 'class')).toBeNull()
+      expect(DOMHelper.removeClass(undefined, 'class')).toBeUndefined()
+      expect(DOMHelper.attr(null, 'attr')).toBeNull()
+      expect(DOMHelper.css(undefined, 'prop')).toBeNull()
+      expect(DOMHelper.width(null)).toBe(0)
+      expect(DOMHelper.height(undefined)).toBe(0)
+    })
+
+    it('should handle non-existent selectors gracefully', () => {
+      expect(DOMHelper.addClass('#nonexistent', 'class')).toBeNull()
+      expect(DOMHelper.removeClass('#nonexistent', 'class')).toBeNull()
+      expect(DOMHelper.attr('#nonexistent', 'attr')).toBeNull()
+      expect(DOMHelper.width('#nonexistent')).toBe(0)
+    })
+
+    it('should return null for getter methods when element not found', () => {
+      // Test css method
+      expect(DOMHelper.css('#nonexistent', 'color')).toBeNull()
+      expect(DOMHelper.css('#nonexistent', {})).toBeNull()
+
+      // Test val method
+      expect(DOMHelper.val('#nonexistent')).toBeNull()
+
+      // Test html method
+      expect(DOMHelper.html('#nonexistent')).toBeNull()
+
+      // Test text method
+      expect(DOMHelper.text('#nonexistent')).toBeNull()
+    })
+  })
+})

--- a/tests/utils/index.test.js
+++ b/tests/utils/index.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import Utils from '@/utils/index.js'
 
 describe('normalizeAccent', () => {
@@ -296,6 +296,7 @@ describe('normalizeAccent', () => {
   it('should handle edge cases', () => {
     // Test very long strings
     const longString = 'Á'.repeat(1000)
+
     expect(Utils.normalizeAccent(longString)).toBe('a'.repeat(1000))
   })
 })
@@ -360,7 +361,7 @@ describe('isObject', () => {
 
   it('should return false for functions', () => {
     expect(Utils.isObject(() => {})).toBe(false)
-    expect(Utils.isObject(function() {})).toBe(false)
+    expect(Utils.isObject(function () {})).toBe(false)
   })
 
   it('should return false for Date objects', () => {
@@ -442,6 +443,7 @@ describe('extend', () => {
     const obj1 = { a: 1 }
     const obj2 = { b: 2 }
     const result = Utils.extend(obj1, obj2)
+
     expect(result).toEqual({ a: 1, b: 2 })
   })
 
@@ -449,6 +451,7 @@ describe('extend', () => {
     const obj1 = { a: 1, b: 2 }
     const obj2 = { b: 3, c: 4 }
     const result = Utils.extend(obj1, obj2)
+
     expect(result).toEqual({ a: 1, b: 3, c: 4 })
   })
 
@@ -456,6 +459,7 @@ describe('extend', () => {
     const obj1 = { a: { x: 1 } }
     const obj2 = { a: { y: 2 } }
     const result = Utils.extend(true, obj1, obj2)
+
     expect(result).toEqual({ a: { x: 1, y: 2 } })
   })
 
@@ -464,23 +468,27 @@ describe('extend', () => {
     const obj2 = { b: 2 }
     const obj3 = { c: 3 }
     const result = Utils.extend(obj1, obj2, obj3)
+
     expect(result).toEqual({ a: 1, b: 2, c: 3 })
   })
 
   it('should handle empty objects', () => {
     const result = Utils.extend({}, { a: 1 })
+
     expect(result).toEqual({ a: 1 })
   })
 
   it('should handle null and undefined sources', () => {
     const obj = { a: 1 }
     const result = Utils.extend(obj, null, undefined, { b: 2 })
+
     expect(result).toEqual({ a: 1, b: 2 })
   })
 
   it('should not modify source objects in shallow merge', () => {
     const obj1 = { a: 1 }
     const obj2 = { b: 2 }
+
     Utils.extend({}, obj1, obj2)
     expect(obj1).toEqual({ a: 1 })
     expect(obj2).toEqual({ b: 2 })
@@ -490,6 +498,7 @@ describe('extend', () => {
     const obj1 = { arr: [1, 2] }
     const obj2 = { arr: [3, 4] }
     const result = Utils.extend(obj1, obj2)
+
     expect(result.arr).toEqual([3, 4])
   })
 })
@@ -499,6 +508,7 @@ describe('addQueryToUrl', () => {
     const url = 'https://example.com/page'
     const query = { foo: 'bar', baz: 'qux' }
     const result = Utils.addQueryToUrl(url, query)
+
     expect(result).toContain('foo=bar')
     expect(result).toContain('baz=qux')
   })
@@ -507,6 +517,7 @@ describe('addQueryToUrl', () => {
     const url = 'https://example.com/page?existing=param'
     const query = { foo: 'bar' }
     const result = Utils.addQueryToUrl(url, query)
+
     expect(result).toContain('existing=param')
     expect(result).toContain('foo=bar')
   })
@@ -515,6 +526,7 @@ describe('addQueryToUrl', () => {
     const url = 'https://example.com/page?foo=old'
     const query = { foo: 'new' }
     const result = Utils.addQueryToUrl(url, query)
+
     expect(result).toContain('foo=new')
     expect(result).not.toContain('foo=old')
   })
@@ -523,6 +535,7 @@ describe('addQueryToUrl', () => {
     const url = 'https://example.com/page#section'
     const query = { foo: 'bar' }
     const result = Utils.addQueryToUrl(url, query)
+
     expect(result).toContain('#section')
     expect(result).toContain('foo=bar')
   })
@@ -531,6 +544,7 @@ describe('addQueryToUrl', () => {
     const url = 'https://example.com/page?existing=param#section'
     const query = { foo: 'bar' }
     const result = Utils.addQueryToUrl(url, query)
+
     expect(result).toContain('existing=param')
     expect(result).toContain('foo=bar')
     expect(result).toContain('#section')
@@ -540,6 +554,7 @@ describe('addQueryToUrl', () => {
     const url = 'https://example.com/page'
     const query = {}
     const result = Utils.addQueryToUrl(url, query)
+
     expect(result).toContain('https://example.com/page')
   })
 
@@ -547,6 +562,7 @@ describe('addQueryToUrl', () => {
     const url = 'https://example.com/page'
     const query = { search: 'hello world', special: '!@#$' }
     const result = Utils.addQueryToUrl(url, query)
+
     expect(result).toContain('search=')
     expect(result).toContain('special=')
   })
@@ -555,6 +571,7 @@ describe('addQueryToUrl', () => {
     const url = 'https://example.com/page#section#subsection'
     const query = { foo: 'bar' }
     const result = Utils.addQueryToUrl(url, query)
+
     expect(result).toContain('#section#subsection')
   })
 })

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -5,7 +5,7 @@ export default defineConfig({
   test: {
     environment: 'happy-dom',
     include: [
-      'tests/utils/**/*.js'
+      'tests/**/*.js'
     ]
   },
   resolve: {


### PR DESCRIPTION
* Add native JavaScript DOM manipulation library as phase 1 of the jQuery removal plan.
* Includes comprehensive test coverage with 134 passing tests.

**🤔Type of Request**
- [ ] **Bug fix**
- [x] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**