### PR TITLE
Fix locale README: remove missing status for existing translations

### DIFF
--- a/src/locale/README.md
+++ b/src/locale/README.md
@@ -45,7 +45,7 @@ Table bellow is sorted ascending by language code. If case of add new translatio
 | Corsican (France)                                              | co-FR          | co         | missing        |
 | Czech (Czech Republic)                                         | cs-CZ          | cs         |                |
 | Welsh (United Kingdom)                                         | cy-GB          | cy         | missing        |
-| Danish (Denmark)                                               | da-DK          | da         | missing        |
+| Danish (Denmark)                                               | da-DK          | da         |                |
 | German (Austria)                                               | de-AT          |            | missing        |
 | German (Switzerland)                                           | de-CH          |            | missing        |
 | German (Germany)                                               | de-DE          | de         |                |
@@ -158,7 +158,7 @@ Table bellow is sorted ascending by language code. If case of add new translatio
 | Kyrgyz (Kyrgyzstan)                                            | ky-KG          | ky         | missing        |
 | Luxembourgish (Luxembourg)                                     | lb-LU          | lb         |                |
 | Lao (Lao P.D.R.)                                               | lo-LA          | lo         | missing        |
-| Lithuanian (Lithuania)                                         | lt-LT          | lt         | missing        |
+| Lithuanian (Lithuania)                                         | lt-LT          | lt         |                |
 | Latvian (Latvia)                                               | lv-LV          | lv         | missing        |
 | Maori (New Zealand)                                            | mi-NZ          | mi         | missing        |
 | Macedonian (Macedonia (Former Yugoslav Republic of Macedonia)) | mk-MK          | mk         | missing        |
@@ -179,7 +179,7 @@ Table bellow is sorted ascending by language code. If case of add new translatio
 | Nepali (Nepal)                                                 | ne-NP          | ne         | missing        |
 | Dutch (Belgium)                                                | nl-BE          |            |                |
 | Dutch (Netherlands)                                            | nl-NL          | nl         |                |
-| Norwegian, Nynorsk (Norway)                                    | nn-NO          | nn         | missing        |
+| Norwegian, Nynorsk (Norway)                                    | nn-NO          | nn         |                |
 | Sesotho sa Leboa (South Africa)                                | nso-ZA         | nso        | missing        |
 | Occitan (France)                                               | oc-FR          | oc         | missing        |
 | Oromo (Ethiopia)                                               | om-ET          | om         | missing        |
@@ -212,7 +212,7 @@ Table bellow is sorted ascending by language code. If case of add new translatio
 | Sami, Northern (Sweden)                                        | se-SE          |            | missing        |
 | Sinhala (Sri Lanka)                                            | si-LK          | si         | missing        |
 | Slovak (Slovakia)                                              | sk-SK          | sk         |                |
-| Slovenian (Slovenia)                                           | sl-SI          | sl         | missing        |
+| Slovenian (Slovenia)                                           | sl-SI          | sl         |                |
 | Sami, Southern (Norway)                                        | sma-NO         | sma        | missing        |
 | Sami, Southern (Sweden)                                        | sma-SE         |            | missing        |
 | Sami, Lule (Norway)                                            | smj-NO         | smj        | missing        |


### PR DESCRIPTION
**🤔Type of Request**
- [ ] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [x] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
<!-- Please prefix each issue number with  "Fix #"  (e.g. Fix #200)  -->

**📝Changelog**

- [x] **Core**
- [ ] **Extensions**

Remove the "missing" status in `src/locale/README.md` for locales that already have translation files:

- `nn-NO` (Norwegian Nynorsk) - added in PR #8395
- `da-DK` (Danish)
- `lt-LT` (Lithuanian)
- `sl-SI` (Slovenian)

**💡Example(s)?**
<!-- Please use our online Editor (https://live.bootstrap-table.com/) to create example(s) (Before and after your changes).
On our Wiki (https://github.com/wenzhixin/bootstrap-table/wiki/Online-Editor-Explanation) you can read how to use the editor.-->

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed
