### PR TITLE
Fix table header alignment with vertical scrollbar (#6006)

### DIFF
--- a/src/modules/header.js
+++ b/src/modules/header.js
@@ -255,8 +255,7 @@ export default {
     }
 
     const fixedBody = this.$tableBody.get(0)
-    const scrollWidth = this.hasScrollBar &&
-    fixedBody.scrollHeight > fixedBody.clientHeight + this.$header.outerHeight() ?
+    const scrollWidth = fixedBody.scrollHeight > fixedBody.clientHeight ?
       Utils.getScrollBarWidth() : 0
 
     this.$el.css('margin-top', -this.$header.outerHeight())
@@ -448,8 +447,7 @@ export default {
     }
 
     const fixedBody = this.$tableBody.get(0)
-    const scrollWidth = this.hasScrollBar &&
-      fixedBody.scrollHeight > fixedBody.clientHeight + this.$header.outerHeight() ?
+    const scrollWidth = fixedBody.scrollHeight > fixedBody.clientHeight ?
       Utils.getScrollBarWidth() : 0
 
     this.$tableFooter


### PR DESCRIPTION
**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
Fix #6006

**📝Changelog**

- [x] **Core**
- [ ] **Extensions**

Fixed the table header not aligning with its content when a vertical scrollbar is present. The `scrollWidth` (scrollbar offset) calculation in `fitHeader()` / `fitFooter()` previously required `hasScrollBar` (which detects the *horizontal* scrollbar) and added `header.outerHeight()` to the comparison, causing the offset to be skipped in cases where only a vertical scrollbar existed. Now the offset is applied whenever `scrollHeight > clientHeight`.

**💡Example(s)?**
<!-- TODO: add before/after example -->

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Changelog is provided or not needed