### PR TITLE
Fix table layout breaking when sorting rows with rowspan

### DIFF
--- a/src/modules/data.js
+++ b/src/modules/data.js
@@ -186,6 +186,10 @@ export default {
         })
       }
 
+      if (Utils.hasRowspanCells(this.data)) {
+        Utils.flattenRowspanCells(this.data)
+      }
+
       if (this.options.customSort) {
         Utils.calculateObjectValue(this.options, this.options.customSort, [
           this.options.sortName,

--- a/src/utils/table-data.js
+++ b/src/utils/table-data.js
@@ -272,3 +272,69 @@ export function checkAutoMergeCells (data) {
   }
   return false
 }
+
+/**
+ * Checks if any row in the data has rowspan cells with a span greater than 1.
+ *
+ * @param {Array.<Object.<string, *>>} data - The data array to check.
+ * @returns {boolean} True if any row has real rowspan merges, false otherwise.
+ */
+export function hasRowspanCells (data) {
+  for (const row of data) {
+    for (const key of Object.keys(row)) {
+      if (key.startsWith('_') && key.endsWith('_rowspan') && (+row[key] || 0) > 1) {
+        return true
+      }
+    }
+  }
+  return false
+}
+
+/**
+ * Flattens rowspan cells in the data by copying the cell value from the
+ * rowspan parent row into all spanned child rows, so each row becomes
+ * independent and can be sorted without breaking the table layout.
+ *
+ * @param {Array.<Object.<string, *>>} data - The data array to flatten.
+ */
+export function flattenRowspanCells (data) {
+  for (let i = 0; i < data.length; i++) {
+    const row = data[i]
+
+    for (const key of Object.keys(row)) {
+      if (!key.startsWith('_') || !key.endsWith('_rowspan')) {
+        continue
+      }
+      const field = key.replace(/^_/, '').replace(/_rowspan$/, '')
+      const rowspan = +row[key] || 1
+
+      if (rowspan <= 1) {
+        continue
+      }
+
+      const value = getItemField(row, field, false)
+      const useFlatKey = row.hasOwnProperty(field)
+
+      for (let j = 1; j < rowspan && i + j < data.length; j++) {
+        const childRow = data[i + j]
+
+        if (field.includes('.') && !useFlatKey) {
+          const props = field.split('.')
+          let target = childRow
+
+          for (let k = 0; k < props.length - 1; k++) {
+            if (typeof target[props[k]] !== 'object' || target[props[k]] === null) {
+              target[props[k]] = {}
+            }
+            target = target[props[k]]
+          }
+          target[props[props.length - 1]] = value
+        } else {
+          childRow[field] = value
+        }
+        delete childRow[`_${field}_rowspan`]
+      }
+      delete row[key]
+    }
+  }
+}

--- a/tests/utils/table-data.test.js
+++ b/tests/utils/table-data.test.js
@@ -436,6 +436,158 @@ describe('checkAutoMergeCells', () => {
   })
 })
 
