### PR TITLE
Refactor showColumn/hideColumn to batch column toggles with single re-render

### DIFF
--- a/site/src/pages/docs/api/methods.mdx
+++ b/site/src/pages/docs/api/methods.mdx
@@ -284,8 +284,8 @@ For example: `$('#table').bootstrapTable('append', data)`
 
 - **Detail:**
 
-  Hide the specified `field` column.
-  The parameter can be a string or an array of fields.
+  Hide the specified column(s).
+  Supports hiding multiple columns at once by passing an array of fields, which triggers only a single re-render.
 
 - **Example:** [Show/Hide Column](https://examples.bootstrap-table.com/#methods/show-hide-column.html)
 
@@ -540,8 +540,8 @@ For example: `$('#table').bootstrapTable('append', data)`
 
 - **Detail:**
 
-  Show the specified `field` column.
-  The parameter can be a string or an array of fields.
+  Show the specified column(s).
+  Supports showing multiple columns at once by passing an array of fields, which triggers only a single re-render.
 
 - **Example:** [Show/Hide Column](https://examples.bootstrap-table.com/#methods/show-hide-column.html)
 

--- a/src/extensions/cookie/bootstrap-table-cookie.js
+++ b/src/extensions/cookie/bootstrap-table-cookie.js
@@ -363,8 +363,8 @@ $.BootstrapTable = class extends $.BootstrapTable {
     UtilsCookie.setCookie(this, UtilsCookie.cookieIds.pageNumber, this.options.pageNumber)
   }
 
-  _toggleColumn (...args) {
-    super._toggleColumn(...args)
+  _toggleColumns (...args) {
+    super._toggleColumns(...args)
     if (!this.options.cookie) {
       return
     }

--- a/src/extensions/filter-control/bootstrap-table-filter-control.js
+++ b/src/extensions/filter-control/bootstrap-table-filter-control.js
@@ -562,9 +562,11 @@ $.BootstrapTable = class extends $.BootstrapTable {
     })
   }
 
-  _toggleColumn (index, checked, needUpdate) {
-    this._initialized = false
-    super._toggleColumn(index, checked, needUpdate)
+  _toggleColumns (fields, checked, needUpdate) {
+    if (fields.length) {
+      this._initialized = false
+    }
+    super._toggleColumns(fields, checked, needUpdate)
     UtilsFilterControl.syncHeaders(this)
   }
 }

--- a/src/extensions/mobile/bootstrap-table-mobile.js
+++ b/src/extensions/mobile/bootstrap-table-mobile.js
@@ -94,14 +94,19 @@ $.BootstrapTable = class extends $.BootstrapTable {
   }
 
   showHideColumns (checked) {
-    if (this.options.columnsHidden.length > 0) {
-      this.columns.forEach(column => {
-        if (this.options.columnsHidden.includes(column.field)) {
-          if (column.visible !== checked) {
-            this._toggleColumn(this.fieldsColumnsIndex[column.field], checked, true)
-          }
-        }
-      })
+    if (this.options.columnsHidden.length === 0) {
+      return
+    }
+
+    const fieldsToToggle = this.columns
+      .filter(column =>
+        this.options.columnsHidden.includes(column.field) &&
+        column.visible !== checked
+      )
+      .map(column => column.field)
+
+    if (fieldsToToggle.length > 0) {
+      this._toggleColumns(fieldsToToggle, checked, true)
     }
   }
 

--- a/src/extensions/reorder-columns/bootstrap-table-reorder-columns.js
+++ b/src/extensions/reorder-columns/bootstrap-table-reorder-columns.js
@@ -86,8 +86,8 @@ $.BootstrapTable = class extends $.BootstrapTable {
     this.makeColumnsReorderable()
   }
 
-  _toggleColumn (...args) {
-    super._toggleColumn(...args)
+  _toggleColumns (...args) {
+    super._toggleColumns(...args)
 
     if (!this.options.reorderableColumns) {
       return

--- a/src/modules/body.js
+++ b/src/modules/body.js
@@ -624,26 +624,22 @@ export default {
   },
 
   showColumn (field) {
-    const fields = Array.isArray(field) ? field : [field]
-
-    fields.forEach(field => {
-      this._toggleColumn(this.fieldsColumnsIndex[field], true, true)
-    })
+    this._toggleColumns(Array.isArray(field) ? field : [field], true, true)
   },
 
   hideColumn (field) {
-    const fields = Array.isArray(field) ? field : [field]
-
-    fields.forEach(field => {
-      this._toggleColumn(this.fieldsColumnsIndex[field], false, true)
-    })
+    this._toggleColumns(Array.isArray(field) ? field : [field], false, true)
   },
 
-  _toggleColumn (index, checked, needUpdate) {
+  _toggleColumnVisibility (index, checked) {
     if (index === undefined || this.columns[index].visible === checked) {
-      return
+      return false
     }
     this.columns[index].visible = checked
+    return true
+  },
+
+  _updateAfterColumnToggle (changedIndices, checked, needUpdate) {
     this.initHeader()
     this.initSearch()
     this.initPagination()
@@ -653,12 +649,34 @@ export default {
       const $items = this.$toolbar.find('.keep-open input:not(".toggle-all")').prop('disabled', false)
 
       if (needUpdate) {
-        $items.filter(Utils.sprintf('[value="%s"]', index)).prop('checked', checked)
+        for (const index of changedIndices) {
+          $items.filter(Utils.sprintf('[value="%s"]', index)).prop('checked', checked)
+        }
       }
 
       if ($items.filter(':checked').length <= this.options.minimumCountColumns) {
         $items.filter(':checked').prop('disabled', true)
       }
+    }
+  },
+
+  _toggleColumns (fields, checked, needUpdate) {
+    if (!fields.length) {
+      return
+    }
+
+    const changedIndices = []
+
+    for (const field of fields) {
+      const index = this.fieldsColumnsIndex[field]
+
+      if (this._toggleColumnVisibility(index, checked)) {
+        changedIndices.push(index)
+      }
+    }
+
+    if (changedIndices.length) {
+      this._updateAfterColumnToggle(changedIndices, checked, needUpdate)
     }
   },
 

--- a/src/modules/toolbar.js
+++ b/src/modules/toolbar.js
@@ -288,7 +288,7 @@ export default {
       $checkboxes.off('click').on('click', ({ currentTarget }) => {
         const $this = $(currentTarget)
 
-        this._toggleColumn($this.val(), $this.prop('checked'), false)
+        this._toggleColumns([$this.data('field')], $this.prop('checked'), false)
         this.trigger('column-switch', $this.data('field'), $this.prop('checked'))
         $toggleAll.prop('checked', $checkboxes.filter(':checked').length === this.columns.filter(column => !this.isSelectionColumn(column)).length)
       })


### PR DESCRIPTION
**🤔Type of Request**
- [ ] **Bug fix**
- [ ] **New feature**
- [x] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
Fix #7774

**📝Changelog**

- [x] **Core**
- [x] **Extensions**

Refactored `showColumn`/`hideColumn` to batch multiple column toggles into a single re-render cycle. Previously, passing an array of fields would trigger a separate `initHeader`/`initSearch`/`initPagination`/`initBody` cycle for each column, causing unnecessary re-renders.

**💡Example(s)?**

Before: `$('#table').bootstrapTable('hideColumn', ['name', 'price', 'stock'])` — 3 separate re-renders
After: Same call — 1 re-render with all columns toggled at once

**☑️Self Check before Merge**

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->