### PR TITLE
Refactor: move events.js to helpers and replace direct DOM ops in print

### DIFF
--- a/cypress/extensions/print/options.js
+++ b/cypress/extensions/print/options.js
@@ -606,6 +606,47 @@ module.exports = (theme = '') => {
         })
     })
 
+    const createFakeLink = () => {
+      const link = {
+        eventListeners: {},
+        addEventListener (event, callback) {
+          if (!link.eventListeners[event]) {
+            link.eventListeners[event] = []
+          }
+          link.eventListeners[event].push(callback)
+        },
+        triggerLoad () {
+          (link.eventListeners.load || []).forEach(cb => cb())
+        },
+        triggerError () {
+          (link.eventListeners.error || []).forEach(cb => cb())
+        }
+      }
+
+      return link
+    }
+
+    const createFakePrintWindow = (links, onPrint) => {
+      const doc = {
+        write () {},
+        close () {},
+        querySelectorAll (selector) {
+          return selector === 'link[rel="stylesheet"]' ? links : []
+        }
+      }
+
+      doc.documentElement = doc
+      return {
+        document: doc,
+        focus () {},
+        print () {
+          onPrint()
+        },
+        close () {},
+        addEventListener () {}
+      }
+    }
+
     it('Test printStyles waits for all stylesheets to load before printing', () => {
       cy.visit(`${baseUrl}print.html`)
         .get('.fixed-table-toolbar [name="print"]')
@@ -616,56 +657,17 @@ module.exports = (theme = '') => {
 
           let printCount = 0
           const loadCallbacks = []
-
           const originalOpen = win.window.open
 
-          const createFakeLink = () => {
-            const link = {
-              eventListeners: {},
-              addEventListener (event, callback) {
-                if (!link.eventListeners[event]) {
-                  link.eventListeners[event] = []
-                }
-                link.eventListeners[event].push(callback)
-              },
-              triggerLoad () {
-                (link.eventListeners.load || []).forEach(cb => cb())
-              },
-              triggerError () {
-                (link.eventListeners.error || []).forEach(cb => cb())
-              }
-            }
-
-            return link
-          }
-
           win.window.open = () => {
-            const links = []
-
-            for (let i = 0; i < 3; i++) {
+            const links = Array.from({ length: 3 }, () => {
               const link = createFakeLink()
 
-              links.push(link)
               loadCallbacks.push(link)
-            }
-            return {
-              document: {
-                write () {},
-                close () {},
-                querySelectorAll (selector) {
-                  if (selector === 'link[rel="stylesheet"]') {
-                    return links
-                  }
-                  return []
-                }
-              },
-              focus () {},
-              print () {
-                printCount++
-              },
-              close () {},
-              addEventListener () {}
-            }
+              return link
+            })
+
+            return createFakePrintWindow(links, () => printCount++)
           }
 
           instance.options.printStyles = ['a.css', 'b.css', 'c.css']
@@ -697,56 +699,17 @@ module.exports = (theme = '') => {
 
           let printCount = 0
           const loadCallbacks = []
-
           const originalOpen = win.window.open
 
-          const createFakeLink = () => {
-            const link = {
-              eventListeners: {},
-              addEventListener (event, callback) {
-                if (!link.eventListeners[event]) {
-                  link.eventListeners[event] = []
-                }
-                link.eventListeners[event].push(callback)
-              },
-              triggerLoad () {
-                (link.eventListeners.load || []).forEach(cb => cb())
-              },
-              triggerError () {
-                (link.eventListeners.error || []).forEach(cb => cb())
-              }
-            }
-
-            return link
-          }
-
           win.window.open = () => {
-            const links = []
-
-            for (let i = 0; i < 2; i++) {
+            const links = Array.from({ length: 2 }, () => {
               const link = createFakeLink()
 
-              links.push(link)
               loadCallbacks.push(link)
-            }
-            return {
-              document: {
-                write () {},
-                close () {},
-                querySelectorAll (selector) {
-                  if (selector === 'link[rel="stylesheet"]') {
-                    return links
-                  }
-                  return []
-                }
-              },
-              focus () {},
-              print () {
-                printCount++
-              },
-              close () {},
-              addEventListener () {}
-            }
+              return link
+            })
+
+            return createFakePrintWindow(links, () => printCount++)
           }
 
           instance.options.printStyles = ['valid.css', 'broken.css']
@@ -776,48 +739,13 @@ module.exports = (theme = '') => {
 
           let printCount = 0
           const loadCallbacks = []
-
           const originalOpen = win.window.open
-
-          const createFakeLink = () => {
-            const link = {
-              eventListeners: {},
-              addEventListener (event, callback) {
-                if (!link.eventListeners[event]) {
-                  link.eventListeners[event] = []
-                }
-                link.eventListeners[event].push(callback)
-              },
-              triggerLoad () {
-                (link.eventListeners.load || []).forEach(cb => cb())
-              }
-            }
-
-            return link
-          }
 
           win.window.open = () => {
             const link = createFakeLink()
 
             loadCallbacks.push(link)
-            return {
-              document: {
-                write () {},
-                close () {},
-                querySelectorAll (selector) {
-                  if (selector === 'link[rel="stylesheet"]') {
-                    return [link]
-                  }
-                  return []
-                }
-              },
-              focus () {},
-              print () {
-                printCount++
-              },
-              close () {},
-              addEventListener () {}
-            }
+            return createFakePrintWindow([link], () => printCount++)
           }
 
           instance.options.printStyles = []

--- a/src/extensions/print/bootstrap-table-print.js
+++ b/src/extensions/print/bootstrap-table-print.js
@@ -2,6 +2,8 @@
  * @update zhixin wen <wenzhixin2010@gmail.com>
  */
 
+import DOMHelper from '../../helpers/dom.js'
+
 const Utils = $.fn.bootstrapTable.utils
 
 function printPageBuilderDefault (table, styles) {
@@ -150,7 +152,7 @@ $.BootstrapTable = class extends $.BootstrapTable {
         [value_, row, i], value_)
 
       return typeof value === 'undefined' || value === null ?
-        this.options.undefinedText : $('<div>').html(value).html()
+        this.options.undefinedText : DOMHelper.html(DOMHelper.create('<div></div>'), value).innerHTML
     }
 
     const getCellStyle = (row, i, column) => {
@@ -363,7 +365,7 @@ $.BootstrapTable = class extends $.BootstrapTable {
     newWin.document.write(calculatedPrintPage)
     newWin.document.close()
 
-    const links = newWin.document.querySelectorAll('link[rel="stylesheet"]')
+    const links = DOMHelper.$$('link[rel="stylesheet"]', newWin.document.documentElement)
 
     if (!links.length) {
       startPrint()

--- a/src/helpers/events.js
+++ b/src/helpers/events.js
@@ -3,9 +3,9 @@
  * Provides jQuery-style event handling APIs using native JavaScript
  */
 
-import DOMHelper from '../helpers/dom.js'
+import DOMHelper from './dom.js'
 
-export class EventHelper {
+class EventHelper {
   /**
    * Add event listener with namespace support
    * @param {Element|string} element - DOM element or selector
@@ -409,3 +409,6 @@ export class EventHelper {
     return element
   }
 }
+
+// Export EventHelper class
+export default EventHelper

--- a/tests/helpers/events.test.js
+++ b/tests/helpers/events.test.js
@@ -3,7 +3,7 @@
  */
 
 import { beforeEach, describe, expect, it } from 'vitest'
-import { EventHelper } from '@/utils/events.js'
+import EventHelper from '@/helpers/events.js'
 import DOMHelper from '@/helpers/dom.js'
 
 // Setup test environment


### PR DESCRIPTION
**🤔Type of Request**
- [ ] **Bug fix**
- [ ] **New feature**
- [x] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**

**📝Changelog**

<!-- The type of the change. --->
- [x] **Core**
- [ ] **Extensions**

<!-- Describe changes from the user side. -->

- Move `src/utils/events.js` to `src/helpers/events.js` to align with `dom.js`
- Convert `EventHelper` to default export
- Replace direct DOM operations with `DOMHelper` in the print extension
- Extract shared test helpers (`createFakeLink`, `createFakePrintWindow`) to reduce duplication in print Cypress tests
- Move `tests/utils/events.test.js` to `tests/helpers/events.test.js`

**💡Example(s)?**
No visual changes, internal refactoring only.

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed