### PR TITLE
Document that group-by-v2 extension does not support pagination

### DIFF
--- a/site/src/pages/docs/extensions/group-by-v2.mdx
+++ b/site/src/pages/docs/extensions/group-by-v2.mdx
@@ -17,6 +17,10 @@ toc: true
 
 [Group By v2](https://examples.bootstrap-table.com/#extensions/group-by-v2.html)
 
+## Note
+
+The `group-by-v2` extension **does not support pagination**. Grouping operates on the full dataset, which is fundamentally incompatible with how pagination splits data into pages.
+
 ## Options
 
 ### groupBy

--- a/site/src/pages/zh-cn/docs/extensions/group-by-v2.mdx
+++ b/site/src/pages/zh-cn/docs/extensions/group-by-v2.mdx
@@ -17,6 +17,10 @@ toc: true
 
 [Group By v2](https://examples.bootstrap-table.com/#extensions/group-by-v2.html)
 
+## 注意
+
+`group-by-v2` 扩展**不支持分页**。分组操作作用于完整数据集，与分页切分数据的机制存在根本性冲突。
+
 ## 选项
 
 ### groupBy


### PR DESCRIPTION
**🤔Type of Request**
- [ ] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [x] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**

**📝Changelog**

- [ ] **Core**
- [x] **Extensions**

Added a note to both the English and Chinese docs for the `group-by-v2` extension explaining that it does not support pagination, since grouping operates on the full dataset which is incompatible with how pagination splits data.

**💡Example(s)?**

N/A (documentation only)

**☑️Self Check before Merge**

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

Fix #5334