### PR TITLE
fix: simplify isCollapsed to support function and array via Utils.calculateObjectValue

### DIFF
--- a/src/extensions/cookie/bootstrap-table-cookie.js
+++ b/src/extensions/cookie/bootstrap-table-cookie.js
@@ -242,8 +242,7 @@ $.BootstrapTable = class extends $.BootstrapTable {
       this._filterControlValuesLoaded = false
 
       this.options.cookiesEnabled = typeof this.options.cookiesEnabled === 'string' ?
-        this.options.cookiesEnabled.replace('[', '').replace(']', '')
-          .replace(/'/g, '').replace(/ /g, '').split(',') :
+        Utils.parseStringArray(this.options.cookiesEnabled) :
         this.options.cookiesEnabled
 
       if (this.options.filterControl) {

--- a/src/extensions/group-by-v2/bootstrap-table-group-by.js
+++ b/src/extensions/group-by-v2/bootstrap-table-group-by.js
@@ -65,12 +65,17 @@ BootstrapTable.prototype.initSort = function (...args) {
     this._groupCollapsedState = new Map()
     // Pre-populate with default collapsed groups
     if (this.options.groupByCollapsedGroups) {
-      const collapsedGroups = Array.isArray(this.options.groupByCollapsedGroups) ?
-        this.options.groupByCollapsedGroups : []
+      let collapsedGroups = this.options.groupByCollapsedGroups
 
-      collapsedGroups.forEach(group => {
-        this._groupCollapsedState.set(group, true)
-      })
+      if (typeof collapsedGroups === 'string') {
+        collapsedGroups = Utils.parseStringArray(collapsedGroups)
+      }
+
+      if (Array.isArray(collapsedGroups)) {
+        collapsedGroups.forEach(group => {
+          this._groupCollapsedState.set(group, true)
+        })
+      }
     }
   }
   if (this.options.sortName !== this.options.groupByField) {
@@ -275,7 +280,13 @@ BootstrapTable.prototype.isCollapsed = function (groupKey) {
     return this._groupCollapsedState.get(groupKey)
   }
 
-  const result = Utils.calculateObjectValue(this.options, this.options.groupByCollapsedGroups, [groupKey], false)
+  let groupByCollapsedGroups = this.options.groupByCollapsedGroups
+
+  if (typeof groupByCollapsedGroups === 'string') {
+    groupByCollapsedGroups = Utils.parseStringArray(groupByCollapsedGroups)
+  }
+
+  const result = Utils.calculateObjectValue(this.options, groupByCollapsedGroups, [groupKey], false)
 
   if (Array.isArray(result)) {
     return result.includes(groupKey)

--- a/src/extensions/group-by-v2/bootstrap-table-group-by.js
+++ b/src/extensions/group-by-v2/bootstrap-table-group-by.js
@@ -275,15 +275,14 @@ BootstrapTable.prototype.isCollapsed = function (groupKey) {
     return this._groupCollapsedState.get(groupKey)
   }
 
-  // Backwards compatibility: support groupByCollapsedGroups as array or function
-  const collapsedGroups = this.options.groupByCollapsedGroups
+  const result = Utils.calculateObjectValue(this.options, this.options.groupByCollapsedGroups, [groupKey], false)
 
-  if (typeof collapsedGroups === 'function') {
-    return Utils.calculateObjectValue(this.options, collapsedGroups, [groupKey], false)
+  if (Array.isArray(result)) {
+    return result.includes(groupKey)
   }
 
-  if (Array.isArray(collapsedGroups)) {
-    return collapsedGroups.includes(groupKey)
+  if (typeof result === 'boolean') {
+    return result
   }
 
   return false

--- a/src/modules/pagination.js
+++ b/src/modules/pagination.js
@@ -36,7 +36,7 @@ export default {
 
     this.paginationParts = opts.paginationParts
     if (typeof this.paginationParts === 'string') {
-      this.paginationParts = this.paginationParts.replace(/\[|\]| |'/g, '').split(',')
+      this.paginationParts = Utils.parseStringArray(this.paginationParts)
     }
 
     if (opts.sidePagination !== 'server') {

--- a/src/modules/toolbar.js
+++ b/src/modules/toolbar.js
@@ -28,7 +28,7 @@ export default {
     ].join(' ')}">`]
 
     if (typeof opts.buttonsOrder === 'string') {
-      opts.buttonsOrder = opts.buttonsOrder.replace(/\[|\]| |'/g, '').split(',')
+      opts.buttonsOrder = Utils.parseStringArray(opts.buttonsOrder)
     }
 
     this.buttons = Object.assign(this.buttons, {

--- a/src/utils/helper.js
+++ b/src/utils/helper.js
@@ -154,3 +154,39 @@ export function isIEBrowser () {
   return navigator.userAgent.includes('MSIE ') ||
     /Trident.*rv:11\./.test(navigator.userAgent)
 }
+
+/**
+ * Parse a string into an array of strings.
+ * @param {string} str - Input string in formats like "['a', 'b']", "[1, 2]", "a,b", or "[]".
+ * @returns {string[]} Parsed array of strings.
+ */
+export function parseStringArray (str) {
+  if (!str) {
+    return []
+  }
+
+  const normalized = String(str).trim()
+
+  if (!normalized || normalized === '[]') {
+    return []
+  }
+
+  if (normalized.startsWith('[') && normalized.endsWith(']')) {
+    try {
+      const parsed = JSON.parse(normalized)
+
+      if (Array.isArray(parsed)) {
+        return parsed
+          .map(item => String(item))
+          .filter(item => item !== '')
+      }
+    } catch {
+      // Fall back to delimiter-based parsing for non-JSON array strings.
+    }
+  }
+
+  return normalized
+    .replace(/\[|\]|['"\s]/g, '')
+    .split(',')
+    .filter(item => item !== '')
+}

--- a/tests/utils/helper.test.js
+++ b/tests/utils/helper.test.js
@@ -418,3 +418,37 @@ describe('isIEBrowser', () => {
     }
   })
 })
+
+describe('parseStringArray', () => {
+  it('should parse string with brackets, quotes and spaces', () => {
+    expect(helper.parseStringArray('[\'a\', \'b\', \'c\']')).toEqual(['a', 'b', 'c'])
+  })
+
+  it('should parse string with brackets and spaces but no quotes', () => {
+    expect(helper.parseStringArray('[a, b, c]')).toEqual(['a', 'b', 'c'])
+  })
+
+  it('should parse comma-separated string', () => {
+    expect(helper.parseStringArray('a,b,c')).toEqual(['a', 'b', 'c'])
+  })
+
+  it('should parse numeric elements', () => {
+    expect(helper.parseStringArray('[10, 25, 50]')).toEqual(['10', '25', '50'])
+  })
+
+  it('should parse single element', () => {
+    expect(helper.parseStringArray('[\'only\']')).toEqual(['only'])
+  })
+
+  it('should parse JSON-style array with double quotes', () => {
+    expect(helper.parseStringArray('["a","b","c"]')).toEqual(['a', 'b', 'c'])
+  })
+
+  it('should return empty array for empty array string', () => {
+    expect(helper.parseStringArray('[]')).toEqual([])
+  })
+
+  it('should return empty array for empty string', () => {
+    expect(helper.parseStringArray('')).toEqual([])
+  })
+})


### PR DESCRIPTION
**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
<!-- Please prefix each issue number with  "Fix #"  (e.g. Fix #200)  -->

**📝Changelog**

<!-- The type of the change. --->
- [x] **Extensions**

<!-- Describe changes from the user side. -->
- Simplified `isCollapsed` method to use `Utils.calculateObjectValue` for both function and array types of `groupByCollapsedGroups`, keeping it consistent with how other options are handled throughout the codebase.
- Extracted `parseStringArray` utility function to eliminate code duplication across pagination, toolbar, group-by, and cookie extensions.

**💡Example(s)?**
Before: https://live.bootstrap-table.com/code/designdisorder/19179
After: https://live.bootstrap-table.com/code/designdisorder/19179

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->