### PR TITLE
Fix fixedColumns hover conflict with CSS transitions

### DIFF
--- a/cypress/e2e/extensions/export/index.cy.js
+++ b/cypress/e2e/extensions/export/index.cy.js
@@ -1,0 +1,1 @@
+require('../../../extensions/export/options')()

--- a/cypress/e2e/extensions/export/options/index.cy.js
+++ b/cypress/e2e/extensions/export/options/index.cy.js
@@ -1,1 +1,0 @@
-require('../../../../extensions/export/options')()

--- a/cypress/e2e/extensions/filter-control/index.cy.js
+++ b/cypress/e2e/extensions/filter-control/index.cy.js
@@ -1,0 +1,1 @@
+require('../../../extensions/filter-control/options')()

--- a/cypress/e2e/extensions/filter-control/options/index.cy.js
+++ b/cypress/e2e/extensions/filter-control/options/index.cy.js
@@ -1,1 +1,0 @@
-require('../../../../extensions/filter-control/options')()

--- a/cypress/e2e/extensions/fixed-columns/index.cy.js
+++ b/cypress/e2e/extensions/fixed-columns/index.cy.js
@@ -1,0 +1,1 @@
+require('../../../extensions/fixed-columns')()

--- a/cypress/e2e/extensions/fixed-columns/options/index.cy.js
+++ b/cypress/e2e/extensions/fixed-columns/options/index.cy.js
@@ -1,0 +1,1 @@
+require('../../../../extensions/fixed-columns')()

--- a/cypress/e2e/extensions/reorder-columns/index.cy.js
+++ b/cypress/e2e/extensions/reorder-columns/index.cy.js
@@ -1,0 +1,1 @@
+require('../../../extensions/reorder-columns')()

--- a/cypress/e2e/extensions/reorder-columns/options/index.cy.js
+++ b/cypress/e2e/extensions/reorder-columns/options/index.cy.js
@@ -1,1 +1,0 @@
-require('../../../../extensions/reorder-columns')()

--- a/cypress/extensions/fixed-columns.js
+++ b/cypress/extensions/fixed-columns.js
@@ -1,0 +1,45 @@
+module.exports = (theme = '') => {
+  const baseUrl = require('../common/utils')(theme, 'extensions')
+
+  describe('Fixed Columns Test', () => {
+    it('should sync hover-row class between main table and fixed columns', () => {
+      cy.visit(`${baseUrl}fixed-columns.html`)
+        .get('.bootstrap-table').should('exist')
+        .get('.fixed-columns').should('exist')
+
+      // Hover a row in the main table body
+      cy.get('.fixed-table-container > .fixed-table-body tr[data-index="0"]')
+        .invoke('trigger', 'mouseenter')
+      cy.get('.fixed-columns .fixed-table-body tr[data-index="0"]')
+        .should('have.class', 'hover-row')
+
+      // Leave the row - hover-row should be removed from the synced fixed row
+      cy.get('.fixed-table-container > .fixed-table-body tr[data-index="0"]')
+        .invoke('trigger', 'mouseleave')
+      cy.get('.fixed-columns .fixed-table-body tr[data-index="0"]')
+        .should('not.have.class', 'hover-row')
+    })
+
+    it('should sync hover-row class from fixed columns to main table', () => {
+      cy.visit(`${baseUrl}fixed-columns.html`)
+        .get('.bootstrap-table').should('exist')
+        .get('.fixed-columns').should('exist')
+
+      // Hover a row in the fixed columns body
+      cy.get('.fixed-columns .fixed-table-body tr[data-index="1"]')
+        .invoke('trigger', 'mouseenter')
+      cy.get('.fixed-columns .fixed-table-body tr[data-index="1"]')
+        .should('have.class', 'hover-row')
+      cy.get('.fixed-table-container > .fixed-table-body tr[data-index="1"]')
+        .should('have.class', 'hover-row')
+
+      // Leave the row
+      cy.get('.fixed-columns .fixed-table-body tr[data-index="1"]')
+        .invoke('trigger', 'mouseleave')
+      cy.get('.fixed-columns .fixed-table-body tr[data-index="1"]')
+        .should('not.have.class', 'hover-row')
+      cy.get('.fixed-table-container > .fixed-table-body tr[data-index="1"]')
+        .should('not.have.class', 'hover-row')
+    })
+  })
+}

