### PR TITLE
Remove IE9 polyfill and add tests for reorder-columns extension

### DIFF
--- a/cypress/e2e/extensions/reorder-columns/options/index.cy.js
+++ b/cypress/e2e/extensions/reorder-columns/options/index.cy.js
@@ -1,0 +1,1 @@
+require('../../../../extensions/reorder-columns')()

--- a/cypress/extensions/reorder-columns.js
+++ b/cypress/extensions/reorder-columns.js
@@ -1,0 +1,57 @@
+module.exports = (theme = '') => {
+  const baseUrl = require('../common/utils')(theme, 'extensions')
+
+  describe('Reorder Columns Test', () => {
+    it('should render the table with reorderable columns enabled', () => {
+      cy.visit(`${baseUrl}reorder-columns.html`)
+        .get('.bootstrap-table').should('exist')
+        .get('.bootstrap-table thead th').should('have.length.gte', 3)
+    })
+
+    it('should have correct default column order', () => {
+      cy.visit(`${baseUrl}reorder-columns.html`)
+        .get('.bootstrap-table thead th').first()
+        .should('have.attr', 'data-field', 'id')
+        .get('.bootstrap-table thead th').eq(1)
+        .should('have.attr', 'data-field', 'name')
+        .get('.bootstrap-table thead th').eq(2)
+        .should('have.attr', 'data-field', 'price')
+    })
+
+    it('should reorder columns using orderColumns method (name, id, price)', () => {
+      cy.visit(`${baseUrl}reorder-columns.html`)
+        .get('.bootstrap-table').should('exist')
+      cy.window().then(win => {
+        win.$('#table').bootstrapTable('orderColumns', {
+          name: 0,
+          id: 1,
+          price: 2
+        })
+      })
+      cy.get('.bootstrap-table thead th').first()
+        .should('have.attr', 'data-field', 'name')
+      cy.get('.bootstrap-table thead th').eq(1)
+        .should('have.attr', 'data-field', 'id')
+      cy.get('.bootstrap-table thead th').eq(2)
+        .should('have.attr', 'data-field', 'price')
+    })
+
+    it('should reorder columns using orderColumns method (price, name, id)', () => {
+      cy.visit(`${baseUrl}reorder-columns.html`)
+        .get('.bootstrap-table').should('exist')
+      cy.window().then(win => {
+        win.$('#table').bootstrapTable('orderColumns', {
+          price: 0,
+          name: 1,
+          id: 2
+        })
+      })
+      cy.get('.bootstrap-table thead th').first()
+        .should('have.attr', 'data-field', 'price')
+      cy.get('.bootstrap-table thead th').eq(1)
+        .should('have.attr', 'data-field', 'name')
+      cy.get('.bootstrap-table thead th').eq(2)
+        .should('have.attr', 'data-field', 'id')
+    })
+  })
+}

--- a/src/extensions/reorder-columns/bootstrap-table-reorder-columns.js
+++ b/src/extensions/reorder-columns/bootstrap-table-reorder-columns.js
@@ -21,44 +21,6 @@ $.akottr.dragtable.prototype._restoreState = function (persistObj) {
   }
 }
 
-// From MDN site, https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter
-const filterFn = () => {
-  if (!Array.prototype.filter) {
-    Array.prototype.filter = function (fun/* , thisArg*/) {
-      if (this === undefined || this === null) {
-        throw new TypeError()
-      }
-
-      const t = Object(this)
-      const len = t.length >>> 0
-
-      if (typeof fun !== 'function') {
-        throw new TypeError()
-      }
-
-      const res = []
-      const thisArg = arguments.length >= 2 ? arguments[1] : undefined
-
-      for (let i = 0; i < len; i++) {
-        if (i in t) {
-          const val = t[i]
-
-          // NOTE: Technically this should Object.defineProperty at
-          //       the next index, as push can be affected by
-          //       properties on Object.prototype and Array.prototype.
-          //       But this method's new, and collisions should be
-          //       rare, so use the more-compatible alternative.
-          if (fun.call(thisArg, val, i, t)) {
-            res.push(val)
-          }
-        }
-      }
-
-      return res
-    }
-  }
-}
-
 Object.assign($.fn.bootstrapTable.defaults, {
   reorderableColumns: false,
   maxMovingRows: 10,
@@ -178,7 +140,6 @@ $.BootstrapTable = class extends $.BootstrapTable {
 
         this.columns = columns
 
-        filterFn() // Support <IE9
         for (const column of this.columns) {
           let found = false
           const field = column.field

--- a/src/utils/table-data.js
+++ b/src/utils/table-data.js
@@ -93,6 +93,10 @@ export function updateFieldGroup (columns, fieldColumns) {
           const underColumns = allColumns.filter(col => col.fieldIndex === i)
           const column = underColumns[underColumns.length - 1]
 
+          if (!column) {
+            continue
+          }
+
           if (underColumns.length > 1) {
             for (let j = 0; j < underColumns.length - 1; j++) {
               underColumns[j].visible = column.visible

--- a/tests/utils/table-data.test.js
+++ b/tests/utils/table-data.test.js
@@ -143,6 +143,23 @@ describe('updateFieldGroup', () => {
       expect(columns[0][0].visible).toBe(false)
     })
 
+    it('should not throw when no sub-columns match the colspanGroup range', () => {
+      const columns = [
+        [
+          { field: 'group', colspan: 2, colspanGroup: 2, colspanIndex: 4 },
+          { field: 'field1', fieldIndex: 0, visible: true }
+        ]
+      ]
+      const fieldColumns = columns[0].filter(c => !c.colspanGroup)
+
+      expect(() => {
+        tableData.updateFieldGroup(columns, fieldColumns)
+      }).not.toThrow()
+
+      expect(columns[0][0].colspan).toBe(0)
+      expect(columns[0][0].visible).toBe(false)
+    })
+
     it('should sync visibility for columns with same fieldIndex', () => {
       // This sync only happens in multi-row scenario (second part of the function)
       // So we skip this test for single-row colspanGroup scenario


### PR DESCRIPTION
**🤔Type of Request**
- [ ] **Bug fix**
- [ ] **New feature**
- [x] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
Close #5187

**📝Changelog**
- [ ] **Core**
- [x] **Extensions**

- Removed obsolete IE9 `Array.filter` polyfill from reorder-columns extension
- Added defensive null check in `updateFieldGroup` to prevent crash when parent column's `colspanGroup` range has no matching sub-columns
- Added Cypress tests for reorder-columns extension (`orderColumns` method)

**💡Example(s)?**
Not needed

**☑️Self Check before Merge**

- [ ] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

---

**Note:** This PR initially attempted to fix #5187 (reorder-columns not working with parent/child columns). After investigation, we found that the [dragtable](https://github.com/akottr/dragtable/) plugin used by reorder-columns is fundamentally designed for single-row headers only — it swaps columns by `:nth-child()` index and does not understand `colspan`/`rowspan`. Dragging a parent or child column in a nested header will break the DOM structure, and no amount of post-processing can reliably reconstruct it. Therefore, reordering columns with nested headers is not supported.