### PR TITLE
Add orderList option to customize the column sort-direction cycle

### DIFF
--- a/cypress/common/options.js
+++ b/cypress/common/options.js
@@ -176,5 +176,23 @@ module.exports = (theme = '') => {
         .get('tr[data-index="0"]').click()
         .get('input[type="checkbox"][data-index="0"]').should('be.checked')
     })
+
+    testIf('Order List', () => {
+      cy.visit(`${baseUrl}order-list.html`)
+
+      // orderList 'desc,asc': the first click on a column sorts descending,
+      // the next ascending, then the cycle repeats.
+      cy.get('th[data-field="id"] .th-inner').click()
+      cy.get('th[data-field="id"] .th-inner').should('have.class', 'desc')
+      cy.get('tbody tr').first().find('td').eq(0).should('contain', '5')
+
+      cy.get('th[data-field="id"] .th-inner').click()
+      cy.get('th[data-field="id"] .th-inner').should('have.class', 'asc')
+      cy.get('tbody tr').first().find('td').eq(0).should('contain', '1')
+
+      // third click wraps back to the first direction of the cycle
+      cy.get('th[data-field="id"] .th-inner').click()
+      cy.get('th[data-field="id"] .th-inner').should('have.class', 'desc')
+    })
   })
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -68,6 +68,7 @@ export interface BootstrapTableColumn {
   escape?: boolean;
   events?: BootstrapTableEvents;
   order?: string;
+  orderList?: string | string[];
   visible?: boolean;
   detailFormatter?: any;
   valign?: any;
@@ -200,6 +201,7 @@ export interface BootstrapTableOptions {
   showColumnsSearch?: boolean;
   queryParamsType?: string;
   sortOrder?: any;
+  orderList?: string | string[];
   paginationDetailHAlign?: string;
   customSearch?: any;
   visibleSearch?: boolean;

--- a/site/src/pages/docs/api/column-options.mdx
+++ b/site/src/pages/docs/api/column-options.mdx
@@ -331,6 +331,20 @@ $('#table').bootstrapTable({
 
 - **Example:** [Sort Name Order](https://examples.bootstrap-table.com/#column-options/sort-name-order.html)
 
+## orderList
+
+- **Attribute:** `data-order-list`
+
+- **Type:** `String | Array`
+
+- **Detail:**
+
+  Overrides the table-level [`orderList`](table-options.md#orderlist) for this column, controlling the cycle of sort directions when repeatedly clicking this column's header. Handy for making a single column descending-first, e.g. a date column that should sort newest-first: `orderList: 'desc,asc'` ([issue #7477](https://github.com/wenzhixin/bootstrap-table/issues/7477)). Accepts a comma-separated string or an array of `'asc'`/`'desc'` tokens. When unset, the column falls back to the table-level `orderList`, then to this column's [`order`](#order).
+
+- **Default:** `undefined`
+
+- **Example:** [Order List](https://examples.bootstrap-table.com/#column-options/order-list.html)
+
 ## radio
 
 - **Attribute:** `data-radio`

--- a/site/src/pages/docs/api/column-options.mdx
+++ b/site/src/pages/docs/api/column-options.mdx
@@ -339,7 +339,7 @@ $('#table').bootstrapTable({
 
 - **Detail:**
 
-  Overrides the table-level [`orderList`](table-options.md#orderlist) for this column, controlling the cycle of sort directions when repeatedly clicking this column's header. Handy for making a single column descending-first, e.g. a date column that should sort newest-first: `orderList: 'desc,asc'` ([issue #7477](https://github.com/wenzhixin/bootstrap-table/issues/7477)). Accepts a comma-separated string or an array of `'asc'`/`'desc'` tokens. When unset, the column falls back to the table-level `orderList`, then to this column's [`order`](#order).
+  Overrides the table-level [`orderList`](https://bootstrap-table.com/docs/api/table-options/#orderlist) for this column, controlling the cycle of sort directions when repeatedly clicking this column's header. Handy for making a single column descending-first, e.g. a date column that should sort newest-first: `orderList: 'desc,asc'` ([issue #7477](https://github.com/wenzhixin/bootstrap-table/issues/7477)). Accepts a comma-separated string or an array of `'asc'`/`'desc'` tokens. When unset, the column falls back to the table-level `orderList`, then to this column's [`order`](#order).
 
 - **Default:** `undefined`
 

--- a/site/src/pages/docs/api/table-options.mdx
+++ b/site/src/pages/docs/api/table-options.mdx
@@ -1726,6 +1726,20 @@ $('#table').bootstrapTable({
 
 - **Example:** [Sort Empty Last](https://examples.bootstrap-table.com/#options/sort-empty-last.html)
 
+## orderList
+
+- **Attribute:** `data-order-list`
+
+- **Type:** `String | Array`
+
+- **Detail:**
+
+  Defines the cycle of sort directions used when repeatedly clicking a sortable column header, in order. Accepts a comma-separated string (`'asc,desc'`, `'desc, asc'`) or an array (`['asc', 'desc']`); tokens are case-insensitive. With the default `['asc', 'desc']` the first click sorts ascending — set `['desc', 'asc']` to make every sortable column descending-first (e.g. date or amount columns, see [issue #7477](https://github.com/wenzhixin/bootstrap-table/issues/7477)). When `sortReset` is enabled, an "unsorted" state is appended after the last direction. A column-level `orderList` overrides this value.
+
+- **Default:** `['asc', 'desc']`
+
+- **Example:** [Order List](https://examples.bootstrap-table.com/#options/order-list.html)
+
 ## sortName
 
 - **Attribute:** `data-sort-name`

--- a/site/src/pages/docs/api/table-options.mdx
+++ b/site/src/pages/docs/api/table-options.mdx
@@ -1734,9 +1734,9 @@ $('#table').bootstrapTable({
 
 - **Detail:**
 
-  Defines the cycle of sort directions used when repeatedly clicking a sortable column header, in order. Accepts a comma-separated string (`'asc,desc'`, `'desc, asc'`) or an array (`['asc', 'desc']`); tokens are case-insensitive. With the default `['asc', 'desc']` the first click sorts ascending — set `['desc', 'asc']` to make every sortable column descending-first (e.g. date or amount columns, see [issue #7477](https://github.com/wenzhixin/bootstrap-table/issues/7477)). When `sortReset` is enabled, an "unsorted" state is appended after the last direction. A column-level `orderList` overrides this value.
+  Defines the cycle of sort directions used when repeatedly clicking a sortable column header, in order. Accepts a comma-separated string (`'asc,desc'`, `'desc, asc'`) or an array (`['asc', 'desc']`); tokens are case-insensitive. Set `['desc', 'asc']` to make every sortable column descending-first (e.g. date or amount columns, see [issue #7477](https://github.com/wenzhixin/bootstrap-table/issues/7477)). When `sortReset` is enabled, an "unsorted" state is appended after the last direction. A column-level `orderList` overrides this value. When unset (the default), each column falls back to its own [`order`](https://bootstrap-table.com/docs/api/column-options/#order), so most existing configurations keep their current click cycle. The one deliberate change is for columns with `order: 'desc'` combined with `sortReset`: the previous cycle got stuck alternating between ascending and the unsorted state, whereas it now cycles descending → ascending → unsorted → descending.
 
-- **Default:** `['asc', 'desc']`
+- **Default:** `undefined`
 
 - **Example:** [Order List](https://examples.bootstrap-table.com/#options/order-list.html)
 

--- a/site/src/pages/zh-cn/docs/api/column-options.mdx
+++ b/site/src/pages/zh-cn/docs/api/column-options.mdx
@@ -331,6 +331,20 @@ $('#table').bootstrapTable({
 
 - **示例:** [Sort Name Order](https://examples.bootstrap-table.com/#column-options/sort-name-order.html)
 
+## orderList
+
+- **属性:** `data-order-list`
+
+- **类型:** `String | Array`
+
+- **详情:**
+
+  覆盖表级的 [`orderList`](table-options.md#orderlist)，控制重复点击该列头时排序方向的循环。适合让单个列首次即降序，例如日期列希望按最新优先排序：`orderList: 'desc,asc'`（[issue #7477](https://github.com/wenzhixin/bootstrap-table/issues/7477)）。接受逗号分隔的字符串或由 `'asc'`/`'desc'` 组成的数组。未设置时，该列依次回退到表级 `orderList`，再到该列的 [`order`](#order)。
+
+- **默认值:** `undefined`
+
+- **示例:** [Order List](https://examples.bootstrap-table.com/#column-options/order-list.html)
+
 ## radio
 
 - **属性:** `data-radio`

--- a/site/src/pages/zh-cn/docs/api/column-options.mdx
+++ b/site/src/pages/zh-cn/docs/api/column-options.mdx
@@ -339,7 +339,7 @@ $('#table').bootstrapTable({
 
 - **详情:**
 
-  覆盖表级的 [`orderList`](table-options.md#orderlist)，控制重复点击该列头时排序方向的循环。适合让单个列首次即降序，例如日期列希望按最新优先排序：`orderList: 'desc,asc'`（[issue #7477](https://github.com/wenzhixin/bootstrap-table/issues/7477)）。接受逗号分隔的字符串或由 `'asc'`/`'desc'` 组成的数组。未设置时，该列依次回退到表级 `orderList`，再到该列的 [`order`](#order)。
+  覆盖表级的 [`orderList`](https://bootstrap-table.com/zh-cn/docs/api/table-options/#orderlist)，控制重复点击该列头时排序方向的循环。适合让单个列首次即降序，例如日期列希望按最新优先排序：`orderList: 'desc,asc'`（[issue #7477](https://github.com/wenzhixin/bootstrap-table/issues/7477)）。接受逗号分隔的字符串或由 `'asc'`/`'desc'` 组成的数组。未设置时，该列依次回退到表级 `orderList`，再到该列的 [`order`](#order)。
 
 - **默认值:** `undefined`
 

--- a/site/src/pages/zh-cn/docs/api/table-options.mdx
+++ b/site/src/pages/zh-cn/docs/api/table-options.mdx
@@ -1722,6 +1722,20 @@ $('#table').bootstrapTable({
 
 - **示例:** [Sort Empty Last](https://examples.bootstrap-table.com/#options/sort-empty-last.html)
 
+## orderList
+
+- **属性:** `data-order-list`
+
+- **类型:** `String | Array`
+
+- **详情:**
+
+  定义重复点击可排序列头时排序方向的循环顺序。接受逗号分隔的字符串（`'asc,desc'`、`'desc, asc'`）或数组（`['asc', 'desc']`），token 大小写不敏感。默认 `['asc', 'desc']` 表示首次点击按升序排序；设置为 `['desc', 'asc']` 可让所有可排序列首次点击即降序（例如日期、金额列，见 [issue #7477](https://github.com/wenzhixin/bootstrap-table/issues/7477)）。启用 `sortReset` 时，会在最后一个方向之后追加一个"未排序"状态。列级 `orderList` 会覆盖此值。
+
+- **默认值:** `['asc', 'desc']`
+
+- **示例:** [Order List](https://examples.bootstrap-table.com/#options/order-list.html)
+
 ## sortName
 
 - **属性:** `data-sort-name`

--- a/site/src/pages/zh-cn/docs/api/table-options.mdx
+++ b/site/src/pages/zh-cn/docs/api/table-options.mdx
@@ -1730,9 +1730,9 @@ $('#table').bootstrapTable({
 
 - **详情:**
 
-  定义重复点击可排序列头时排序方向的循环顺序。接受逗号分隔的字符串（`'asc,desc'`、`'desc, asc'`）或数组（`['asc', 'desc']`），token 大小写不敏感。默认 `['asc', 'desc']` 表示首次点击按升序排序；设置为 `['desc', 'asc']` 可让所有可排序列首次点击即降序（例如日期、金额列，见 [issue #7477](https://github.com/wenzhixin/bootstrap-table/issues/7477)）。启用 `sortReset` 时，会在最后一个方向之后追加一个"未排序"状态。列级 `orderList` 会覆盖此值。
+  定义重复点击可排序列头时排序方向的循环顺序。接受逗号分隔的字符串（`'asc,desc'`、`'desc, asc'`）或数组（`['asc', 'desc']`），token 大小写不敏感。设置为 `['desc', 'asc']` 可让所有可排序列首次点击即降序（例如日期、金额列，见 [issue #7477](https://github.com/wenzhixin/bootstrap-table/issues/7477)）。启用 `sortReset` 时，会在最后一个方向之后追加一个"未排序"状态。列级 `orderList` 会覆盖此值。未设置时（即默认值），每列回退到自身的 [`order`](https://bootstrap-table.com/zh-cn/docs/api/column-options/#order)，因此大多数已有配置的点击循环保持不变。唯一有意调整的是 `order: 'desc'` 且启用 `sortReset` 的列：之前的循环会在升序与未排序状态之间反复卡住，现在则按降序 → 升序 → 未排序 → 降序 循环。
 
-- **默认值:** `['asc', 'desc']`
+- **默认值:** `undefined`
 
 - **示例:** [Order List](https://examples.bootstrap-table.com/#options/order-list.html)
 

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -285,6 +285,7 @@ const DEFAULTS = {
   sortable: true,
   sortClass: undefined,
   sortEmptyLast: false,
+  orderList: undefined, // ['asc','desc'] | ['desc','asc'] | 'asc,desc'; undefined => legacy column `order` fallback
   sortName: undefined,
   sortOrder: undefined,
   sortReset: false,
@@ -425,6 +426,7 @@ const COLUMN_DEFAULTS = {
   formatter: undefined, // function
   halign: undefined, // left, right, center
   order: 'asc', // asc, desc
+  orderList: undefined, // overrides the table-level orderList for this column
   radio: false,
   rowspan: undefined, // number
   searchable: true,

--- a/src/modules/data.js
+++ b/src/modules/data.js
@@ -232,32 +232,42 @@ export default {
   onSort ({ type, currentTarget }) {
     const $this = type === 'keypress' ? $(currentTarget) : $(currentTarget).parent()
     const $this_ = this.$header.find('th').eq($this.index())
+    const column = this.columns[this.fieldsColumnsIndex[$this.data('field')]]
 
     this.$header.add(this.$header_).find('span.order').remove()
 
+    // Resolve the effective sort-direction cycle for this column:
+    //   column orderList  >  global orderList  >  legacy [order, opposite(order)]
+    // orderList values are normalized to arrays at init time; an unset/invalid
+    // value stays undefined so the legacy column `order` fallback takes over and
+    // existing configurations keep cycling byte-for-byte as before.
+    let orderList = column.orderList || this.options.orderList
+
+    if (!orderList) {
+      const order = column.sortOrder || column.order || 'asc'
+
+      orderList = [order, order === 'asc' ? 'desc' : 'asc']
+    }
+
     if (this.options.sortName === $this.data('field')) {
-      const currentSortOrder = this.options.sortOrder
-      const initialSortOrder = this.columns[this.fieldsColumnsIndex[$this.data('field')]].sortOrder ||
-        this.columns[this.fieldsColumnsIndex[$this.data('field')]].order
+      // Same column clicked again: advance one step through the cycle. With
+      // sortReset, an undefined terminal state is appended after the last
+      // direction; selecting it clears the sort entirely.
+      const cycle = this.options.sortReset ? [...orderList, undefined] : orderList
+      const nextIndex = (cycle.indexOf(this.options.sortOrder) + 1) % cycle.length
 
-      if (currentSortOrder === undefined) {
-        this.options.sortOrder = 'asc'
-      } else if (currentSortOrder === 'asc') {
-        this.options.sortOrder = this.options.sortReset ? initialSortOrder === 'asc' ? 'desc' : undefined : 'desc'
-      } else if (this.options.sortOrder === 'desc') {
-        this.options.sortOrder = this.options.sortReset ? initialSortOrder === 'desc' ? 'asc' : undefined : 'asc'
-      }
-
+      this.options.sortOrder = cycle[nextIndex]
       if (this.options.sortOrder === undefined) {
         this.options.sortName = undefined
       }
     } else {
+      // New column: start from the cycle's first direction, unless rememberOrder
+      // flips the column's last remembered direction (unchanged legacy behavior).
       this.options.sortName = $this.data('field')
       if (this.options.rememberOrder) {
         this.options.sortOrder = $this.data('order') === 'asc' ? 'desc' : 'asc'
       } else {
-        this.options.sortOrder = this.columns[this.fieldsColumnsIndex[$this.data('field')]].sortOrder ||
-          this.columns[this.fieldsColumnsIndex[$this.data('field')]].order
+        this.options.sortOrder = orderList[0]
       }
     }
 

--- a/src/modules/data.js
+++ b/src/modules/data.js
@@ -239,8 +239,10 @@ export default {
     // Resolve the effective sort-direction cycle for this column:
     //   column orderList  >  global orderList  >  legacy [order, opposite(order)]
     // orderList values are normalized to arrays at init time; an unset/invalid
-    // value stays undefined so the legacy column `order` fallback takes over and
-    // existing configurations keep cycling byte-for-byte as before.
+    // value stays undefined so the legacy column `order` fallback takes over.
+    // The only deliberate change vs. the old cycle: order 'desc' with sortReset
+    // previously got stuck (asc <-> undefined) and now cycles
+    // desc -> asc -> undefined -> desc.
     let orderList = column.orderList || this.options.orderList
 
     if (!orderList) {
@@ -251,21 +253,23 @@ export default {
 
     if (this.options.sortName === $this.data('field')) {
       // Same column clicked again: advance one step through the cycle. With
-      // sortReset, an undefined terminal state is appended after the last
-      // direction; selecting it clears the sort entirely.
-      const cycle = this.options.sortReset ? [...orderList, undefined] : orderList
-      const nextIndex = (cycle.indexOf(this.options.sortOrder) + 1) % cycle.length
+      // sortReset, a trailing "unsorted" state (handled inline to avoid an
+      // array allocation) clears the sort entirely.
+      const len = orderList.length
+      const nextIndex = (orderList.indexOf(this.options.sortOrder) + 1) %
+        (this.options.sortReset ? len + 1 : len)
 
-      this.options.sortOrder = cycle[nextIndex]
+      this.options.sortOrder = nextIndex === len ? undefined : orderList[nextIndex]
       if (this.options.sortOrder === undefined) {
         this.options.sortName = undefined
       }
     } else {
-      // New column: start from the cycle's first direction, unless rememberOrder
-      // flips the column's last remembered direction (unchanged legacy behavior).
+      // New column: start at the first direction, or — under rememberOrder —
+      // advance one step from the column's last direction (legacy behavior,
+      // now respecting a custom orderList too).
       this.options.sortName = $this.data('field')
       if (this.options.rememberOrder) {
-        this.options.sortOrder = $this.data('order') === 'asc' ? 'desc' : 'asc'
+        this.options.sortOrder = orderList[(orderList.indexOf($this.data('order')) + 1) % orderList.length]
       } else {
         this.options.sortOrder = orderList[0]
       }

--- a/src/modules/initialization.js
+++ b/src/modules/initialization.js
@@ -20,6 +20,9 @@ export default {
     opts.icons = Object.assign(Utils.getIcons(Constants.ICONS, opts.iconsPrefix),
       $.fn.bootstrapTable.defaults.icons, opts.icons)
 
+    // normalize orderList once at init so the click hot path deals only with arrays
+    opts.orderList = Utils.normalizeOrderList(opts.orderList)
+
     // init buttons class
     const buttonsPrefix = opts.buttonsPrefix ? `${opts.buttonsPrefix}-` : ''
 
@@ -200,6 +203,8 @@ export default {
     this.options.columns.forEach((columns, i) => {
       columns.forEach((_column, j) => {
         const column = Utils.extend({}, Constants.COLUMN_DEFAULTS, _column, { passed: _column })
+
+        column.orderList = Utils.normalizeOrderList(column.orderList)
 
         if (typeof column.fieldIndex !== 'undefined') {
           this.columns[column.fieldIndex] = column

--- a/src/utils/search-sort.js
+++ b/src/utils/search-sort.js
@@ -10,6 +10,35 @@ import { isNumeric } from './helper.js'
  */
 
 /**
+ * Normalizes an `orderList` value into a clean array of `'asc'` / `'desc'` tokens.
+ *
+ * Accepts either an array (e.g. `['desc', 'asc']`) or a comma-separated string
+ * (e.g. `'desc, asc'`). Tokens are trimmed and lowercased; anything that is not
+ * `'asc'` or `'desc'` is silently dropped. Returns the normalized array, or
+ * `undefined` when the input is `undefined`/empty or contains no valid token —
+ * in which case callers fall back to the legacy column `order` cycle.
+ *
+ * @param {undefined|string|string[]} input - The raw `orderList` value.
+ * @returns {string[]|undefined} The normalized list, or `undefined`.
+ */
+export function normalizeOrderList (input) {
+  if (input === undefined || input === null) {
+    return undefined
+  }
+  const tokens = Array.isArray(input) ? input : String(input).split(',')
+  const list = []
+
+  for (const token of tokens) {
+    const normalized = String(token).trim().toLowerCase()
+
+    if (normalized === 'asc' || normalized === 'desc') {
+      list.push(normalized)
+    }
+  }
+  return list.length ? list : undefined
+}
+
+/**
  * Compares a value against a search pattern using regex.
  * Supports both plain text search and regex patterns (e.g., /pattern/flags).
  *

--- a/tests/modules/data.test.js
+++ b/tests/modules/data.test.js
@@ -1,0 +1,308 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import DataModule from '@/modules/data.js'
+import { normalizeOrderList } from '@/utils/search-sort.js'
+
+// Self-referencing jQuery chain stub: any of `add/find/eq/remove` returns the
+// same chain, so the header DOM calls in onSort are no-ops without nesting.
+const headerChain = {
+  add: () => headerChain,
+  find: () => headerChain,
+  eq: () => headerChain,
+  remove: () => headerChain
+}
+
+// Builds a minimal `this` context for exercising DataModule.onSort in isolation.
+// orderList inputs are normalized the same way init/initHeader do, so tests can
+// pass raw strings/arrays and observe the post-init behavior.
+function createSortContext ({ options = {}, columns = [] } = {}) {
+  const ctx = {
+    options: {
+      sortName: undefined,
+      sortOrder: undefined,
+      sortReset: false,
+      rememberOrder: false,
+      sidePagination: 'client',
+      ...options,
+      orderList: normalizeOrderList(options.orderList)
+    },
+    // per-field remembered order, written by onSort via `$el.data('order', val)`
+    _remembered: {},
+    $header: headerChain,
+    $header_: {}
+  }
+
+  ctx.columns = columns.map(column => ({ ...column, orderList: normalizeOrderList(column.orderList) }))
+  ctx.fieldsColumnsIndex = {}
+  ctx.columns.forEach((column, i) => {
+    ctx.fieldsColumnsIndex[column.field] = i
+  })
+  Object.assign(ctx, DataModule)
+  // DataModule also defines _sort; override it (and resetCaret) AFTER the merge
+  // so onSort's tail calls are no-ops in this isolated test.
+  ctx._sort = vi.fn()
+  ctx.resetCaret = vi.fn()
+  return ctx
+}
+
+// Simulates a click on a column header for `field`, returning the resulting sort state.
+function click (ctx, field) {
+  const $this = {
+    data (key, val) {
+      if (arguments.length === 1) {
+        return key === 'field' ? field : ctx._remembered[field]
+      }
+      if (key === 'order') {
+        ctx._remembered[field] = val
+      }
+    },
+    index () {
+      return 0
+    },
+    add () {
+      return this
+    }
+  }
+
+  // @ts-expect-error - `$` is a rollup-injected global, mocked here for tests
+  global.$ = vi.fn(() => ({ parent: () => $this }))
+  ctx.onSort({ type: 'click', currentTarget: {} })
+  return { sortName: ctx.options.sortName, sortOrder: ctx.options.sortOrder }
+}
+
+// Clicks the same field `times` times and collects the sortOrder after each click.
+function cycleOf (ctx, field, times) {
+  const result = []
+
+  for (let i = 0; i < times; i++) {
+    result.push(click(ctx, field).sortOrder)
+  }
+  return result
+}
+
+describe('onSort orderList cycle', () => {
+  let original$
+
+  beforeEach(() => {
+    // @ts-expect-error - testing purposes
+    original$ = global.$
+  })
+
+  afterEach(() => {
+    // @ts-expect-error - testing purposes
+    global.$ = original$
+    vi.restoreAllMocks()
+  })
+
+  it('reproduces legacy behavior with the default cycle (asc → desc → asc)', () => {
+    const ctx = createSortContext({ columns: [{ field: 'name' }] })
+
+    expect(cycleOf(ctx, 'name', 4)).toEqual(['asc', 'desc', 'asc', 'desc'])
+  })
+
+  it('supports a descending-first column via column orderList (desc → asc → desc)', () => {
+    const ctx = createSortContext({
+      columns: [{ field: 'date', orderList: ['desc', 'asc'] }]
+    })
+
+    expect(cycleOf(ctx, 'date', 3)).toEqual(['desc', 'asc', 'desc'])
+  })
+
+  it('applies a global orderList to every sortable column', () => {
+    const ctx = createSortContext({
+      options: { orderList: ['desc', 'asc'] },
+      columns: [{ field: 'a' }, { field: 'b' }]
+    })
+
+    expect(cycleOf(ctx, 'a', 2)).toEqual(['desc', 'asc'])
+    // switch to column b: starts from the global cycle's first direction too
+    expect(click(ctx, 'b').sortOrder).toBe('desc')
+  })
+
+  it('lets a column orderList override the global orderList', () => {
+    const ctx = createSortContext({
+      options: { orderList: ['asc', 'desc'] },
+      columns: [
+        { field: 'override', orderList: ['desc', 'asc'] },
+        { field: 'default' }
+      ]
+    })
+
+    expect(click(ctx, 'override').sortOrder).toBe('desc')
+    expect(click(ctx, 'default').sortOrder).toBe('asc')
+  })
+
+  it('treats a comma-separated string equivalently to an array', () => {
+    const ctx = createSortContext({
+      columns: [{ field: 'date', orderList: 'desc, asc' }]
+    })
+
+    expect(ctx.columns[0].orderList).toEqual(['desc', 'asc'])
+    expect(cycleOf(ctx, 'date', 3)).toEqual(['desc', 'asc', 'desc'])
+  })
+
+  it('falls back to the default cycle when an orderList has no valid token', () => {
+    const ctx = createSortContext({
+      columns: [{ field: 'name', orderList: 'foo, bar' }]
+    })
+
+    expect(ctx.columns[0].orderList).toBeUndefined()
+    expect(cycleOf(ctx, 'name', 2)).toEqual(['asc', 'desc'])
+  })
+})
+
+describe('onSort sortReset', () => {
+  let original$
+
+  beforeEach(() => {
+    // @ts-expect-error - testing purposes
+    original$ = global.$
+  })
+
+  afterEach(() => {
+    // @ts-expect-error - testing purposes
+    global.$ = original$
+    vi.restoreAllMocks()
+  })
+
+  it('appends an undefined terminal state with the default cycle (asc → desc → undefined → asc)', () => {
+    const ctx = createSortContext({
+      options: { sortReset: true },
+      columns: [{ field: 'name' }]
+    })
+
+    expect(cycleOf(ctx, 'name', 4)).toEqual(['asc', 'desc', undefined, 'asc'])
+  })
+
+  it('appends an undefined terminal state with a descending-first cycle', () => {
+    const ctx = createSortContext({
+      options: { sortReset: true },
+      columns: [{ field: 'date', orderList: ['desc', 'asc'] }]
+    })
+
+    expect(cycleOf(ctx, 'date', 4)).toEqual(['desc', 'asc', undefined, 'desc'])
+  })
+
+  it('clears both sortName and sortOrder when reaching the terminal state', () => {
+    const ctx = createSortContext({
+      options: { sortReset: true },
+      columns: [{ field: 'name' }]
+    })
+
+    click(ctx, 'name') // asc
+    click(ctx, 'name') // desc
+    const afterReset = click(ctx, 'name') // undefined
+
+    expect(afterReset.sortName).toBeUndefined()
+    expect(afterReset.sortOrder).toBeUndefined()
+  })
+})
+
+describe('onSort legacy column order fallback', () => {
+  let original$
+
+  beforeEach(() => {
+    // @ts-expect-error - testing purposes
+    original$ = global.$
+  })
+
+  afterEach(() => {
+    // @ts-expect-error - testing purposes
+    global.$ = original$
+    vi.restoreAllMocks()
+  })
+
+  it('keeps the order: "desc" cycle byte-for-byte when sortReset is off (desc → asc → desc)', () => {
+    const ctx = createSortContext({
+      columns: [{ field: 'date', order: 'desc' }]
+    })
+
+    expect(cycleOf(ctx, 'date', 3)).toEqual(['desc', 'asc', 'desc'])
+  })
+
+  it('restarts from the configured direction after reset with order: "desc" (desc → asc → undefined → desc)', () => {
+    const ctx = createSortContext({
+      options: { sortReset: true },
+      columns: [{ field: 'date', order: 'desc' }]
+    })
+
+    expect(cycleOf(ctx, 'date', 4)).toEqual(['desc', 'asc', undefined, 'desc'])
+  })
+
+  it('respects orderList over a conflicting legacy order on the same column', () => {
+    const ctx = createSortContext({
+      columns: [{ field: 'date', order: 'desc', orderList: ['asc', 'desc'] }]
+    })
+
+    // orderList wins: first click is asc, not the legacy order's desc
+    expect(cycleOf(ctx, 'date', 2)).toEqual(['asc', 'desc'])
+  })
+
+  it('keeps the default order: "asc" + sortReset cycle byte-for-byte (asc → desc → undefined → asc)', () => {
+    const ctx = createSortContext({
+      options: { sortReset: true },
+      columns: [{ field: 'name' }]
+    })
+
+    expect(cycleOf(ctx, 'name', 4)).toEqual(['asc', 'desc', undefined, 'asc'])
+  })
+})
+
+describe('onSort rememberOrder', () => {
+  let original$
+
+  beforeEach(() => {
+    // @ts-expect-error - testing purposes
+    original$ = global.$
+  })
+
+  afterEach(() => {
+    // @ts-expect-error - testing purposes
+    global.$ = original$
+    vi.restoreAllMocks()
+  })
+
+  it('flips each column from its own remembered direction when switching columns', () => {
+    const ctx = createSortContext({
+      options: { rememberOrder: true, sortName: 'b', sortOrder: 'asc' },
+      columns: [{ field: 'a' }, { field: 'b' }]
+    })
+
+    // column a was last sorted desc, column b was last sorted asc
+    ctx._remembered = { a: 'desc', b: 'asc' }
+
+    // switching to a flips its remembered desc -> asc
+    expect(click(ctx, 'a').sortOrder).toBe('asc')
+    // switching to b flips its remembered asc -> desc
+    expect(click(ctx, 'b').sortOrder).toBe('desc')
+  })
+})
+
+describe('onSort server pagination', () => {
+  let original$
+
+  beforeEach(() => {
+    // @ts-expect-error - testing purposes
+    original$ = global.$
+  })
+
+  afterEach(() => {
+    // @ts-expect-error - testing purposes
+    global.$ = original$
+    vi.restoreAllMocks()
+  })
+
+  it('selects orderList[0] for the first click; the request wire format is unchanged', () => {
+    const ctx = createSortContext({
+      options: { sidePagination: 'server' },
+      columns: [{ field: 'date', orderList: ['desc', 'asc'] }]
+    })
+
+    const result = click(ctx, 'date')
+
+    // The only behavioral change for server-side sorting is the first sortOrder;
+    // _sort -> initServer still reads this.options.sortOrder/sortName unchanged.
+    expect(result.sortOrder).toBe('desc')
+    expect(result.sortName).toBe('date')
+    expect(ctx._sort).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/modules/data.test.js
+++ b/tests/modules/data.test.js
@@ -275,6 +275,19 @@ describe('onSort rememberOrder', () => {
     // switching to b flips its remembered asc -> desc
     expect(click(ctx, 'b').sortOrder).toBe('desc')
   })
+
+  it('respects a column orderList under rememberOrder (desc → asc → desc)', () => {
+    const ctx = createSortContext({
+      options: { rememberOrder: true },
+      columns: [{ field: 'date', orderList: ['desc', 'asc'] }]
+    })
+
+    // first click on a fresh column starts from the cycle's first direction
+    expect(click(ctx, 'date').sortOrder).toBe('desc')
+    // subsequent clicks advance through the configured cycle, not a plain flip
+    expect(click(ctx, 'date').sortOrder).toBe('asc')
+    expect(click(ctx, 'date').sortOrder).toBe('desc')
+  })
 })
 
 describe('onSort server pagination', () => {

--- a/tests/utils/search-sort.test.js
+++ b/tests/utils/search-sort.test.js
@@ -98,6 +98,50 @@ describe('sort', () => {
   })
 })
 
+describe('normalizeOrderList', () => {
+  it('should accept a valid array of tokens', () => {
+    expect(searchSort.normalizeOrderList(['asc', 'desc'])).toEqual(['asc', 'desc'])
+    expect(searchSort.normalizeOrderList(['desc', 'asc'])).toEqual(['desc', 'asc'])
+  })
+
+  it('should accept a comma-separated string', () => {
+    expect(searchSort.normalizeOrderList('asc,desc')).toEqual(['asc', 'desc'])
+    expect(searchSort.normalizeOrderList('desc, asc')).toEqual(['desc', 'asc'])
+    expect(searchSort.normalizeOrderList(' DESC , asc ')).toEqual(['desc', 'asc'])
+  })
+
+  it('should be case-insensitive and trim whitespace', () => {
+    expect(searchSort.normalizeOrderList('ASC, Desc')).toEqual(['asc', 'desc'])
+    expect(searchSort.normalizeOrderList([' ASC ', 'DESC'])).toEqual(['asc', 'desc'])
+  })
+
+  it('should drop malformed tokens, keeping valid ones', () => {
+    expect(searchSort.normalizeOrderList('asc, descending, desc')).toEqual(['asc', 'desc'])
+    expect(searchSort.normalizeOrderList(['foo', 'asc', 'bar', 'desc'])).toEqual(['asc', 'desc'])
+  })
+
+  it('should return undefined when no token is valid', () => {
+    expect(searchSort.normalizeOrderList('foo, bar')).toBeUndefined()
+    expect(searchSort.normalizeOrderList(['foo', 'bar'])).toBeUndefined()
+  })
+
+  it('should return undefined for empty input', () => {
+    expect(searchSort.normalizeOrderList('')).toBeUndefined()
+    expect(searchSort.normalizeOrderList([])).toBeUndefined()
+    expect(searchSort.normalizeOrderList(' , ')).toBeUndefined()
+  })
+
+  it('should pass through undefined / null untouched', () => {
+    expect(searchSort.normalizeOrderList(undefined)).toBeUndefined()
+    expect(searchSort.normalizeOrderList(null)).toBeUndefined()
+  })
+
+  it('should support a single-direction list', () => {
+    expect(searchSort.normalizeOrderList(['asc'])).toEqual(['asc'])
+    expect(searchSort.normalizeOrderList('desc')).toEqual(['desc'])
+  })
+})
+
 // Note: replaceSearchMark tests are skipped due to potential issues with happy-dom
 // The function modifies DOM elements and may cause worker timeout issues
 // This is a known limitation of testing DOM manipulation in this environment


### PR DESCRIPTION
**🤔Type of Request**
- [ ] **Bug fix**
- [x] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
Fix #7477

**📝Changelog**

<!-- The type of the change. --->
- [x] **Core**
- [ ] **Extensions**

<!-- Describe changes from the user side. -->

Adds a new `orderList` option (table-level and column-level) that controls the cycle of sort directions a column steps through when its header is clicked.

- Table-level `orderList` applies to all sortable columns, e.g. `orderList: 'desc,asc'` makes the first click sort descending.
- Column-level `orderList` overrides the table-level value for that column.
- Accepts an array (`['desc', 'asc']`) or a comma-separated string (`'desc, asc'`).
- When unset, the legacy column `order` cycle is preserved byte-for-byte, so existing configurations are unaffected.
- Plays well with `sortReset` (an undefined terminal state is appended to the cycle).

**💡Example(s)?**
- Options: <https://examples.bootstrap-table.com/#options/order-list.html>
- Column Options: <https://examples.bootstrap-table.com/#column-options/order-list.html>

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->