### PR TITLE
Fix showColumnsSearch not filtering columns in Bootstrap 5

### DIFF
--- a/src/modules/toolbar.js
+++ b/src/modules/toolbar.js
@@ -306,14 +306,18 @@ export default {
           const $this = $(currentTarget)
           const searchValue = $this.val().toLowerCase()
 
-          $listItems.show()
+          $listItems.each((_, el) => {
+            el.style.removeProperty('display')
+          })
           $checkboxes.each((i, el) => {
             const $checkbox = $(el)
             const $listItem = $checkbox.parents('.dropdown-item-marker')
             const text = $listItem.text().toLowerCase()
 
             if (!text.includes(searchValue)) {
-              $listItem.hide()
+              $listItem.each((_, item) => {
+                item.style.setProperty('display', 'none', 'important')
+              })
             }
           })
         })


### PR DESCRIPTION
**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
<!-- Please prefix each issue number with  "Fix #"  (e.g. Fix #200)  -->

**📝Changelog**

<!-- The type of the change. --->
- [x] **Core**
- [ ] **Extensions**

<!-- Describe changes from the user side. -->
Fixed `showColumnsSearch` not filtering columns in the dropdown for Bootstrap 5. The `d-flex` utility class uses `display: flex !important`, which overrides jQuery's `.hide()` (sets `display: none` without `!important`). Replaced `.hide()`/`.show()` with native DOM API `style.setProperty('display', 'none', 'important')` and `style.removeProperty('display')` to ensure the filter works correctly.

**💡Example(s)?**
<!-- Please use our online Editor (https://live.bootstrap-table.com/) to create example(s) (Before and after your changes).
On our Wiki (https://github.com/wenzhixin/bootstrap-table/wiki/Online-Editor-Explanation) you can read how to use the editor.-->

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->