### PR TITLE
Add showFooter support to the fixed-columns extension

### DIFF
--- a/cypress/extensions/fixed-columns.js
+++ b/cypress/extensions/fixed-columns.js
@@ -42,4 +42,72 @@ module.exports = (theme = '') => {
         .should('not.have.class', 'hover-row')
     })
   })
+
+  describe('Fixed Columns Footer Test', () => {
+    it('should render footers in the fixed columns when showFooter is enabled', () => {
+      cy.visit(`${baseUrl}fixed-columns.html`)
+        .get('.bootstrap-table').should('exist')
+        .get('.fixed-columns').should('exist')
+
+      // Enable the footer, which triggers a rebuild of the table
+      cy.get('#showFooter').check()
+
+      // The fixed left column renders a footer cloned from the main footer
+      cy.get('.fixed-columns > .fixed-table-footer').should('exist')
+      // The fixed right column renders a footer too
+      cy.get('.fixed-columns-right > .fixed-table-footer').should('exist')
+
+      // The fixed footer cells mirror the main footer content
+      cy.get('.fixed-table-container > .fixed-table-footer th').its('length').then(total => {
+        cy.get('.fixed-columns > .fixed-table-footer th').its('length')
+          .should('eq', total)
+      })
+    })
+
+    it('should not render footers when showFooter is disabled', () => {
+      cy.visit(`${baseUrl}fixed-columns.html`)
+        .get('.bootstrap-table').should('exist')
+
+      // showFooter is unchecked by default
+      cy.get('#showFooter').uncheck()
+      cy.get('.fixed-columns > .fixed-table-footer').should('not.exist')
+      cy.get('.fixed-columns-right > .fixed-table-footer').should('not.exist')
+    })
+
+    it('should keep the footer inside the body when height is not set', () => {
+      cy.visit(`${baseUrl}fixed-columns.html`)
+        .get('.bootstrap-table').should('exist')
+        .get('.fixed-columns').should('exist')
+
+      // Without a fixed height, the footer is a <tfoot> within the table body.
+      // The fixed columns must not clone a separate footer area in that case.
+      cy.get('#height').uncheck()
+      cy.get('#showFooter').check()
+
+      cy.get('.fixed-columns > .fixed-table-footer').should('not.exist')
+      cy.get('.fixed-columns-right > .fixed-table-footer').should('not.exist')
+      // the <tfoot> footer still renders inside the fixed body
+      cy.get('.fixed-columns .fixed-table-body tfoot').should('exist')
+    })
+
+    it('should keep the fixed footers pinned when the table is scrolled horizontally', () => {
+      cy.visit(`${baseUrl}fixed-columns.html`)
+        .get('.bootstrap-table').should('exist')
+        .get('.fixed-columns').should('exist')
+
+      cy.get('#showFooter').check()
+
+      // scroll the main body horizontally to the right
+      cy.get('.fixed-table-container > .fixed-table-body').scrollTo('right')
+
+      // the left fixed footer stays pinned to its leftmost position
+      cy.get('.fixed-columns > .fixed-table-footer').then($el => {
+        expect($el.scrollLeft()).to.eq(0)
+      })
+      // the right fixed footer stays pinned to its rightmost position
+      cy.get('.fixed-columns-right > .fixed-table-footer').then($el => {
+        expect($el.scrollLeft()).to.be.greaterThan(0)
+      })
+    })
+  })
 }

--- a/site/src/pages/docs/extensions/fixed-columns.mdx
+++ b/site/src/pages/docs/extensions/fixed-columns.mdx
@@ -59,7 +59,7 @@ toc: true
 
 * Not support `detailView` option.
 * Not support `cardView` option.
-* Not support `showFooter` option.
+* Support `showFooter` option: when `showFooter` is `true`, the fixed left and right columns render a footer cloned from the main table footer, keeping alignment and horizontal scroll in sync. Set to `false` (the default) to skip the footer.
 * Need to import after sticky-header when using with sticky-header extension. For example:
 ```html
 <link rel="stylesheet" href="extensions/sticky-header/bootstrap-table-sticky-header.css">

--- a/site/src/pages/zh-cn/docs/extensions/fixed-columns.mdx
+++ b/site/src/pages/zh-cn/docs/extensions/fixed-columns.mdx
@@ -61,7 +61,7 @@ toc: true
 
 * 不支持 `detailView` 选项。
 * 不支持 `cardView` 选项。
-* 不支持 `showFooter` 选项。
+* 支持 `showFooter` 选项：当 `showFooter` 为 `true` 时，固定左列和右列会渲染从主表格页脚克隆的页脚，并保持对齐和水平滚动同步。设为 `false`（默认值）时不渲染页脚。
 * 与 sticky-header 扩展一起使用时需在其后引入。例如：
 ```html
 <link rel="stylesheet" href="extensions/sticky-header/bootstrap-table-sticky-header.css">

--- a/src/extensions/fixed-columns/bootstrap-table-fixed-columns.js
+++ b/src/extensions/fixed-columns/bootstrap-table-fixed-columns.js
@@ -122,6 +122,7 @@ $.BootstrapTable = class extends $.BootstrapTable {
     }
 
     this.initFixedColumnsBody()
+    this.initFixedColumnsFooter()
     this.initFixedColumnsEvents()
   }
 
