### PR TITLE
Fix HTML labels display in checkbox dropdowns

### DIFF
--- a/src/utils/checkbox.js
+++ b/src/utils/checkbox.js
@@ -1,4 +1,4 @@
-import { escapeAttr, escapeHTML } from './string.js'
+import { escapeAttr } from './string.js'
 import { getBootstrapVersion } from './framework.js'
 
 /**
@@ -38,13 +38,12 @@ export function getCheckboxHtml (options) {
   const valueAttr = value !== undefined && value !== '' ? ` value="${escapeAttr(value)}"` : ''
   const classAttr = extraClass ? ` ${extraClass}` : ''
   const escapedName = escapeAttr(name)
-  const escapedLabel = escapeHTML(label)
 
   if (getBootstrapVersion() === 5) {
     if (withLabel) {
       return `<label class="dropdown-item dropdown-item-marker d-flex align-items-center gap-2">
         <input class="form-check-input m-0${classAttr}" type="checkbox" name="${escapedName}"${valueAttr}${checkedAttr}${disabledAttr} />
-        <span>${escapedLabel}</span>
+        <span>${label}</span>
       </label>`
     }
     const centerClass = centered ? ' d-flex justify-content-center' : ''
@@ -55,7 +54,7 @@ export function getCheckboxHtml (options) {
   }
 
   if (withLabel) {
-    return `<label><input type="checkbox" name="${escapedName}"${valueAttr}${checkedAttr}${disabledAttr}${classAttr}> <span>${escapedLabel}</span></label>`
+    return `<label><input type="checkbox" name="${escapedName}"${valueAttr}${checkedAttr}${disabledAttr}${classAttr}> <span>${label}</span></label>`
   }
   return `<label><input type="checkbox" name="${escapedName}"${valueAttr}${checkedAttr}${disabledAttr}${classAttr} /><span></span></label>`
 }
@@ -122,14 +121,13 @@ export function getDropdownColumnCheckboxHtml (options) {
 
   const checkedAttr = checked ? ' checked="checked"' : ''
   const disabledAttr = disabled ? ' disabled="disabled"' : ''
-  const escapedLabel = escapeHTML(label)
 
   if (getBootstrapVersion() === 5) {
     return `<label class="dropdown-item dropdown-item-marker d-flex align-items-center gap-2">
       <input class="form-check-input m-0" type="checkbox" data-field="${escapeAttr(dataField)}" value="${escapeAttr(value)}"${checkedAttr}${disabledAttr} />
-      <span>${escapedLabel}</span>
+      <span>${label}</span>
     </label>`
   }
 
-  return `<input type="checkbox" data-field="${escapeAttr(dataField)}" value="${escapeAttr(value)}"${checkedAttr}${disabledAttr}> <span>${escapedLabel}</span>`
+  return `<input type="checkbox" data-field="${escapeAttr(dataField)}" value="${escapeAttr(value)}"${checkedAttr}${disabledAttr}> <span>${label}</span>`
 }

--- a/tests/utils/checkbox.test.js
+++ b/tests/utils/checkbox.test.js
@@ -108,6 +108,16 @@ describe('getCheckboxHtml', () => {
       expect(html).toContain('dropdown-item')
       expect(html).toContain('Label Text')
     })
+
+    it('should preserve HTML in label', () => {
+      const html = checkbox.getCheckboxHtml({
+        name: 'test',
+        label: '<span>Title</span>',
+        withLabel: true
+      })
+
+      expect(html).toContain('<span>Title</span>')
+    })
   })
 
   describe('Bootstrap 3/4', () => {
@@ -163,6 +173,16 @@ describe('getCheckboxHtml', () => {
 
       expect(html).toContain('<label>')
       expect(html).toContain('Label Text')
+    })
+
+    it('should preserve HTML in label', () => {
+      const html = checkbox.getCheckboxHtml({
+        name: 'test',
+        label: '<em>Styled</em> Label',
+        withLabel: true
+      })
+
+      expect(html).toContain('<em>Styled</em> Label')
     })
 
     it('should handle extra class', () => {
@@ -374,6 +394,18 @@ describe('getDropdownColumnCheckboxHtml', () => {
       expect(html).toContain('dropdown-item')
     })
 
+    it('should preserve HTML in label', () => {
+      const html = checkbox.getDropdownColumnCheckboxHtml({
+        dataField: 'fieldName',
+        value: 'value1',
+        checked: false,
+        disabled: false,
+        label: '<span>Title</span>'
+      })
+
+      expect(html).toContain('<span>Title</span>')
+    })
+
     it('should include checked attribute', () => {
       const html = checkbox.getDropdownColumnCheckboxHtml({
         dataField: 'fieldName',
@@ -427,6 +459,18 @@ describe('getDropdownColumnCheckboxHtml', () => {
       expect(html).toContain('data-field="fieldName"')
       expect(html).toContain('value="value1"')
       expect(html).toContain('Field Label')
+    })
+
+    it('should preserve HTML in label', () => {
+      const html = checkbox.getDropdownColumnCheckboxHtml({
+        dataField: 'fieldName',
+        value: 'value1',
+        checked: false,
+        disabled: false,
+        label: '<span>Title</span>'
+      })
+
+      expect(html).toContain('<span>Title</span>')
     })
 
     it('should include checked attribute', () => {


### PR DESCRIPTION
**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
Fix #8338

**📝Changelog**
- [x] **Core**

Display HTML content as-is in checkbox labels instead of escaping it. This fixes the regression where column titles containing HTML (e.g., `<span>` for vertical text) were showing escaped tags in dropdown menus.

**💡Example(s)?**
Before (1.27.3): Column filter dropdown shows escaped/raw HTML tags for titles containing HTML elements.
After: Column filter dropdown renders HTML content correctly, allowing custom styling like vertical text.

<img width="1009" height="296" alt="image" src="https://github.com/user-attachments/assets/d54152c0-0c35-4fbe-9c5b-54625eee2322" />

**☑️Self Check before Merge**

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed