### PR TITLE
Fix filter-control select option loss and sticky-header undefined crash

### DIFF
--- a/src/extensions/filter-control/utils.js
+++ b/src/extensions/filter-control/utils.js
@@ -474,18 +474,11 @@ export function createControls (that, header) {
       const $selectControl = $(currentTarget)
       const value = $selectControl.val()
 
-      if (Array.isArray(value)) {
-        for (let i = 0; i < value.length; i++) {
-          if (value[i] && value[i].length > 0 && value[i].trim()) {
-            $selectControl.find(`option[value="${value[i]}"]`).attr('selected', true)
-          }
-        }
-      } else if (value && value.length > 0 && value.trim()) {
-        $selectControl.find('option[selected]').removeAttr('selected')
-        $selectControl.find(`option[value="${value}"]`).attr('selected', true)
-      } else {
-        $selectControl.find('option[selected]').removeAttr('selected')
-      }
+      const normalizedValue = value === null ?
+        $selectControl.prop('multiple') ? [] : null :
+        value
+
+      $selectControl.val(normalizedValue)
 
       clearTimeout(currentTarget.timeoutId || 0)
       currentTarget.timeoutId = setTimeout(() => {

--- a/src/extensions/sticky-header/bootstrap-table-sticky-header.js
+++ b/src/extensions/sticky-header/bootstrap-table-sticky-header.js
@@ -89,6 +89,14 @@ $.BootstrapTable = class extends $.BootstrapTable {
   renderStickyHeader () {
     const that = this
 
+    if (
+      !this.$stickyContainer || !this.$stickyContainer.length ||
+      !this.$stickyBegin || !this.$stickyBegin.length ||
+      !this.$stickyEnd || !this.$stickyEnd.length
+    ) {
+      return
+    }
+
     this.$stickyHeader = this.$header.clone(true, true)
 
     if (this.options.filterControl) {
@@ -103,8 +111,11 @@ $.BootstrapTable = class extends $.BootstrapTable {
         } else if ($target.is('select')) {
           const $select = $coreTh.find('select')
 
-          $select.find('option[selected]').removeAttr('selected')
-          $select.find(`option[value="${value}"]`).attr('selected', true)
+          const normalizedValue = value === null ?
+            $select.prop('multiple') ? [] : null :
+            value
+
+          $select.val(normalizedValue)
         }
 
         that.triggerSearch()


### PR DESCRIPTION
**🤔Type of Request**
- [x] **Bug fix**

**🔗Resolves an issue?**
Fix #6950

**📝Changelog**

- [ ] **Core**
- [x] **Extensions**
- Fixed filter-control select `on change` event firing multiple times and selected option being lost, by replacing manual option toggle with `.val()` for reliable value syncing
- Fixed sticky-header `Cannot read properties of undefined (reading 'offset')` error when `$stickyBegin` / `$stickyEnd` / `$stickyContainer` are undefined

**💡Example(s)?**
<!-- Please use our online Editor (https://live.bootstrap-table.com/) to create example(s) (Before and after your changes).
On our Wiki (https://github.com/wenzhixin/bootstrap-table/wiki/Online-Editor-Explanation) you can read how to use the editor.-->

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->