### PR TITLE
Fix cross-reference links in Chinese docs to point to zh-cn pages

### DIFF
--- a/site/src/pages/zh-cn/docs/api/column-options.mdx
+++ b/site/src/pages/zh-cn/docs/api/column-options.mdx
@@ -411,7 +411,7 @@ $('#table').bootstrapTable({
 
 - **详情:**
 
-  定义自定义高亮格式化函数，为 [search highlight](https://bootstrap-table.com/docs/api/table-options/#searchhighlight) 选项提供高亮功能。
+  定义自定义高亮格式化函数，为 [search highlight](https://bootstrap-table.com/zh-cn/docs/api/table-options/#searchhighlight) 选项提供高亮功能。
 
 - **默认值:** `true`
 

--- a/site/src/pages/zh-cn/docs/api/methods.mdx
+++ b/site/src/pages/zh-cn/docs/api/methods.mdx
@@ -185,7 +185,7 @@ toc: true
   * `useCurrentPage`：若为 `true`，只返回当前页数据。
   * `includeHiddenRows`：若为 `true`，包含隐藏行。
   * `unfiltered`：若为 `true`，返回所有数据（未过滤）。
-  * `formatted`：按已定义的 [formatter](https://bootstrap-table.com/docs/api/column-options/#formatter) 返回格式化值。
+  * `formatted`：按已定义的 [formatter](https://bootstrap-table.com/zh-cn/docs/api/column-options/#formatter) 返回格式化值。
 
 - **示例:** [Get Data](https://examples.bootstrap-table.com/#methods/get-data.html)
 
@@ -257,7 +257,7 @@ toc: true
 
   返回所有已选中的行数据。当没有记录被选中时，返回空数组。
 
-  **注意：** 在执行搜索、切换页面或排序等操作时，已选中的行会被自动取消选择。如需在操作后保留选择状态，请配置 [maintainMetaData](https://bootstrap-table.com/docs/api/table-options/#maintainmetadata) 选项。
+  **注意：** 在执行搜索、切换页面或排序等操作时，已选中的行会被自动取消选择。如需在操作后保留选择状态，请配置 [maintainMetaData](https://bootstrap-table.com/zh-cn/docs/api/table-options/#maintainmetadata) 选项。
 
 - **示例:** [Get Selections](https://examples.bootstrap-table.com/#methods/get-selections.html)
 

--- a/site/src/pages/zh-cn/docs/api/table-options.mdx
+++ b/site/src/pages/zh-cn/docs/api/table-options.mdx
@@ -70,14 +70,14 @@ $('#table').bootstrapTable({
 - **详情:**
 
   允许创建/添加自定义按钮到按钮栏（表格右上角）。
-  这些按钮可以通过表格选项 [buttonsOrder](https://bootstrap-table.com/docs/api/table-options/#buttonsorder) 进行排序，应使用事件对应的键/名称进行排序。
+  这些按钮可以通过表格选项 [buttonsOrder](https://bootstrap-table.com/zh-cn/docs/api/table-options/#buttonsorder) 进行排序，应使用事件对应的键/名称进行排序。
 
   自定义按钮具有高度可配置性，存在以下选项：
   - `text`
-    - 描述：此选项用于 [showButtonText](https://bootstrap-table.com/docs/api/table-options/#showbuttontext) 表格选项。
+    - 描述：此选项用于 [showButtonText](https://bootstrap-table.com/zh-cn/docs/api/table-options/#showbuttontext) 表格选项。
     - 类型：`String`
   - `icon`
-    - 描述：此选项用于 [showButtonIcons](https://bootstrap-table.com/docs/api/table-options/#showbuttonicons) 表格选项。
+    - 描述：此选项用于 [showButtonIcons](https://bootstrap-table.com/zh-cn/docs/api/table-options/#showbuttonicons) 表格选项。
     - 类型：`String` - 只需要图标类，例如 `fa-users`
   - `render`
     - 描述：将此选项设置为 `false` 以默认隐藏按钮，当添加数据属性 `data-show-button-name="true"` 时按钮再次可见。
@@ -756,7 +756,7 @@ $('#table').bootstrapTable({
 
 - **详情:**
 
-  指定用作复选框/单选框值的字段，对应 [selectItemName](https://bootstrap-table.com/docs/api/table-options/#selectitemname) 选项。
+  指定用作复选框/单选框值的字段，对应 [selectItemName](https://bootstrap-table.com/zh-cn/docs/api/table-options/#selectitemname) 选项。
 
 - **默认值:** `undefined`
 
@@ -914,7 +914,7 @@ $('#table').bootstrapTable({
 
   设置分页时，通过选择列表初始化页面大小。如果包含 `'all'` 或 `'unlimited'` 选项，所有记录将显示在表格中。
 
-  *提示：如果表格行数少于选项数量，选项将自动隐藏。要禁用此功能，可将 [smartDisplay](https://bootstrap-table.com/docs/api/table-options/#smartdisplay) 设置为 `false`*
+  *提示：如果表格行数少于选项数量，选项将自动隐藏。要禁用此功能，可将 [smartDisplay](https://bootstrap-table.com/zh-cn/docs/api/table-options/#smartdisplay) 设置为 `false`*
 
 - **默认值:** `[10, 25, 50, 100]`
 
@@ -1262,9 +1262,9 @@ $('#table').bootstrapTable({
     示例：4 大于 3。
 
   注意：
-  - 如果要使用自定义搜索输入，请使用 [searchSelector](https://bootstrap-table.com/docs/api/table-options/#searchSelector)。
-  - 您也可以使用 [regexSearch](https://bootstrap-table.com/docs/api/table-options/#regexSearch) 选项通过正则表达式搜索。
-  - 如果要向服务器端分页发送可搜索参数，请使用 [searchable](https://bootstrap-table.com/docs/api/table-options/#searchable) 选项。
+  - 如果要使用自定义搜索输入，请使用 [searchSelector](https://bootstrap-table.com/zh-cn/docs/api/table-options/#searchSelector)。
+  - 您也可以使用 [regexSearch](https://bootstrap-table.com/zh-cn/docs/api/table-options/#regexSearch) 选项通过正则表达式搜索。
+  - 如果要向服务器端分页发送可搜索参数，请使用 [searchable](https://bootstrap-table.com/zh-cn/docs/api/table-options/#searchable) 选项。
 
 - **默认值:** `false`
 
@@ -1278,7 +1278,7 @@ $('#table').bootstrapTable({
 
 - **详情:**
 
-  设置为 `true` 以在使用服务器端分页时向服务器发送[可搜索参数](https://bootstrap-table.com/docs/api/column-options/#searchable)。
+  设置为 `true` 以在使用服务器端分页时向服务器发送[可搜索参数](https://bootstrap-table.com/zh-cn/docs/api/column-options/#searchable)。
 
 - **默认值:** `false`
 
@@ -1321,7 +1321,7 @@ $('#table').bootstrapTable({
 - **详情:**
 
   设置为 `true` 以突出显示搜索的文本（使用 `<mark>` HTML 标签）。
-  您也可以定义[自定义高亮格式化程序](https://bootstrap-table.com/docs/api/column-options/#searchhighlightformatter)，例如，对于带有 HTML 的值或使用自定义高亮颜色。
+  您也可以定义[自定义高亮格式化程序](https://bootstrap-table.com/zh-cn/docs/api/column-options/#searchhighlightformatter)，例如，对于带有 HTML 的值或使用自定义高亮颜色。
 
 - **默认值:** `'false'`
 
@@ -1988,7 +1988,7 @@ $('#table').bootstrapTable({
 
 - **错误处理**
 
-  要获取加载错误，请使用 [onLoadError](https://bootstrap-table.com/docs/api/events/#onloaderror)
+  要获取加载错误，请使用 [onLoadError](https://bootstrap-table.com/zh-cn/docs/api/events/#onloaderror)
 
 ## virtualScroll
 

--- a/site/src/pages/zh-cn/docs/extensions/filter-control.mdx
+++ b/site/src/pages/zh-cn/docs/extensions/filter-control.mdx
@@ -67,7 +67,7 @@ toc: true
 
   指定过滤控件的容器选择器。例如设置为 `#filter`，会将所有过滤控件渲染到 id 为 `filter` 的元素中。
 
-  容器中的每个过滤元素（input 或 select）必须包含类名 `bootstrap-table-filter-control-<FieldName>`，其中 `<FieldName>` 需要替换为对应列的 [field](https://bootstrap-table.com/docs/api/column-options/#field) 属性值。
+  容器中的每个过滤元素（input 或 select）必须包含类名 `bootstrap-table-filter-control-<FieldName>`，其中 `<FieldName>` 需要替换为对应列的 [field](https://bootstrap-table.com/zh-cn/docs/api/column-options/#field) 属性值。
 
 - **默认值:** `false`
 

--- a/site/src/pages/zh-cn/docs/extensions/reorder-columns.mdx
+++ b/site/src/pages/zh-cn/docs/extensions/reorder-columns.mdx
@@ -76,4 +76,4 @@ toc: true
 
 - **详情:**
 
-  根据传入的配置对象重新排列列顺序。对象的键为 [field](https://bootstrap-table.com/docs/api/column-options/#field)（列字段名），值为列索引（从 0 开始）。
+  根据传入的配置对象重新排列列顺序。对象的键为 [field](https://bootstrap-table.com/zh-cn/docs/api/column-options/#field)（列字段名），值为列索引（从 0 开始）。


### PR DESCRIPTION
**🤔Type of Request**
- [ ] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [x] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
<!-- Please prefix each issue numbers with  "Fix #"  (e.g. Fix #200)  -->

**📝Changelog**

<!-- The type of the change. --->
- [ ] **Core**
- [ ] **Extensions**

<!-- Describe changes from the user side. -->
Cross-reference links inside the Chinese (`zh-cn`) documentation pages pointed to the English site (`https://bootstrap-table.com/docs/...`) instead of the Chinese version. They now point to `https://bootstrap-table.com/zh-cn/docs/...`, consistent with the link style introduced for `orderList` in #8417.

Affected files:
- `docs/api/table-options.mdx`
- `docs/api/column-options.mdx`
- `docs/api/methods.mdx`
- `docs/extensions/filter-control.mdx`
- `docs/extensions/reorder-columns.mdx`

**💡Example(s)?**
<!-- Please use our online Editor (https://live.bootstrap-table.com/) to create example(s) (Before and after your changes).
On our Wiki (https://github.com/wenzhixin/bootstrap-table/wiki/Online-Editor-Explanation) you can read how to use the editor.-->

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed