### PR TITLE
fix(filter-control): keep _initialized true after a no-op column toggle

### DIFF
--- a/src/extensions/filter-control/bootstrap-table-filter-control.js
+++ b/src/extensions/filter-control/bootstrap-table-filter-control.js
@@ -567,6 +567,9 @@ $.BootstrapTable = class extends $.BootstrapTable {
       this._initialized = false
     }
     super._toggleColumns(fields, checked, needUpdate)
+    // initHeader only runs when a column really changed visibility, so restore
+    // the flag here to stop it latching to false (#8216).
+    this._initialized = true
     UtilsFilterControl.syncHeaders(this)
   }
 }


### PR DESCRIPTION
## Bug

With `sidePagination: "server"` and `filterControl`, changing a filter control updates the table once and then never again — no further requests are sent.

## Root cause

`_toggleColumns` in the filter-control extension clears `_initialized` before delegating:

```js
_toggleColumns (fields, checked, needUpdate) {
  if (fields.length) {
    this._initialized = false
  }
  super._toggleColumns(fields, checked, needUpdate)
  UtilsFilterControl.syncHeaders(this)
}
```

The core implementation only reaches `_updateAfterColumnToggle` (and therefore `initHeader`, the one place that sets `_initialized = true`) when a column actually changed visibility:

```js
if (changedIndices.length) {
  this._updateAfterColumnToggle(changedIndices, checked, needUpdate)
}
```

So toggling a column that is already in the requested state — e.g. `showColumn(field)` on a visible column, common in "restore saved column state" code — leaves `_initialized` latched to `false` with nothing to restore it.

While it is `false`, `onColumnSearch` treats every subsequent filter change as the initial render:

```js
const isInitialRender = !this._initialized
...
this.onSearch({ currentTarget, firedByInitSearchText: isInitialRender }, false)
```

and `onSearch` skips `updatePagination()` for anything other than client-side pagination when `firedByInitSearchText` is truthy. For a server-side table that means no request, forever.

This predates the `_toggleColumn` → `_toggleColumns` refactor: the old code had the same hole, since `_toggleColumn` returned early on `this.columns[index].visible === checked` without reaching `initHeader`. Consistent with the issue being reported against 1.27.0.

## Fix

Restore the flag after the core call. `_toggleColumns` only runs from user/app actions after init (toolbar checkbox, `showColumn`/`hideColumn`, mobile's resize path, which pre-filters to actually-changing fields), so this cannot affect the initial-render guard added for #7287.

## Repro

vitest + happy-dom, using a custom `ajax` function as a request counter, mirroring the reporter's setup (server-side pagination, external control via `filterControlContainer`):

```js
const requests = []

$('#table').bootstrapTable({
  sidePagination: 'server',
  pagination: true,
  filterControl: true,
  filterControlContainer: '#filter',
  searchTimeOut: 0,
  ajax (params) {
    requests.push(params.data)
    params.success({ total: 0, rows: [] })
  }
})

await tick()
await changeFilter('1')
const before = requests.length

// "id" is already visible, so _toggleColumns changes nothing
$('#table').bootstrapTable('showColumn', 'id')

await changeFilter('0')
expect(requests.length).toBe(before + 1)
expect(requests.at(-1).filter).toBe('{"enabled":"0"}')
```

Before the fix:

```
× keeps requesting after a no-op showColumn
AssertionError: filter change after showColumn: expected 2 to be 3
```

After the fix it passes, and the request carries `filter={"enabled":"0"}`. A companion case that changes the filter twice *without* the `showColumn` call passes either way, which pins the cause on the toggle rather than the filter path.

The repro isn't included as a test file because it needs `jquery` in `devDependencies` (currently a peer dependency only) and there are no plugin-level vitest tests yet — happy to add both if you'd like it kept as a regression test.

## Notes

- `yarn test:vitest`: 415 passed, `eslint` clean.
- Previous revision of this PR touched `onColumnSearch` instead. That change was a no-op for server-side pagination and dropped `updatePagination()` for client-side, as @copilot-pull-request-reviewer correctly pointed out; it has been dropped and `onColumnSearch` is now untouched.

Fixes #8216
