### PR TITLE
Fix guard against pageSize <= 0 causing division by zero in initPagination

### DIFF
--- a/src/modules/pagination.js
+++ b/src/modules/pagination.js
@@ -44,6 +44,11 @@ export default {
     }
 
     this.totalPages = 0
+    if (opts.pageSize <= 0) {
+      console.warn('pageSize must be a positive number, falling back to show all rows.')
+      opts.pageSize = opts.totalRows || 1
+      allSelected = true
+    }
     if (opts.totalRows) {
       if (opts.pageSize === opts.formatAllRows()) {
         opts.pageSize = opts.totalRows


### PR DESCRIPTION
**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
Replaces #8271

**📝Changelog**
- [x] **Core**
- [ ] **Extensions**

Fix division by zero when `pageSize` is 0 or negative by moving the guard before `if (opts.totalRows)` to also cover the `pageFrom`/`pageTo` calculation. Added `console.warn` for invalid input to help developers detect configuration errors.

**💡Example(s)?**

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->