### PR TITLE
Fix table rendering when initially hidden with fixed height

### DIFF
--- a/src/bootstrap-table.js
+++ b/src/bootstrap-table.js
@@ -23,7 +23,8 @@ class BootstrapTable {
     this.$el_ = this.$el.clone()
     this._timeoutId = {
       header: 0,
-      footer: 0
+      footer: 0,
+      resetView: 0
     }
   }
 
@@ -80,6 +81,10 @@ class BootstrapTable {
   destroy () {
     for (const type of Object.keys(this._timeoutId)) {
       clearTimeout(this._timeoutId[type])
+    }
+    if (this._resizeObserver) {
+      this._resizeObserver.disconnect()
+      this._resizeObserver = null
     }
     this.$el.insertBefore(this.$container)
     $(this.options.toolbar).insertBefore(this.$el)

--- a/src/modules/body.js
+++ b/src/modules/body.js
@@ -452,6 +452,13 @@ export default {
 
     this.$tableContainer.toggleClass('has-card-view', this.options.cardView)
 
+    if (this.options.height && this.$el.is(':hidden')) {
+      if (!this._resizeObserver) {
+        this._setDelayTimeout('resetView', () => this.resetView(), 100)
+      }
+      return
+    }
+
     if (this.options.height) {
       const fixedBody = this.$tableBody.get(0)
 

--- a/src/modules/header.js
+++ b/src/modules/header.js
@@ -202,6 +202,30 @@ export default {
       this[checked ? 'checkAll' : 'uncheckAll']()
       this.updateSelected()
     })
+
+    if (this.options.height && typeof ResizeObserver !== 'undefined') {
+      if (this.$el.is(':hidden')) {
+        if (this._resizeObserver) {
+          this._resizeObserver.disconnect()
+          this._resizeObserver = null
+        }
+        const observer = new ResizeObserver(entries => {
+          for (const entry of entries) {
+            if (entry.contentRect.width > 0 && entry.contentRect.height > 0) {
+              observer.disconnect()
+              if (this._resizeObserver === observer) {
+                this._resizeObserver = null
+              }
+              this.resetView()
+              return
+            }
+          }
+        })
+
+        this._resizeObserver = observer
+        observer.observe(this.$el[0])
+      }
+    }
   },
 
   getVisibleFields () {

--- a/tests/modules/body.test.js
+++ b/tests/modules/body.test.js
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import BodyModule from '@/modules/body.js'
+
+function createBodyMockContext (overrides = {}) {
+  const timeoutIds = {}
+
+  return {
+    options: {
+      height: 500,
+      cardView: false,
+      showHeader: true,
+      showFooter: false
+    },
+    $el: {
+      is: vi.fn(() => false),
+      attr: vi.fn(() => 'test-table'),
+      outerWidth: vi.fn(() => 800),
+      outerHeight: vi.fn(() => 50),
+      css: vi.fn(),
+      [0]: document.createElement('table')
+    },
+    $tableContainer: { toggleClass: vi.fn(), css: vi.fn() },
+    $tableHeader: { show: vi.fn(), hide: vi.fn() },
+    $tableBody: {
+      get: vi.fn(() => ({ scrollWidth: 100, clientWidth: 100 })),
+      scrollTop: vi.fn(),
+      find: vi.fn(() => ({
+        outerHeight: vi.fn(() => 400),
+        outerWidth: vi.fn(() => 800),
+        is: vi.fn(() => true)
+      }))
+    },
+    $header: { outerHeight: vi.fn(() => 50) },
+    $tableFooter: {
+      show: vi.fn(),
+      hide: vi.fn(),
+      outerHeight: vi.fn(() => 30)
+    },
+    $container: { hasClass: vi.fn(() => false) },
+    $toolbar: { outerHeight: vi.fn(() => 40) },
+    $pagination: { outerHeight: vi.fn(() => 20) },
+    $tableBorder: null,
+    _timeoutId: timeoutIds,
+    _setDelayTimeout: vi.fn((type, callback, delay) => {
+      clearTimeout(timeoutIds[type])
+      timeoutIds[type] = setTimeout(callback, delay)
+    }),
+    resetHeader: vi.fn(),
+    resetCaret: vi.fn(),
+    fitFooter: vi.fn(),
+    trigger: vi.fn(),
+    hasScrollBar: false,
+    ...overrides
+  }
+}
+
+describe('BodyModule', () => {
+  describe('resetView hidden detection', () => {
+    let ctx
+
+    beforeEach(() => {
+      vi.useFakeTimers()
+      ctx = createBodyMockContext()
+      Object.assign(ctx, BodyModule)
+    })
+
+    afterEach(() => {
+      vi.clearAllTimers()
+      vi.useRealTimers()
+      vi.restoreAllMocks()
+    })
+
+    it('should schedule delayed resetView when table is hidden', () => {
+      ctx.$el.is = vi.fn(() => true)
+
+      ctx.resetView()
+
+      expect(ctx._setDelayTimeout).toHaveBeenCalledWith(
+        'resetView', expect.any(Function), 100
+      )
+      expect(ctx.trigger).not.toHaveBeenCalledWith('reset-view', expect.anything())
+    })
+
+    it('should not schedule delayed resetView when table is visible', () => {
+      ctx.$el.is = vi.fn(() => false)
+
+      ctx.resetView()
+
+      const resetViewCalls = ctx._setDelayTimeout.mock.calls.filter(
+        call => call[0] === 'resetView'
+      )
+
+      expect(resetViewCalls).toHaveLength(0)
+    })
+
+    it('should debounce multiple resetView calls when hidden', () => {
+      ctx.$el.is = vi.fn(() => true)
+
+      ctx.resetView()
+      ctx.resetView()
+      ctx.resetView()
+
+      expect(ctx._setDelayTimeout).toHaveBeenCalledTimes(3)
+      const allCalls = ctx._setDelayTimeout.mock.calls
+      const resetViewCalls = allCalls.filter(call => call[0] === 'resetView')
+
+      expect(resetViewCalls).toHaveLength(3)
+    })
+
+    it('should not schedule delayed resetView when height is not set', () => {
+      ctx.options.height = undefined
+      ctx.$el.is = vi.fn(() => true)
+
+      ctx.resetView()
+
+      const resetViewCalls = ctx._setDelayTimeout.mock.calls.filter(
+        call => call[0] === 'resetView'
+      )
+
+      expect(resetViewCalls).toHaveLength(0)
+    })
+
+    it('should not schedule timeout when ResizeObserver is active', () => {
+      ctx.$el.is = vi.fn(() => true)
+      ctx._resizeObserver = { disconnect: vi.fn(), observe: vi.fn() }
+
+      ctx.resetView()
+
+      const resetViewCalls = ctx._setDelayTimeout.mock.calls.filter(
+        call => call[0] === 'resetView'
+      )
+
+      expect(resetViewCalls).toHaveLength(0)
+    })
+  })
+})

--- a/tests/modules/header.test.js
+++ b/tests/modules/header.test.js
@@ -1,0 +1,252 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import HeaderModule from '@/modules/header.js'
+
+function createHeaderMockContext (overrides = {}) {
+  const timeoutIds = {}
+
+  return {
+    options: {
+      height: 500,
+      cardView: false,
+      showHeader: true,
+      showFooter: false,
+      columns: [[]],
+      detailView: false,
+      sortable: false,
+      escape: false,
+      escapeTitle: false,
+      singleSelect: false,
+      checkboxHeader: true
+    },
+    columns: [],
+    _headerTrClasses: [''],
+    _headerTrStyles: [''],
+    header: {},
+    $el: {
+      is: vi.fn(() => false),
+      attr: vi.fn(() => 'test-table'),
+      find: vi.fn(() => ({ each: vi.fn(), data: vi.fn() })),
+      [0]: document.createElement('table')
+    },
+    $header: {
+      html: vi.fn(),
+      show: vi.fn(),
+      hide: vi.fn(),
+      outerHeight: vi.fn(() => 50),
+      find: vi.fn(() => ({
+        each: vi.fn(),
+        data: vi.fn(),
+        off: vi.fn(() => ({ on: vi.fn() }))
+      }))
+    },
+    $container: { off: vi.fn(() => ({ on: vi.fn() })) },
+    $tableHeader: { show: vi.fn(), hide: vi.fn() },
+    $tableLoading: { css: vi.fn() },
+    $selectAll: { off: vi.fn(), on: vi.fn() },
+    _timeoutId: timeoutIds,
+    _setDelayTimeout: vi.fn((type, callback, delay) => {
+      clearTimeout(timeoutIds[type])
+      timeoutIds[type] = setTimeout(callback, delay)
+    }),
+    resetView: vi.fn(),
+    resetCaret: vi.fn(),
+    _resizeObserver: null,
+    destroy () {
+      for (const type of Object.keys(this._timeoutId)) {
+        clearTimeout(this._timeoutId[type])
+      }
+      if (this._resizeObserver) {
+        this._resizeObserver.disconnect()
+        this._resizeObserver = null
+      }
+    },
+    ...overrides
+  }
+}
+
+describe('HeaderModule', () => {
+  describe('ResizeObserver hidden-to-visible detection', () => {
+    let ctx
+    let originalResizeObserver
+    let original$
+
+    beforeEach(() => {
+      originalResizeObserver = globalThis.ResizeObserver
+      // @ts-expect-error - testing purposes
+      original$ = global.$
+      // @ts-expect-error - testing purposes
+      global.$ = vi.fn(() => ({ off: vi.fn(), on: vi.fn() }))
+      ctx = createHeaderMockContext()
+      Object.assign(ctx, HeaderModule)
+    })
+
+    afterEach(() => {
+      if (ctx._resizeObserver) {
+        ctx._resizeObserver.disconnect()
+        ctx._resizeObserver = null
+      }
+      globalThis.ResizeObserver = originalResizeObserver
+      // @ts-expect-error - testing purposes
+      global.$ = original$
+      vi.restoreAllMocks()
+    })
+
+    it('should create ResizeObserver when table is hidden at init', () => {
+      globalThis.ResizeObserver = vi.fn(function (cb) {
+        this.callback = cb
+        this.observe = vi.fn()
+        this.disconnect = vi.fn()
+      })
+      ctx.$el.is = vi.fn(() => true)
+
+      ctx.initHeader()
+
+      expect(ctx._resizeObserver).toBeTruthy()
+      expect(ctx._resizeObserver.observe).toHaveBeenCalledWith(ctx.$el[0])
+    })
+
+    it('should not create ResizeObserver when table is visible at init', () => {
+      const MockRO = vi.fn(function (cb) {
+        this.callback = cb
+        this.observe = vi.fn()
+        this.disconnect = vi.fn()
+      })
+
+      globalThis.ResizeObserver = MockRO
+      ctx.$el.is = vi.fn(() => false)
+
+      ctx.initHeader()
+
+      expect(ctx._resizeObserver).toBeNull()
+      expect(MockRO).not.toHaveBeenCalled()
+    })
+
+    it('should call resetView and disconnect when hidden-to-visible is detected', () => {
+      let observerCallback
+
+      globalThis.ResizeObserver = vi.fn(function (cb) {
+        observerCallback = cb
+        this.observe = vi.fn()
+        this.disconnect = vi.fn()
+      })
+      ctx.$el.is = vi.fn(() => true)
+
+      ctx.initHeader()
+
+      expect(observerCallback).toBeDefined()
+
+      const observer = ctx._resizeObserver
+
+      observerCallback([{
+        contentRect: { width: 800, height: 600 }
+      }])
+
+      expect(observer.disconnect).toHaveBeenCalled()
+      expect(ctx.resetView).toHaveBeenCalled()
+    })
+
+    it('should disconnect observer after first hidden-to-visible trigger', () => {
+      let observerCallback
+
+      globalThis.ResizeObserver = vi.fn(function (cb) {
+        observerCallback = cb
+        this.observe = vi.fn()
+        this.disconnect = vi.fn()
+      })
+      ctx.$el.is = vi.fn(() => true)
+
+      ctx.initHeader()
+
+      observerCallback([{
+        contentRect: { width: 800, height: 600 }
+      }])
+
+      expect(ctx.resetView).toHaveBeenCalledTimes(1)
+      expect(ctx._resizeObserver).toBeNull()
+    })
+
+    it('should not trigger resetView while still hidden', () => {
+      let observerCallback
+
+      globalThis.ResizeObserver = vi.fn(function (cb) {
+        observerCallback = cb
+        this.observe = vi.fn()
+        this.disconnect = vi.fn()
+      })
+      ctx.$el.is = vi.fn(() => true)
+
+      ctx.initHeader()
+
+      observerCallback([{
+        contentRect: { width: 0, height: 0 }
+      }])
+
+      expect(ctx.resetView).not.toHaveBeenCalled()
+      expect(ctx._resizeObserver.disconnect).not.toHaveBeenCalled()
+    })
+
+    it('should not trigger resetView when only one dimension is non-zero', () => {
+      let observerCallback
+
+      globalThis.ResizeObserver = vi.fn(function (cb) {
+        observerCallback = cb
+        this.observe = vi.fn()
+        this.disconnect = vi.fn()
+      })
+      ctx.$el.is = vi.fn(() => true)
+
+      ctx.initHeader()
+
+      observerCallback([{
+        contentRect: { width: 800, height: 0 }
+      }])
+
+      expect(ctx.resetView).not.toHaveBeenCalled()
+      expect(ctx._resizeObserver.disconnect).not.toHaveBeenCalled()
+    })
+
+    it('should disconnect existing observer before creating a new one', () => {
+      const disconnectSpy = vi.fn()
+      const oldObserver = { disconnect: disconnectSpy, observe: vi.fn() }
+
+      ctx._resizeObserver = oldObserver
+
+      globalThis.ResizeObserver = vi.fn(function (cb) {
+        this.callback = cb
+        this.observe = vi.fn()
+        this.disconnect = vi.fn()
+      })
+      ctx.$el.is = vi.fn(() => true)
+
+      ctx.initHeader()
+
+      expect(disconnectSpy).toHaveBeenCalled()
+      expect(ctx._resizeObserver).toBeTruthy()
+      expect(ctx._resizeObserver).not.toBe(oldObserver)
+    })
+  })
+
+  describe('destroy cleanup', () => {
+    it('should disconnect ResizeObserver on destroy', () => {
+      const mockDisconnect = vi.fn()
+      const ctx = createHeaderMockContext({
+        _resizeObserver: {
+          disconnect: mockDisconnect
+        }
+      })
+
+      ctx.destroy()
+
+      expect(mockDisconnect).toHaveBeenCalled()
+      expect(ctx._resizeObserver).toBeNull()
+    })
+
+    it('should handle destroy when no ResizeObserver exists', () => {
+      const ctx = createHeaderMockContext({
+        _resizeObserver: null
+      })
+
+      expect(() => ctx.destroy()).not.toThrow()
+    })
+  })
+})


### PR DESCRIPTION
**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
Fix #8149

**📝Changelog**

- [x] **Core**
- [ ] **Extensions**

Fix table rendering issue when the table is initially hidden (e.g., in a tab or collapsed container) with a fixed `height` option set. The table would not render correctly because layout calculations (scrollbar detection, header/footer sizing) fail on hidden elements.

- When `resetView` is called on a hidden table with `height`, delay the layout recalculation until the table becomes visible.
- Use `ResizeObserver` to detect when a hidden table transitions to visible, then trigger `resetView` automatically.
- Clean up `ResizeObserver` on destroy and after first detection.

**💡Example(s)?**
Before: https://live.bootstrap-table.com/code/robske110/19109
After: https://live.bootstrap-table.com/code/wenzhixin/19195

**☑️Self Check before Merge**

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed