### PR TITLE
fix(filter-control): wire up hideUnusedSelectOptions for hide-unused-select-options

### DIFF
--- a/src/extensions/filter-control/bootstrap-table-filter-control.js
+++ b/src/extensions/filter-control/bootstrap-table-filter-control.js
@@ -56,6 +56,7 @@ Object.assign($.fn.bootstrapTable.defaults, {
   searchOnEnterKey: false,
   showFilterControlSwitch: false,
   sortSelectOptions: false,
+  filterControlHideUnusedSelectOptions: false,
   // internal variables
   _valuesFilterControl: [],
   _initialized: false,

--- a/src/extensions/filter-control/utils.js
+++ b/src/extensions/filter-control/utils.js
@@ -337,6 +337,10 @@ export function initFilterSelectControls (that) {
       if (that.options.sortSelectOptions) {
         sortSelectControl(selectControl, column.filterOrderBy, that.options)
       }
+
+      if (that.options.filterControlHideUnusedSelectOptions) {
+        hideUnusedSelectOptions(selectControl, uniqueValues)
+      }
     }
   })
 }


### PR DESCRIPTION
## Description

The `hideUnusedSelectOptions` function in `src/extensions/filter-control/utils.js` was defined and exported but never called anywhere, making the `data-hide-unused-select-options` attribute completely non-functional.

Reported in #7719 — the feature last worked in v1.19.1.

## Changes

- Add `filterControlHideUnusedSelectOptions: false` to the filter-control default options
- Call `hideUnusedSelectOptions(selectControl, uniqueValues)` in `initFilterSelectControls` when the option is enabled

## Example

```html
<table data-toggle="table"
       data-filter-control="true"
       data-filter-control-hide-unused-select-options="true"
       data-url="json/data1.json">
  <thead>
    <tr>
      <th data-field="id" data-filter-control="select">ID</th>
      <th data-field="name" data-filter-control="select">Name</th>
    </tr>
  </thead>
</table>
```

Fixes #7719