### PR TITLE
fix: avoid filter-control selection errors

### DIFF
--- a/src/extensions/filter-control/utils.js
+++ b/src/extensions/filter-control/utils.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-use-before-define */
 const Utils = $.fn.bootstrapTable.utils
 const searchControls = 'select, input:not([type="checkbox"]):not([type="radio"])'
+const selectionInputTypes = ['password', 'search', 'tel', 'text', 'url']
 
 export function getInputClass (that, isSelect = false) {
   const formControlClass = isSelect ? that.constants.classes.select : that.constants.classes.input
@@ -170,13 +171,27 @@ export function setCaretPosition (elem, caretPos) {
 
         range.move('character', caretPos)
         range.select()
-      } else if (elem.setSelectionRange) {
+      } else if (elem.setSelectionRange && canSetCaretPosition(elem)) {
         elem.setSelectionRange(caretPos, caretPos)
       }
     }
   } catch (ex) {
     console.error(ex)
   }
+}
+
+function canSetCaretPosition (elem) {
+  const tagName = elem.tagName && elem.tagName.toLowerCase()
+
+  if (tagName === 'textarea') {
+    return true
+  }
+
+  if (tagName !== 'input') {
+    return false
+  }
+
+  return selectionInputTypes.includes(elem.type)
 }
 
 export function setValues (that) {

--- a/tests/extensions/filter-control/utils.test.js
+++ b/tests/extensions/filter-control/utils.test.js
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+describe('filter-control utils', () => {
+  describe('setCaretPosition', () => {
+    let original$
+    let setCaretPosition
+
+    beforeEach(async () => {
+      vi.resetModules()
+      original$ = globalThis.$
+      globalThis.$ = {
+        fn: {
+          bootstrapTable: {
+            utils: {}
+          }
+        },
+        inArray: vi.fn()
+      }
+      const utils = await import('@/extensions/filter-control/utils.js')
+
+      setCaretPosition = utils.setCaretPosition
+    })
+
+    afterEach(() => {
+      globalThis.$ = original$
+      vi.restoreAllMocks()
+    })
+
+    it('sets the caret for text-like filter inputs', () => {
+      const input = document.createElement('input')
+      const setSelectionRange = vi.fn()
+
+      input.type = 'search'
+      input.setSelectionRange = setSelectionRange
+
+      setCaretPosition(input, 3)
+
+      expect(setSelectionRange).toHaveBeenCalledWith(3, 3)
+    })
+
+    it('skips unsupported input types without logging an error', () => {
+      const input = document.createElement('input')
+      const setSelectionRange = vi.fn(() => {
+        throw new Error('unsupported input type')
+      })
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      input.type = 'date'
+      input.setSelectionRange = setSelectionRange
+
+      setCaretPosition(input, -1)
+
+      expect(setSelectionRange).not.toHaveBeenCalled()
+      expect(consoleError).not.toHaveBeenCalled()
+    })
+
+    it('skips select filter controls even if a selection API is present', () => {
+      const select = document.createElement('select')
+      const setSelectionRange = vi.fn()
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      select.setSelectionRange = setSelectionRange
+
+      setCaretPosition(select, -1)
+
+      expect(setSelectionRange).not.toHaveBeenCalled()
+      expect(consoleError).not.toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
Fix #7703

**📝Changelog**

- [ ] **Core**
- [x] **Extensions**

Filter-control now restores caret position only for text-like controls. Select and date filter controls no longer attempt `setSelectionRange`, avoiding the console error after filtering.

**💡Example(s)?**
Covered by a focused unit test for `setCaretPosition` with text, date, and select controls.

**☑️Self Check before Merge**

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

Verification:
- `yarn vitest run tests/extensions/filter-control/utils.test.js`
- `yarn test:vitest`
- `yarn eslint src/extensions/filter-control/utils.js tests/extensions/filter-control/utils.test.js`
- `yarn lint:js`
- `git diff --check`
