### PR TITLE
Fix refreshOptions breaking grouped rows with colspan

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -67,7 +67,16 @@ class BootstrapTable {
     }
     this.optionsColumnsChanged = !!options.columns
     this.options = Utils.extend(this.options, options)
+
+    const hasNewData = Object.prototype.hasOwnProperty.call(options, 'data')
+    const shouldResetHtmlData = this.fromHtml && !hasNewData
+
     this.trigger('refresh-options', this.options)
+
+    if (shouldResetHtmlData) {
+      this.options.data = []
+      this.fromHtml = false
+    }
     this.destroy()
     this.init()
   }


### PR DESCRIPTION
**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
Fix #5720

**📝Changelog**

<!-- The type of the change. --->
- [x] **Core**
- [ ] **Extensions**

<!-- Describe changes from the user side. -->
Fixed `refreshOptions` breaking grouped rows (rows with `colspan`) when the table is initialized from HTML. The issue was that `destroy()` restores the original HTML but `this.options.data` was not cleared, causing `init()` to skip HTML re-parsing and losing the `fromHtml` flag needed to correctly render grouped rows.

**💡Example(s)?**
https://live.bootstrap-table.com/code/lvalladares/7588

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->