+describe('hasRowspanCells', () => {
+  it('should return true when rowspan > 1', () => {
+    const data = [{ name: 'A', _name_rowspan: 3 }]
+
+    expect(tableData.hasRowspanCells(data)).toBe(true)
+  })
+
+  it('should return false when rowspan is 1', () => {
+    const data = [{ name: 'A', _name_rowspan: 1 }]
+
+    expect(tableData.hasRowspanCells(data)).toBe(false)
+  })
+
+  it('should return false when rowspan is null', () => {
+    const data = [{ name: 'A', _name_rowspan: null }]
+
+    expect(tableData.hasRowspanCells(data)).toBe(false)
+  })
+
+  it('should return false for empty array', () => {
+    expect(tableData.hasRowspanCells([])).toBe(false)
+  })
+
+  it('should check all rows', () => {
+    const data = [
+      { name: 'A' },
+      { name: 'B', _name_rowspan: 2 }
+    ]
+
+    expect(tableData.hasRowspanCells(data)).toBe(true)
+  })
+})
+
+describe('flattenRowspanCells', () => {
+  it('should copy rowspan cell value to spanned rows', () => {
+    const data = [
+      { name: 'Item 1', _name_rowspan: 3 },
+      { price: 10 },
+      { price: 20 }
+    ]
+
+    tableData.flattenRowspanCells(data)
+
+    expect(data[0]._name_rowspan).toBeUndefined()
+    expect(data[1].name).toBe('Item 1')
+    expect(data[1]._name_rowspan).toBeUndefined()
+    expect(data[2].name).toBe('Item 1')
+    expect(data[2]._name_rowspan).toBeUndefined()
+  })
+
+  it('should not modify rows without rowspan', () => {
+    const data = [
+      { name: 'A', price: 1 },
+      { name: 'B', price: 2 }
+    ]
+
+    tableData.flattenRowspanCells(data)
+
+    expect(data[0].name).toBe('A')
+    expect(data[1].name).toBe('B')
+  })
+
+  it('should handle rowspan of 1', () => {
+    const data = [{ name: 'A', _name_rowspan: 1 }]
+
+    tableData.flattenRowspanCells(data)
+
+    expect(data[0].name).toBe('A')
+    expect(data[0]._name_rowspan).toBe(1)
+  })
+
+  it('should handle multiple rowspan fields in same row', () => {
+    const data = [
+      { group: 'G1', _group_rowspan: 2, tag: 'T1', _tag_rowspan: 2 },
+      { value: 1 }
+    ]
+
+    tableData.flattenRowspanCells(data)
+
+    expect(data[1].group).toBe('G1')
+    expect(data[1].tag).toBe('T1')
+    expect(data[1]._group_rowspan).toBeUndefined()
+    expect(data[1]._tag_rowspan).toBeUndefined()
+  })
+
+  it('should handle empty array', () => {
+    tableData.flattenRowspanCells([])
+  })
+
+  it('should not exceed data bounds', () => {
+    const data = [
+      { name: 'A', _name_rowspan: 10 },
+      { price: 1 }
+    ]
+
+    tableData.flattenRowspanCells(data)
+
+    expect(data[0]._name_rowspan).toBeUndefined()
+    expect(data[1].name).toBe('A')
+    expect(data.length).toBe(2)
+  })
+
+  it('should skip keys not starting with underscore', () => {
+    const data = [
+      { name: 'A', foo_rowspan: 2 },
+      { name: 'B' }
+    ]
+
+    tableData.flattenRowspanCells(data)
+
+    expect(data[0].foo_rowspan).toBe(2)
+    expect(data[1].name).toBe('B')
+  })
+
+  it('should handle dot-notation fields', () => {
+    const data = [
+      { user: { name: 'Alice' }, '_user.name_rowspan': 2 },
+      { price: 10 }
+    ]
+
+    tableData.flattenRowspanCells(data)
+
+    expect(data[1].user.name).toBe('Alice')
+    expect(data[1]['user.name']).toBeUndefined()
+    expect(data[0]['_user.name_rowspan']).toBeUndefined()
+  })
+
+  it('should handle dot-notation fields with non-object intermediate', () => {
+    const data = [
+      { user: { name: 'Alice' }, '_user.name_rowspan': 2 },
+      { user: null, price: 10 }
+    ]
+
+    tableData.flattenRowspanCells(data)
+
+    expect(data[1].user.name).toBe('Alice')
+    expect(data[0]['_user.name_rowspan']).toBeUndefined()
+  })
+
+  it('should handle dot-notation fields with flat keys', () => {
+    const data = [
+      { 'user.name': 'Alice', '_user.name_rowspan': 2 },
+      { price: 10 }
+    ]
+
+    tableData.flattenRowspanCells(data)
+
+    expect(data[1]['user.name']).toBe('Alice')
+    expect(data[0]['_user.name_rowspan']).toBeUndefined()
+  })
+})
+
 describe('trToData', () => {
   beforeEach(() => {
     // Create a table element for testing


### PR DESCRIPTION
**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
Fix #3462

**📝Changelog**

- [x] **Core**
- [ ] **Extensions**

Flatten rowspan cells before sorting to prevent table layout from breaking.

**💡Example(s)?**
- Before (broken): https://live.bootstrap-table.com/code/wenzhixin/19155
- After (fixed): https://live.bootstrap-table.com/code/wenzhixin/19156

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

---

### Why this approach?

When sorting a table with rowspan cells, the sort operation only reorders the data array without considering the visual grouping created by rowspan. This causes spanned rows to break away from their group, resulting in a broken table layout.

The fix flattens rowspan cells before sorting by copying the parent cell value into all spanned child rows, making each row independent. After sorting, the table renders correctly with each row containing its own data.

This approach is consistent with how **Excel** handles merged cells during sorting — Excel's recommended practice is to unmerge cells and fill values before sorting, as merged cells are fundamentally incompatible with sort operations. Excel even blocks sorting entirely on ranges with merged cells, showing the error: *"All the merged cells need to be the same size"*.

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->