### PR TITLE
Fix reorder-columns not restoring column order from cookies on init

### DIFF
--- a/src/extensions/reorder-columns/bootstrap-table-reorder-columns.js
+++ b/src/extensions/reorder-columns/bootstrap-table-reorder-columns.js
@@ -45,7 +45,63 @@ $.BootstrapTable = class extends $.BootstrapTable {
       return
     }
 
+    if (this.columnsSortOrder) {
+      this.syncColumnsStateFromDOM()
+      super.initHeader(...args)
+    }
+
     this.makeColumnsReorderable()
+  }
+
+  syncColumnsStateFromDOM () {
+    const ths = []
+    const formatters = []
+    const columns = []
+    const optionsColumns = []
+
+    const $headerRow = this.$header.find('tr').last()
+    const $headerCells = ($headerRow.length ? $headerRow : this.$header).find('th[data-field]:not(.detail)')
+
+    $headerCells.each((i, el) => {
+      ths.push($(el).data('field'))
+      formatters.push($(el).data('formatter'))
+    })
+
+    if (ths.length < this.columns.length) {
+      const columnsHidden = this.columns.filter(column => !column.visible)
+
+      for (let i = 0; i < columnsHidden.length; i++) {
+        ths.push(columnsHidden[i].field)
+        formatters.push(columnsHidden[i].formatter)
+      }
+    }
+
+    for (let i = 0; i < ths.length; i++) {
+      const columnIndex = this.fieldsColumnsIndex[ths[i]]
+
+      if (!Number.isInteger(columnIndex) || !this.columns[columnIndex]) {
+        continue
+      }
+
+      this.fieldsColumnsIndex[ths[i]] = i
+      this.columns[columnIndex].fieldIndex = i
+      columns.push(this.columns[columnIndex])
+    }
+
+    this.columns = columns
+
+    for (const column of this.columns) {
+      const field = column.field
+      const matchedColumn = this.options.columns[0].find(item => item.field === field)
+
+      if (matchedColumn) {
+        optionsColumns.push(matchedColumn)
+      }
+    }
+
+    this.options.columns[0] = optionsColumns
+    this.header.fields = ths
+    this.header.formatters = formatters
   }
 
   _toggleColumns (...args) {
@@ -82,6 +138,13 @@ $.BootstrapTable = class extends $.BootstrapTable {
     this.makeColumnsReorderable()
   }
 
+  // requires cookie extension enabled to persist state
+  _persistColumnsSortOrder () {
+    if (this.options.cookie && typeof this.persistReorderColumnsState === 'function') {
+      this.persistReorderColumnsState(this)
+    }
+  }
+
   makeColumnsReorderable (order = null) {
     try {
       $(this.$el).dragtable('destroy')
@@ -104,72 +167,45 @@ $.BootstrapTable = class extends $.BootstrapTable {
         })
 
         this.columnsSortOrder = sortOrder
-        if (this.options.cookie) {
-          this.persistReorderColumnsState(this)
-        }
+        this._persistColumnsSortOrder()
 
-        const ths = []
-        const formatters = []
-        const columns = []
-        let columnsHidden
-        let columnIndex
-        const optionsColumns = []
-
-        this.$header.find('th:not(.detail)').each((i, el) => {
-          ths.push($(el).data('field'))
-          formatters.push($(el).data('formatter'))
-        })
-
-        // Exist columns not shown
-        if (ths.length < this.columns.length) {
-          columnsHidden = this.columns.filter(column => !column.visible)
-          for (let i = 0; i < columnsHidden.length; i++) {
-            ths.push(columnsHidden[i].field)
-            formatters.push(columnsHidden[i].formatter)
-          }
-        }
-
-        for (let i = 0; i < ths.length; i++) {
-          columnIndex = this.fieldsColumnsIndex[ths[i]]
-          if (columnIndex !== -1) {
-            this.fieldsColumnsIndex[ths[i]] = i
-            this.columns[columnIndex].fieldIndex = i
-            columns.push(this.columns[columnIndex])
-          }
-        }
-
-        this.columns = columns
-
-        for (const column of this.columns) {
-          let found = false
-          const field = column.field
-
-          this.options.columns[0].filter(item => {
-            if (!found && item['field'] === field) {
-              optionsColumns.push(item)
-              found = true
-              return false
-            }
-            return true
-          })
-        }
-
-        this.options.columns[0] = optionsColumns
-
-        this.header.fields = ths
-        this.header.formatters = formatters
+        this.syncColumnsStateFromDOM()
         this.initHeader()
         this.initToolbar()
         this.initSearchText()
         this.initBody()
         this.resetView()
-        this.trigger('reorder-column', ths)
+        this.trigger('reorder-column', this.header.fields)
       }
     })
   }
 
   orderColumns (order) {
+    if (!order || typeof order !== 'object') {
+      return
+    }
+
+    const $headerRow = this.$header.find('tr').last()
+    const $target = $headerRow.length ? $headerRow : this.$header
+
+    const sortedEntries = Object.entries(order).sort((a, b) => a[1] - b[1])
+
+    for (const [field] of sortedEntries) {
+      const $th = $target.find(`th[data-field="${field}"]`)
+
+      if ($th.length) {
+        $target.append($th)
+      }
+    }
+
     this.columnsSortOrder = order
-    this.makeColumnsReorderable()
+    this._persistColumnsSortOrder()
+    this.syncColumnsStateFromDOM()
+    this.initHeader()
+    this.initToolbar()
+    this.initSearchText()
+    this.initBody()
+    this.resetView()
+    this.trigger('reorder-column', this.header.fields)
   }
 }


### PR DESCRIPTION
**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
Fix #7468

**📝Changelog**

<!-- The type of the change. --->
- [ ] **Core**
- [x] **Extensions**

<!-- Describe changes from the user side. -->
Fixed reorder-columns extension not restoring the saved column order from cookies on table initialization. The column sync logic has been extracted into a reusable `syncColumnsStateFromDOM` method and is now called during init when `columnsSortOrder` is available from cookies.

**💡Example(s)?**
<!-- Please use our online Editor (https://live.bootstrap-table.com/) to create example(s) (Before and after your changes).
On our Wiki (https://github.com/wenzhixin/bootstrap-table/wiki/Online-Editor-Explanation) you can read how to use the editor.-->

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->