### PR TITLE
Mark vue as external dependency in vite config

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -13,6 +13,7 @@ export default defineConfig({
       formats: ['es', 'umd']
     },
     rollupOptions: {
+      external: ['vue'],
       output: {
         globals: {
           vue: 'Vue'


### PR DESCRIPTION
**🤔Type of Request**
- [ ] **Bug fix**
- [ ] **New feature**
- [x] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**📝Changelog**

- [x] **Core**
- [ ] **Extensions**

Mark `vue` as an external dependency in the Vite build config so it is not bundled into the output, relying on the global `Vue` variable instead.

**☑️Self Check before Merge**

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed