### PR TITLE
Fixed style attributes not being preserved on thead>tr>th elements

### DIFF
--- a/src/modules/header.js
+++ b/src/modules/header.js
@@ -106,7 +106,7 @@ export default {
           column.checkbox || column.radio ?
             Utils.sprintf(' class="bs-checkbox %s"', column['class'] || '') :
             classes || class_,
-          Utils.sprintf(' style="%s"', halign + style + csses.join('; ') || undefined),
+          Utils.sprintf(' style="%s"', (column.style || '') + halign + style + csses.join('; ') || undefined),
           Utils.sprintf(' rowspan="%s"', column.rowspan),
           Utils.sprintf(' colspan="%s"', column.colspan),
           Utils.sprintf(' scope="%s"', column.scope),

--- a/src/modules/initialization.js
+++ b/src/modules/initialization.js
@@ -171,7 +171,8 @@ export default {
           titleTooltip: $th.attr('title'),
           rowspan: $th.attr('rowspan') ? +$th.attr('rowspan') : undefined,
           colspan: $th.attr('colspan') ? +$th.attr('colspan') : undefined,
-          scope: $th.attr('scope') ? $th.attr('scope') : undefined
+          scope: $th.attr('scope') ? $th.attr('scope') : undefined,
+          style: Utils.normalizeStyle($th.attr('style'))
         }, $th.data()))
       })
       columns.push(column)

--- a/src/utils/string.js
+++ b/src/utils/string.js
@@ -6,6 +6,7 @@
  * - HTML escaping and unescaping
  * - Accent character normalization for search
  * - HTML tag removal
+ * - CSS style string normalization
  *
  * @module utils/string
  */
@@ -208,4 +209,30 @@ export function normalizeAccent (value) {
     .replace(pattern, char => ACCENT_MAP[char])
     .toLowerCase()
     .trim()
+}
+
+/**
+ * Normalizes a CSS style string by ensuring it ends with '; ' for proper concatenation.
+ * Returns undefined if the input is empty or contains only whitespace.
+ *
+ * @param {string|undefined} style - The style string to normalize.
+ * @returns {string|undefined} The normalized style string ending with '; ', or undefined.
+ * @example
+ * normalizeStyle('color: red')  // returns 'color: red; '
+ * normalizeStyle('color: red;') // returns 'color: red; '
+ * normalizeStyle('')            // returns undefined
+ * normalizeStyle(undefined)     // returns undefined
+ */
+export function normalizeStyle (style) {
+  if (!style) {
+    return undefined
+  }
+
+  const trimmed = style.trim()
+
+  if (!trimmed) {
+    return undefined
+  }
+
+  return trimmed.replace(/;?\s*$/, '; ')
 }

--- a/tests/utils/string.test.js
+++ b/tests/utils/string.test.js
@@ -459,3 +459,48 @@ describe('normalizeAccent', () => {
     expect(string.normalizeAccent(longString)).toBe('a'.repeat(1000))
   })
 })
+
+describe('normalizeStyle', () => {
+  it('should return undefined for falsy values', () => {
+    expect(string.normalizeStyle(undefined)).toBe(undefined)
+    expect(string.normalizeStyle(null)).toBe(undefined)
+    expect(string.normalizeStyle('')).toBe(undefined)
+    expect(string.normalizeStyle('   ')).toBe(undefined)
+    expect(string.normalizeStyle('\t\n')).toBe(undefined)
+  })
+
+  it('should add trailing semicolon and space to style without one', () => {
+    expect(string.normalizeStyle('color: red')).toBe('color: red; ')
+    expect(string.normalizeStyle('text-align: center')).toBe('text-align: center; ')
+    expect(string.normalizeStyle('width: 100px')).toBe('width: 100px; ')
+  })
+
+  it('should preserve existing trailing semicolon', () => {
+    expect(string.normalizeStyle('color: red;')).toBe('color: red; ')
+    expect(string.normalizeStyle('color: red; ')).toBe('color: red; ')
+    expect(string.normalizeStyle('color: red;  ')).toBe('color: red; ')
+  })
+
+  it('should handle multiple CSS properties', () => {
+    expect(string.normalizeStyle('color: red; background: blue')).toBe('color: red; background: blue; ')
+    expect(string.normalizeStyle('color: red;background: blue')).toBe('color: red;background: blue; ')
+    expect(string.normalizeStyle('color: red; background: blue;')).toBe('color: red; background: blue; ')
+  })
+
+  it('should trim leading and trailing whitespace', () => {
+    expect(string.normalizeStyle('  color: red  ')).toBe('color: red; ')
+    expect(string.normalizeStyle('\tcolor: red\n')).toBe('color: red; ')
+    expect(string.normalizeStyle('  color: red;  ')).toBe('color: red; ')
+  })
+
+  it('should handle complex CSS values', () => {
+    expect(string.normalizeStyle('background: url("test.png")')).toBe('background: url("test.png"); ')
+    expect(string.normalizeStyle('font-family: Arial, sans-serif')).toBe('font-family: Arial, sans-serif; ')
+    expect(string.normalizeStyle('box-shadow: 0 0 5px rgba(0,0,0,0.5)')).toBe('box-shadow: 0 0 5px rgba(0,0,0,0.5); ')
+  })
+
+  it('should handle !important declarations', () => {
+    expect(string.normalizeStyle('color: red !important')).toBe('color: red !important; ')
+    expect(string.normalizeStyle('color: red !important;')).toBe('color: red !important; ')
+  })
+})


### PR DESCRIPTION
**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
Fix #5470

**📝Changelog**

<!-- The type of the change. --->
- [x] **Core**
- [ ] **Extensions**

Fixed style attributes not being preserved on `thead>tr>th` elements

**💡Example(s)?**
Before: https://live.bootstrap-table.com/code/dmalan/5627
After: https://live.bootstrap-table.com/code/wenzhixin/19117

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
