### PR TITLE
Fix print footer error with rowspan/colspan columns

### DIFF
--- a/cypress/extensions/print/options.js
+++ b/cypress/extensions/print/options.js
@@ -209,6 +209,40 @@ module.exports = (theme = '') => {
         })
     })
 
+    // Options: showFooter with print and rowspan/colspan columns
+    it('Test print footer output with rowspan/colspan columns', () => {
+      cy.visit(`${baseUrl}print-footer-rowspan-colspan.html`)
+        .get('.fixed-table-toolbar [name="print"]')
+        .should('exist')
+        .window().then(win => {
+          const instance = win.$('#table').data('bootstrap.table')
+          const data = instance.getData()
+          const stub = stubWindowOpen(win)
+
+          try {
+            instance.doPrint(data)
+            const html = stub.getHtml()
+
+            expect(html).to.include('<tfoot>')
+            expect(html).to.include('</tfoot>')
+
+            const tfootMatch = html.match(/<tfoot>[\s\S]*?<\/tfoot>/)
+
+            expect(tfootMatch).to.not.be.null
+
+            const tfootCells = tfootMatch[0].match(/<th>/g) || []
+
+            expect(tfootCells.length).to.equal(3)
+
+            // Verify footerFormatter results
+            expect(tfootMatch[0]).to.include('$600')
+            expect(tfootMatch[0]).to.include('3 items')
+          } finally {
+            stub.restore()
+          }
+        })
+    })
+
     // Options: printAsFilteredAndSortedOnUI
     it('Test printAsFilteredAndSortedOnUI defaults to true', () => {
       cy.visit(`${baseUrl}print.html`)

--- a/src/extensions/print/bootstrap-table-print.js
+++ b/src/extensions/print/bootstrap-table-print.js
@@ -290,7 +290,9 @@ $.BootstrapTable = class extends $.BootstrapTable {
       if (this.options.showFooter) {
         html.push('<tfoot><tr>')
 
-        const columns = columnsArray.flat(1)
+        const columns = columnsArray.flat(1).filter(column => !(column.colspanGroup > 0))
+
+        columns.sort((c1, c2) => c1.colspanIndex - c2.colspanIndex)
         const footerData = Utils.trToData(columns, this.$el.find('>tfoot>tr').get())
 
         for (const column of columns) {


### PR DESCRIPTION
**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
Fix #5442

**📝Changelog**

<!-- The type of the change. --->
- [ ] **Core**
- [x] **Extensions**

<!-- Describe changes from the user side. -->
Skip columns with `colspanGroup > 0` in print footer rendering to avoid duplicate columns and errors.

**💡Example(s)?**
- Before: https://live.bootstrap-table.com/code/Mikerobenics/5420
- After: https://live.bootstrap-table.com/code/wenzhixin/19184

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->