@@ -134,6 +135,8 @@ $.BootstrapTable = class extends $.BootstrapTable {
 
     if (args[0] === 'post-header') {
       this.initFixedColumnsHeader()
+    } else if (args[0] === 'post-footer') {
+      this.initFixedColumnsFooter()
     } else if (args[0] === 'scroll-body') {
       if (this.needFixedColumns && this.options.fixedNumber) {
         this.$fixedBody.scrollTop(this.$tableBody.scrollTop())
@@ -142,6 +145,8 @@ $.BootstrapTable = class extends $.BootstrapTable {
       if (this.needFixedColumns && this.options.fixedRightNumber) {
         this.$fixedBodyRight.scrollTop(this.$tableBody.scrollTop())
       }
+
+      this.syncFixedColumnsFooterScroll()
     }
   }
 
@@ -234,10 +239,13 @@ $.BootstrapTable = class extends $.BootstrapTable {
     }
 
     this.initFixedColumnsBody()
+    this.initFixedColumnsFooter()
     this.initFixedColumnsEvents()
   }
 
   initFixedColumnsBody () {
+    const footerHeight = this.getFixedColumnsFooterHeight()
+
     const initFixedBody = ($fixedColumns, $fixedHeader) => {
       $fixedColumns.find('.fixed-table-body').remove()
       $fixedColumns.append(this.$tableBody.clone(true))
@@ -255,7 +263,7 @@ $.BootstrapTable = class extends $.BootstrapTable {
       })
 
       $fixedBody.css({
-        height: height - $fixedHeader.height()
+        height: height - $fixedHeader.height() - footerHeight
       })
 
       return $fixedBody
@@ -269,6 +277,71 @@ $.BootstrapTable = class extends $.BootstrapTable {
       this.$fixedBodyRight = initFixedBody(this.$fixedColumnsRight, this.$fixedHeaderRight)
       this.$fixedBodyRight.scrollLeft(this.$fixedBodyRight.find('table').width())
       this.$fixedBodyRight.css('overflow-y', this.options.height ? 'auto' : 'hidden')
+    }
+  }
+
+  getFixedColumnsFooterHeight () {
+    // Without a fixed height the footer is rendered as a <tfoot> inside the
+    // table body, which is already covered by the cloned fixed body — so there
+    // is no separate footer area to reserve.
+    if (!this.options.height || !this.options.showFooter || this.options.cardView ||
+      !this.$tableFooter || !this.$tableFooter.length) {
+      return 0
+    }
+    return this.$tableFooter.outerHeight(true)
+  }
+
+  initFixedColumnsFooter () {
+    // Only tables with a fixed height keep the footer in a separate
+    // `.fixed-table-footer` container that needs to be cloned for the fixed
+    // columns. Without a fixed height the <tfoot> lives inside the cloned body.
+    const showFooter = this.options.height &&
+      this.options.showFooter && !this.options.cardView
+
+    const initFixedFooter = ($fixedColumns, isRight) => {
+      $fixedColumns.find('.fixed-table-footer').remove()
+      if (!showFooter) {
+        return null
+      }
+      $fixedColumns.append(this.$tableFooter.clone(true))
+      const $fixedFooter = $fixedColumns.find('.fixed-table-footer')
+
+      if (isRight) {
+        // keep the right footer scrolled to its rightmost position, mirroring
+        // the right header/body behavior
+        $fixedFooter.scrollLeft($fixedFooter.find('table').width())
+      }
+      return $fixedFooter
+    }
+
+    if (this.needFixedColumns && this.options.fixedNumber) {
+      this.$fixedFooter = initFixedFooter(this.$fixedColumns)
+    } else if (this.$fixedColumns) {
+      this.$fixedColumns.find('.fixed-table-footer').remove()
+      this.$fixedFooter = null
+    }
+
+    if (this.needFixedColumns && this.options.fixedRightNumber && this.$fixedColumnsRight) {
+      this.$fixedFooterRight = initFixedFooter(this.$fixedColumnsRight, true)
+    } else if (this.$fixedColumnsRight) {
+      this.$fixedColumnsRight.find('.fixed-table-footer').remove()
+      this.$fixedFooterRight = null
+    }
+  }
+
+  syncFixedColumnsFooterScroll () {
+    if (!this.options.showFooter || this.options.cardView) {
+      return
+    }
+
+    // The fixed columns are horizontally pinned and must not follow the main
+    // footer's horizontal scroll: the left footer stays at its leftmost
+    // position, while the right footer stays pinned to its rightmost position.
+    if (this.$fixedFooter) {
+      this.$fixedFooter.scrollLeft(0)
+    }
+    if (this.$fixedFooterRight) {
+      this.$fixedFooterRight.scrollLeft(this.$fixedFooterRight.find('table').width())
     }
   }
 

--- a/src/extensions/fixed-columns/bootstrap-table-fixed-columns.scss
+++ b/src/extensions/fixed-columns/bootstrap-table-fixed-columns.scss
@@ -25,6 +25,17 @@
 }
 
 .fixed-columns,
+.fixed-columns-right {
+  > .fixed-table-footer {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    box-sizing: border-box;
+  }
+}
+
+.fixed-columns,
 .fixed-columns-right,
 .fixed-table-container > .fixed-table-body {
   .table-hover .hover-row {


### PR DESCRIPTION
**🤔Type of Request**
- [ ] **Bug fix**
- [x] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
<!-- Please prefix each issue number with  "Fix #"  (e.g. Fix #200)  -->

**📝Changelog**

<!-- The type of the change. --->
- [ ] **Core**
- [x] **Extensions**

<!-- Describe changes from the user side. -->
The fixed-columns extension now supports the `showFooter` option. When `showFooter` is `true`, the fixed left and right columns render a footer cloned from the main table footer, keeping alignment and horizontal scroll in sync with the body. Previously this was listed as an unsupported option.

**💡Example(s)?**
[Fixed Columns Footer](https://examples.bootstrap-table.com/#extensions/fixed-columns-footer.html)

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed