### PR TITLE
Fix print window closing before print dialog completes

### DIFF
--- a/cypress/extensions/print/options.js
+++ b/cypress/extensions/print/options.js
@@ -23,7 +23,8 @@ const stubWindowOpen = win => {
     document: fakeDoc,
     focus () {},
     print () {},
-    close () {}
+    close () {},
+    addEventListener () {}
   })
 
   return {
@@ -662,7 +663,8 @@ module.exports = (theme = '') => {
               print () {
                 printCount++
               },
-              close () {}
+              close () {},
+              addEventListener () {}
             }
           }
 
@@ -742,7 +744,8 @@ module.exports = (theme = '') => {
               print () {
                 printCount++
               },
-              close () {}
+              close () {},
+              addEventListener () {}
             }
           }
 
@@ -812,7 +815,8 @@ module.exports = (theme = '') => {
               print () {
                 printCount++
               },
-              close () {}
+              close () {},
+              addEventListener () {}
             }
           }
 

--- a/src/extensions/print/bootstrap-table-print.js
+++ b/src/extensions/print/bootstrap-table-print.js
@@ -338,13 +338,20 @@ $.BootstrapTable = class extends $.BootstrapTable {
     data = sortRows(data, this.options.printSortColumn, this.options.printSortOrder)
     const table = buildTable(data, this.options.columns)
     const newWin = window.open('')
+
+    if (!newWin) {
+      return
+    }
+
     const printStyles = typeof this.options.printStyles === 'string' ?
       this.options.printStyles.replace(/\[|\]| /g, '').toLowerCase().split(',') :
       this.options.printStyles
     const startPrint = () => {
       newWin.focus()
+      newWin.addEventListener('afterprint', () => {
+        newWin.close()
+      }, { once: true })
       newWin.print()
-      newWin.close()
     }
 
     const styles = printStyles.length ?


### PR DESCRIPTION
**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**

**📝Changelog**

- [ ] **Core**
- [x] **Extensions**

Fixed print window closing immediately in Chrome when running inside an iframe. The print dialog was dismissed instantly because `window.close()` was called synchronously after `window.print()`, before the user could interact with the dialog. Now uses `onafterprint` event to close the window only after printing completes or is cancelled.

**💡Example(s)?**

https://live.bootstrap-table.com/code/wenzhixin/19186

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->