### PR TITLE
fix: prevent division by zero when pageSize is 0 or negative

### DIFF
--- a/src/modules/pagination.js
+++ b/src/modules/pagination.js
@@ -50,6 +50,11 @@ export default {
         allSelected = true
       }
 
+      if (opts.pageSize <= 0) {
+        opts.pageSize = opts.totalRows
+        allSelected = true
+      }
+
       this.totalPages = ~~((opts.totalRows - 1) / opts.pageSize) + 1
 
       opts.totalPages = this.totalPages


### PR DESCRIPTION
In initPagination, if pageSize is 0 or negative, the calculation ~~((totalRows - 1) / pageSize) + 1 causes a division by zero. Added a guard to treat pageSize <= 0 the same as 'show all rows', which sets pageSize to totalRows and allSelected to true. All 339 existing tests pass.