### PR TITLE
Add conditional site lint and build check to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,21 @@ on:
   pull_request:
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      site: ${{ steps.filter.outputs.site }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            site:
+              - 'site/**'
+
   test:
+    needs: changes
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -23,9 +37,14 @@ jobs:
         run: |
           yarn install --frozen-lockfile
           yarn pre-commit
+
+      - name: Lint and build site
+        if: needs.changes.outputs.site == 'true'
+        run: |
           cd site
           yarn install --frozen-lockfile
           yarn lint
+          yarn build
 
       - name: Cypress Test
         run: |


### PR DESCRIPTION
**🤔Type of Request**
- [ ] **Bug fix**
- [ ] **New feature**
- [x] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**

**📝Changelog**

- [ ] **Core**
- [ ] **Extensions**

Use `dorny/paths-filter` to detect changes in `site/` directory. Only run `site/yarn lint` and `site/yarn build` when site files are modified, avoiding unnecessary CI time on non-site changes.

**💡Example(s)?**

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed