### PR TITLE
Fix print footer not displayed by using tfoot tag

### DIFF
--- a/src/extensions/print/bootstrap-table-print.js
+++ b/src/extensions/print/bootstrap-table-print.js
@@ -231,11 +231,11 @@ $.BootstrapTable = class extends $.BootstrapTable {
 
       html.push('</tbody>')
       if (this.options.showFooter) {
-        html.push('<footer><tr>')
+        html.push('<tfoot><tr>')
 
         for (const columns of columnsArray) {
           for (let h = 0; h < columns.length; h++) {
-            if (canPrint(columns)) {
+            if (canPrint(columns[h])) {
               const footerData = Utils.trToData(columns, this.$el.find('>tfoot>tr').get())
               const footerValue = Utils.calculateObjectValue(columns[h], columns[h].footerFormatter, [data], footerData[0] && footerData[0][columns[h].field] || '')
 
@@ -244,7 +244,7 @@ $.BootstrapTable = class extends $.BootstrapTable {
           }
         }
 
-        html.push('</tr></footer>')
+        html.push('</tr></tfoot>')
       }
       html.push('</table>')
       return html.join('')

--- a/src/extensions/print/bootstrap-table-print.js
+++ b/src/extensions/print/bootstrap-table-print.js
@@ -233,14 +233,14 @@ $.BootstrapTable = class extends $.BootstrapTable {
       if (this.options.showFooter) {
         html.push('<tfoot><tr>')
 
-        for (const columns of columnsArray) {
-          for (let h = 0; h < columns.length; h++) {
-            if (canPrint(columns[h])) {
-              const footerData = Utils.trToData(columns, this.$el.find('>tfoot>tr').get())
-              const footerValue = Utils.calculateObjectValue(columns[h], columns[h].footerFormatter, [data], footerData[0] && footerData[0][columns[h].field] || '')
+        const columns = columnsArray.flat(1)
+        const footerData = Utils.trToData(columns, this.$el.find('>tfoot>tr').get())
 
-              html.push(`<th>${footerValue}</th>`)
-            }
+        for (const column of columns) {
+          if (canPrint(column)) {
+            const footerValue = Utils.calculateObjectValue(column, column.footerFormatter, [data], footerData[0] && footerData[0][column.field] || '')
+
+            html.push(`<th>${footerValue}</th>`)
           }
         }
 


### PR DESCRIPTION
**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**

**📝Changelog**

- [x] **Extensions**

Fix the print extension footer not being displayed. Changed the footer HTML tag from `<footer>` to `<tfoot>`, which is the correct element for table footers and is properly rendered when printing.

Also fixed a bug in the footer column rendering where `canPrint(columns)` was checking the entire columns array instead of the individual column `canPrint(columns[h])`.

**💡Example(s)?**

**☑️Self Check before Merge**

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed