### PR TITLE
fix(filter-control): Keep current page on refresh with cookie

### DIFF
--- a/src/extensions/filter-control/bootstrap-table-filter-control.js
+++ b/src/extensions/filter-control/bootstrap-table-filter-control.js
@@ -193,7 +193,6 @@ $.BootstrapTable = class extends $.BootstrapTable {
     }
 
     UtilsFilterControl.createControls(this, UtilsFilterControl.getControlContainer(this))
-    this._initialized = true
   }
 
   initSearch () {
@@ -519,6 +518,7 @@ $.BootstrapTable = class extends $.BootstrapTable {
     })
 
     this.onSearch({ currentTarget, firedByInitSearchText: isInitialRender }, false)
+    this._initialized = true
   }
 
   toggleFilterControl () {


### PR DESCRIPTION
## Summary

This commit fixes an issue where using the filter-control and cookie extensions together would cause the table to reset to the first page upon refresh. The problem was that an initialization flag was set prematurely, causing the initial filter application from cookies to be treated as a user-initiated search. The fix defers setting this flag until after the first search event, ensuring the initial page number from the cookie is respected.

## Changes

- **src/extensions/filter-control/bootstrap-table-filter-control.js**: The `this._initialized = true` line was removed from the `initHeader` method to prevent it from being set prematurely. This line was moved to the end of the `onColumnSearch` method. This change ensures that the initial search triggered by the cookie extension on page load is correctly identified as an initial render, which preserves the saved page number, while subsequent user-initiated searches will correctly reset the page to 1.

## Related Issue

Closes #8246