--- a/src/extensions/fixed-columns/bootstrap-table-fixed-columns.js
+++ b/src/extensions/fixed-columns/bootstrap-table-fixed-columns.js
@@ -294,7 +294,12 @@ $.BootstrapTable = class extends $.BootstrapTable {
   initFixedColumnsEvents () {
     const toggleHover = (e, toggle) => {
       const tr = `tr[data-index="${$(e.currentTarget).data('index')}"]`
-      let $trs = this.$tableBody.find(tr)
+      const isFromFixed = $(e.currentTarget).closest('.fixed-columns, .fixed-columns-right').length > 0
+      let $trs = $()
+
+      if (isFromFixed) {
+        $trs = $trs.add(this.$tableBody.find(tr))
+      }
 
       if (this.$fixedBody) {
         $trs = $trs.add(this.$fixedBody.find(tr))
@@ -303,14 +308,18 @@ $.BootstrapTable = class extends $.BootstrapTable {
         $trs = $trs.add(this.$fixedBodyRight.find(tr))
       }
 
-      $trs.css('background-color', toggle ? $(e.currentTarget).css('background-color') : '')
+      $trs.toggleClass('hover-row', toggle)
     }
 
-    this.$tableBody.find('tr').hover(e => {
-      toggleHover(e, true)
-    }, e => {
-      toggleHover(e, false)
-    })
+    const bindHover = $el => {
+      $el.find('tr').hover(e => {
+        toggleHover(e, true)
+      }, e => {
+        toggleHover(e, false)
+      })
+    }
+
+    bindHover(this.$tableBody)
 
     const isFirefox = typeof navigator !== 'undefined' &&
       navigator.userAgent.toLowerCase().indexOf('firefox') > -1
@@ -337,11 +346,7 @@ $.BootstrapTable = class extends $.BootstrapTable {
     }
 
     if (this.needFixedColumns && this.options.fixedNumber && this.$fixedBody) {
-      this.$fixedBody.find('tr').hover(e => {
-        toggleHover(e, true)
-      }, e => {
-        toggleHover(e, false)
-      })
+      bindHover(this.$fixedBody)
 
       this.$fixedBody[0].addEventListener(mousewheel, e => {
         updateScroll(e, this.$fixedBody[0])
@@ -349,11 +354,7 @@ $.BootstrapTable = class extends $.BootstrapTable {
     }
 
     if (this.needFixedColumns && this.options.fixedRightNumber) {
-      this.$fixedBodyRight.find('tr').hover(e => {
-        toggleHover(e, true)
-      }, e => {
-        toggleHover(e, false)
-      })
+      bindHover(this.$fixedBodyRight)
 
       this.$fixedBodyRight.off('scroll').on('scroll', () => {
         const top = this.$fixedBodyRight.scrollTop()

--- a/src/extensions/fixed-columns/bootstrap-table-fixed-columns.scss
+++ b/src/extensions/fixed-columns/bootstrap-table-fixed-columns.scss
@@ -23,3 +23,11 @@
     overflow-x: hidden !important;
   }
 }
+
+.fixed-columns,
+.fixed-columns-right,
+.fixed-table-container > .fixed-table-body {
+  .table-hover .hover-row {
+    background-color: var(--bt-table-hover-bg, var(--bs-table-hover-bg, rgba(0, 0, 0, 0.075)));
+  }
+}


### PR DESCRIPTION
**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
Fix #5425 (part 4)

**📝Changelog**

- [ ] **Core**
- [x] **Extensions**

Fixed `fixedColumns` hover not working when CSS transitions are applied to `.table-hover` rows.

**Before:** `toggleHover` used jQuery `.css('background-color')` to sync hover across table bodies, which bypassed CSS transitions and caused double-layer hover coloring (darker on main body, lighter on fixed columns).

**After:** Replaced with `.toggleClass('hover-row')` and a corresponding CSS rule, so CSS transitions work naturally and hover coloring is consistent across all table bodies.

**💡Example(s)?**
TODO: add before/after examples using https://live.bootstrap-table.com/

**☑️Self Check before Merge**

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed