### PR TITLE
fix: support async loading of bootstrapTable methods in Vue component

### DIFF
--- a/src/vue/BootstrapTable.vue
+++ b/src/vue/BootstrapTable.vue
@@ -53,6 +53,7 @@ export default {
   },
   methods: {
     _initTable () {
+      this._bindMethods()
       const options = {
         ...deepCopy(this.options),
         columns: deepCopy(this.columns),
@@ -65,15 +66,19 @@ export default {
         this.refreshOptions(options)
       }
     },
-    ...(() => {
-      const res = {}
-      for (const method of $.fn.bootstrapTable.methods) {
-        res[method] = function (...args) {
-          return this.$table.bootstrapTable(method, ...args)
+    refreshOptions (...args) {
+      return this.$table.bootstrapTable('refreshOptions', ...args)
+    },
+    load (...args) {
+      return this.$table.bootstrapTable('load', ...args)
+    },
+    _bindMethods () {
+      for (const method of ($.fn.bootstrapTable.methods || [])) {
+        if (!this[method]) {
+          this[method] = (...args) => this.$table.bootstrapTable(method, ...args)
         }
       }
-      return res
-    })()
+    }
   },
   watch: {
     options: {


### PR DESCRIPTION
Replace static IIFE method spread with dynamic binding in mounted/_initTable, resolving the issue where $.fn.bootstrapTable.methods is empty at component definition time due to async loading.

Vue methods 会引入的时候就初始化，若插件引入的顺序落后于Vue 组件或异步引入，则会导致 `$.fn.bootstrapTable.methods`  缺少插件方法，从而导致 Vue 组件方法缺失。

**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
<!-- Please prefix each issue number with  "Fix #"  (e.g. Fix #200)  -->

**📝Changelog**

<!-- The type of the change. --->
- [x] **Core**
- [ ] **Extensions**

<!-- Describe changes from the user side. -->

**💡Example(s)?**
<!-- Please use our online Editor (https://live.bootstrap-table.com/) to create example(s) (Before and after your changes).
On our Wiki (https://github.com/wenzhixin/bootstrap-table/wiki/Online-Editor-Explanation) you can read how to use the editor.-->

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
