### PR TITLE
feat: add RTL support for the rtl option

### DIFF
--- a/cypress/common/options.js
+++ b/cypress/common/options.js
@@ -194,5 +194,34 @@ module.exports = (theme = '') => {
       cy.get('th[data-field="id"] .th-inner').click()
       cy.get('th[data-field="id"] .th-inner').should('have.class', 'desc')
     })
+
+    testIf('RTL', () => {
+      cy.visit(`${baseUrl}rtl.html`)
+
+      // The root container carries the RTL direction attribute and semantic class.
+      cy.get('.bootstrap-table')
+        .should('have.class', 'bootstrap-table-rtl')
+        .and('have.attr', 'dir', 'rtl')
+
+      // The checkbox column is the first DOM column. Under dir="rtl" the browser
+      // lays columns out right-to-left, so its visual left edge ends up to the
+      // right of the last column's left edge (visual order is mirrored).
+      cy.get('.fixed-table-body thead tr:first-child th').then($ths => {
+        const lefts = $ths.map((_, el) => Math.round(el.getBoundingClientRect().left)).get()
+
+        expect(lefts.length).to.be.greaterThan(1)
+        expect(lefts[0]).to.be.greaterThan(lefts[lefts.length - 1])
+      })
+
+      // The columns button group is floated (pull/float-right in LTR); under RTL
+      // the mirror rule floats it to the left, so it sits in the left half of
+      // the toolbar.
+      cy.get('.fixed-table-toolbar .columns').then($el => {
+        const rect = Cypress.$('.bootstrap-table')[0].getBoundingClientRect()
+        const midX = rect.left + rect.width / 2
+
+        expect($el[0].getBoundingClientRect().left).to.be.lessThan(midX)
+      })
+    })
   })
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -159,6 +159,7 @@ export interface BootstrapTableOptions {
     $element: JQuery<HTMLElement>
   ) => boolean | void;
   rowStyle?: (row: any, index: number) => {};
+  rtl?: boolean | 'ltr' | 'rtl' | 'auto';
   showColumnsToggleAll?: boolean;
   footerStyle?: (column: BootstrapTableColumn) => {};
   onUncheck?: (row: any, $element: JQuery<HTMLElement>) => boolean | void;

--- a/site/src/pages/docs/api/table-options.mdx
+++ b/site/src/pages/docs/api/table-options.mdx
@@ -1247,6 +1247,39 @@ $('#table').bootstrapTable({
 
 - **Example:** [Row Style](https://examples.bootstrap-table.com/#options/row-style.html)
 
+## rtl
+
+- **Attribute:** `data-rtl`
+
+- **Type:** `Boolean | String`
+
+- **Detail:**
+
+  Set the table direction to right-to-left (RTL).
+
+  Supported values:
+  - `false` (default): left-to-right (LTR), byte-for-byte identical to previous versions.
+  - `true` / `'rtl'`: render the table as RTL.
+  - `'ltr'`: render the table as LTR (explicit).
+  - `'auto'`: detect the direction automatically. It reads the `dir` attribute of
+    the table element first, then the `<html>` element, and falls back to LTR if
+    neither is set.
+
+  When RTL is active, the root container gets a `dir="rtl"` attribute and a
+  `bootstrap-table-rtl` class, so the toolbar buttons, pagination, search box
+  and sort icons are mirrored, while the checkbox/index columns move to the
+  right side natively via `dir="rtl"`.
+
+  Column alignment (`align` / `halign` / `falign`) keeps its physical meaning
+  and is **not** flipped under RTL. If you need alignment that follows the
+  direction, use CSS logical values instead.
+
+  The RTL support for the `fixed-columns` extension is planned for a future change.
+
+- **Default:** `false`
+
+- **Example:** [RTL Support](https://examples.bootstrap-table.com/#options/rtl.html)
+
 ## search
 
 - **Attribute:** `data-search`

--- a/site/src/pages/zh-cn/docs/api/table-options.mdx
+++ b/site/src/pages/zh-cn/docs/api/table-options.mdx
@@ -1243,6 +1243,35 @@ $('#table').bootstrapTable({
 
 - **示例:** [Row Style](https://examples.bootstrap-table.com/#options/row-style.html)
 
+## rtl
+
+- **属性:** `data-rtl`
+
+- **类型:** `Boolean | String`
+
+- **详情:**
+
+  设置表格的方向为从右到左（RTL）。
+
+  支持的取值：
+  - `false`（默认）：从左到右（LTR），与之前的版本逐字节一致。
+  - `true` / `'rtl'`：以 RTL 方向渲染表格。
+  - `'ltr'`：显式以 LTR 方向渲染表格。
+  - `'auto'`：自动探测方向。优先读取表格元素的 `dir` 属性，其次是 `<html>` 元素的 `dir`
+    属性，两者都未设置时回退为 LTR。
+
+  当 RTL 生效时，根容器会获得 `dir="rtl"` 属性和 `bootstrap-table-rtl` 类，因此工具栏按钮、
+  分页、搜索框和排序图标会左右镜像，而复选框 / 索引列则通过 `dir="rtl"` 的原生行为移动到右侧。
+
+  列对齐（`align` / `halign` / `falign`）保持物理语义，在 RTL 模式下**不会**被翻转。
+  如果需要随方向变化的逻辑对齐，请使用 CSS 逻辑值。
+
+  `fixed-columns` 扩展的 RTL 支持将作为后续工作提供。
+
+- **默认值:** `false`
+
+- **示例:** [RTL Support](https://examples.bootstrap-table.com/#options/rtl.html)
+
 ## search
 
 - **属性:** `data-search`

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -253,6 +253,7 @@ const DEFAULTS = {
   responseHandler: res => res,
   rowAttributes: (row, index) => ({}),
   rowStyle: (row, index) => ({}),
+  rtl: false, // false, true, 'ltr', 'rtl', 'auto'
   search: false,
   searchable: false,
   searchAccentNeutralise: false,

--- a/src/modules/initialization.js
+++ b/src/modules/initialization.js
@@ -73,6 +73,25 @@ export default {
     }
   },
 
+  // Resolve the `rtl` option into a normalized internal value: 'ltr' or 'rtl'.
+  // Called during initContainer (after initConstants), before rendering the root container.
+  getRtlDirection () {
+    const rtl = this.options.rtl
+
+    if (rtl === 'auto') {
+      // Probe priority: the table element ($el) first, then <html>, else ltr.
+      const dir = (this.$el.attr('dir') || $('html').attr('dir') || '').toLowerCase()
+
+      return dir === 'rtl' ? 'rtl' : 'ltr'
+    }
+
+    if (rtl === true || rtl === 'rtl') {
+      return 'rtl'
+    }
+
+    return 'ltr'
+  },
+
   initContainer () {
     const topPagination = ['top', 'both'].includes(this.options.paginationVAlign) ?
       '<div class="fixed-table-pagination clearfix"></div>' : ''
@@ -81,8 +100,15 @@ export default {
     const loadingTemplate = Utils.calculateObjectValue(this.options,
       this.options.loadingTemplate, [this.options.formatLoadingMessage()])
 
+    // Normalize the table direction once; only the root container carries it
+    // (inherited by the table/toolbar/pagination). The original <table> dir is
+    // left untouched so existing extensions (print, filter-control) keep working.
+    const isRtl = this.getRtlDirection() === 'rtl'
+    const rtlClass = isRtl ? ' bootstrap-table-rtl' : ''
+    const rtlDir = isRtl ? ' dir="rtl"' : ''
+
     this.$container = $(`
-      <div class="bootstrap-table ${this.constants.theme}">
+      <div class="bootstrap-table ${this.constants.theme}${rtlClass}"${rtlDir}>
       <div class="fixed-table-toolbar"></div>
       ${topPagination}
       <div class="fixed-table-container">

--- a/src/themes/_theme.scss
+++ b/src/themes/_theme.scss
@@ -388,6 +388,100 @@ html[data-bs-theme="dark"] {
   }
 }
 
+// Right-to-left (RTL) support.
+// Only the root container carries dir="rtl" (inherited by the table, toolbar
+// and pagination); these rules mirror the directional LTR layout. Column
+// alignment keeps its physical meaning and is intentionally NOT flipped here.
+// Pagination prev/next arrows are reversed natively by the browser via
+// dir="rtl", so no CSS is needed for them.
+.bootstrap-table[dir="rtl"] {
+  // Mirror toolbar / pagination floats (pull-* for BS3, float-* for BS4/5).
+  // !important is required: BS3/BS4 framework utilities declare float with
+  // !important, so the override must too (higher specificity + !important wins).
+  .pull-right,
+  .float-right {
+    float: left !important;
+  }
+
+  .pull-left,
+  .float-left {
+    float: right !important;
+  }
+
+  .fixed-table-toolbar {
+    .columns {
+      .btn-group > .btn-group {
+        margin-right: -1px;
+        margin-left: 0;
+
+        &:first-child > .btn {
+          border-top-right-radius: 4px;
+          border-bottom-right-radius: 4px;
+        }
+
+        &:last-child > .btn {
+          border-top-left-radius: 4px;
+          border-bottom-left-radius: 4px;
+        }
+      }
+
+      .dropdown-menu {
+        text-align: right;
+      }
+    }
+
+    .columns-left {
+      margin-left: 5px;
+      margin-right: 0;
+    }
+
+    .columns-right {
+      margin-right: 5px;
+      margin-left: 0;
+    }
+
+    // Mirror the dropdown opened from a .pull-right (BS3) / .float-right (BS4/5)
+    // toolbar group. Theme-specific dropdown positioning lives in each theme
+    // file (e.g. bootstrap-table.scss).
+    .pull-right .dropdown-menu,
+    .float-right .dropdown-menu {
+      left: 0;
+      right: auto;
+    }
+  }
+
+  .fixed-table-container {
+    .table {
+      thead th,
+      tfoot th {
+        .sortable {
+          background-position: left;
+          padding-left: 30px !important;
+          padding-right: 0.75rem !important;
+        }
+
+        .both {
+          background-position: center left 2px;
+        }
+      }
+    }
+  }
+
+  .fixed-table-pagination {
+    > .pagination-detail {
+      .pagination-info {
+        margin-left: 5px;
+        margin-right: 0;
+      }
+    }
+  }
+
+  .fixed-table-loading .loading-wrap .loading-text {
+    margin-left: 6px;
+    margin-right: 0;
+  }
+}
+
 /* calculate scrollbar width */
 div.fixed-table-scroll-inner {
   width: 100%;

--- a/src/themes/bootstrap-table/bootstrap-table.scss
+++ b/src/themes/bootstrap-table/bootstrap-table.scss
@@ -221,6 +221,67 @@
     float: right;
   }
 
+  &[dir="rtl"] {
+    .caret {
+      margin-right: 2px;
+      margin-left: 0;
+    }
+
+    .fixed-table-toolbar {
+      .columns {
+        > .btn,
+        > .btn-group {
+          &:not(:last-child):not(.dropdown-toggle),
+          &:not(:last-child) > .btn {
+            border-top-left-radius: 0;
+            border-bottom-left-radius: 0;
+            border-left: none;
+          }
+
+          &:not(:first-child):not(.dropdown-toggle),
+          &:not(:first-child) > .btn {
+            border-top-right-radius: 0;
+            border-bottom-right-radius: 0;
+          }
+        }
+      }
+
+      .search .input-group {
+        .search-input {
+          border-top-left-radius: 0;
+          border-bottom-left-radius: 0;
+          border-left: none;
+        }
+
+        button[name="search"],
+        button[name="clearSearch"] {
+          border-top-right-radius: 0;
+          border-bottom-right-radius: 0;
+
+          &:not(:last-child) {
+            border-top-left-radius: 0;
+            border-bottom-left-radius: 0;
+            border-left: none;
+          }
+        }
+      }
+    }
+
+    // In LTR, the columns dropdown is right-anchored to its toggle; mirror
+    // it to the left side under RTL. The `_theme.scss` rules for
+    // `.pull-right/.float-right .dropdown-menu` (which are not nested under a
+    // toolbar prefix) win on specificity for those wrappers, so this base
+    // override only applies to dropdowns that are not floated.
+    .dropdown-menu {
+      left: 0;
+      right: auto;
+    }
+
+    .pagination-detail {
+      float: right;
+    }
+  }
+
   .pagination {
     padding: 0;
     align-items: center;

--- a/tests/modules/rtl.test.js
+++ b/tests/modules/rtl.test.js
@@ -1,0 +1,329 @@
+/**
+ * Tests for the `rtl` option (change: add-rtl-support).
+ *
+ * Covers direction resolution (getRtlDirection), root container injection
+ * (initContainer), preservation of the original <table> dir for extensions,
+ * and the physical semantics of column alignment.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import InitializationModule from '@/modules/initialization.js'
+import HeaderModule from '@/modules/header.js'
+import Utils from '@/utils/index.js'
+
+const { getRtlDirection, initContainer } = InitializationModule
+
+// Lightweight chainable jQuery stub for the parts of initContainer we exercise.
+function makeChainable () {
+  const c = {}
+
+  for (const m of ['find', 'insertAfter', 'after', 'append', 'addClass', 'css', 'show', 'hide', 'off', 'on']) {
+    c[m] = vi.fn(() => c)
+  }
+  c.length = 1
+  return c
+}
+
+describe('getRtlDirection', () => {
+  let original$
+
+  beforeEach(() => {
+    original$ = global.$
+  })
+
+  afterEach(() => {
+    global.$ = original$
+    vi.restoreAllMocks()
+  })
+
+  // ctx with a $el.attr getter; $('html') resolved via the global $ mock.
+  function ctx (rtl, { $elDir } = {}) {
+    return {
+      options: { rtl },
+      $el: { attr: vi.fn(() => $elDir) }
+    }
+  }
+
+  it('resolves false / "ltr" to ltr', () => {
+    global.$ = vi.fn()
+    expect(getRtlDirection.call(ctx(false))).toBe('ltr')
+    expect(getRtlDirection.call(ctx('ltr'))).toBe('ltr')
+  })
+
+  it('resolves true / "rtl" to rtl', () => {
+    global.$ = vi.fn()
+    expect(getRtlDirection.call(ctx(true))).toBe('rtl')
+    expect(getRtlDirection.call(ctx('rtl'))).toBe('rtl')
+  })
+
+  describe('auto probing', () => {
+    function mockHtml (htmlDir) {
+      global.$ = vi.fn(selector => {
+        if (selector === 'html') {
+          return { attr: vi.fn(() => htmlDir) }
+        }
+        return makeChainable()
+      })
+    }
+
+    it('follows the table element dir when set', () => {
+      mockHtml('rtl')
+      expect(getRtlDirection.call(ctx('auto', { $elDir: 'rtl' }))).toBe('rtl')
+    })
+
+    it('falls back to <html> dir when the table has none', () => {
+      mockHtml('rtl')
+      expect(getRtlDirection.call(ctx('auto', { $elDir: undefined }))).toBe('rtl')
+    })
+
+    it('falls back to ltr when neither the table nor <html> has dir', () => {
+      mockHtml(undefined)
+      expect(getRtlDirection.call(ctx('auto', { $elDir: undefined }))).toBe('ltr')
+    })
+
+    it('prefers the table element dir over <html>', () => {
+      mockHtml('rtl')
+      // table says ltr, html says rtl -> table wins
+      expect(getRtlDirection.call(ctx('auto', { $elDir: 'ltr' }))).toBe('ltr')
+    })
+
+    it('treats uppercase DIR values case-insensitively', () => {
+      mockHtml(undefined)
+      expect(getRtlDirection.call(ctx('auto', { $elDir: 'RTL' }))).toBe('rtl')
+    })
+  })
+})
+
+describe('initContainer direction injection', () => {
+  let original$
+  let capturedTemplates
+
+  beforeEach(() => {
+    original$ = global.$
+    capturedTemplates = []
+    global.$ = vi.fn(html => {
+      if (typeof html === 'string') {
+        capturedTemplates.push(html)
+      }
+      return makeChainable()
+    })
+  })
+
+  afterEach(() => {
+    global.$ = original$
+    vi.restoreAllMocks()
+  })
+
+  function run (rtl) {
+    const $el = makeChainable()
+
+    $el.attr = vi.fn(() => undefined) // getter only; tracked for setter assertions
+
+    const self = {
+      options: {
+        rtl,
+        loadingTemplate: msg => `<span>${msg}</span>`,
+        formatLoadingMessage: () => 'Loading',
+        classes: 'table',
+        paginationVAlign: 'bottom',
+        buttonsToolbar: undefined
+      },
+      constants: { theme: 'bootstrap3' },
+      $el,
+      getRtlDirection: InitializationModule.getRtlDirection
+    }
+
+    initContainer.call(self)
+
+    return { self, template: capturedTemplates[0], $el }
+  }
+
+  it('injects dir="rtl" and bootstrap-table-rtl class when RTL', () => {
+    const { template } = run(true)
+
+    expect(template).toContain('dir="rtl"')
+    expect(template).toContain('bootstrap-table-rtl')
+  })
+
+  it('injects neither dir nor class when LTR', () => {
+    const { template } = run(false)
+
+    expect(template).not.toContain('dir="rtl"')
+    expect(template).not.toContain('bootstrap-table-rtl')
+  })
+
+  it('keeps the root class ordering valid in RTL (no stray quotes)', () => {
+    const { template } = run(true)
+
+    // class attribute must still be well-formed
+    expect(template).toMatch(/class="bootstrap-table bootstrap3 bootstrap-table-rtl"\s+dir="rtl"/)
+  })
+
+  // The core must never SET dir on the original <table>, so print/filter-control
+  // keep reading their own value. Cover both the explicit path (rtl: true, where
+  // getRtlDirection never touches $el) and the auto path (where it reads
+  // $el.attr('dir') as a getter) to ensure neither issues a setter call.
+  it.each([
+    ['explicit rtl', true],
+    ['auto probing', 'auto']
+  ])('does not modify this.$el dir attribute in %s mode (extension compatibility)', (_name, rtl) => {
+    // auto mode also probes $('html').attr('dir'); provide a stub for that.
+    global.$ = vi.fn(selector => {
+      if (selector === 'html') {
+        return { attr: vi.fn(() => 'ltr') }
+      }
+      return makeChainable()
+    })
+
+    const $el = makeChainable()
+    // getter-only stub: returns 'ltr' (so auto resolves to ltr); we assert below
+    // that it is never called with a 2nd (value) argument.
+
+    $el.attr = vi.fn((...args) => args.length > 1 ? undefined : 'ltr')
+
+    const self = {
+      options: {
+        rtl,
+        loadingTemplate: msg => `<span>${msg}</span>`,
+        formatLoadingMessage: () => 'Loading',
+        classes: 'table',
+        paginationVAlign: 'bottom',
+        buttonsToolbar: undefined
+      },
+      constants: { theme: 'bootstrap3' },
+      $el,
+      getRtlDirection: InitializationModule.getRtlDirection
+    }
+
+    initContainer.call(self)
+
+    // Assert no attr('dir', value) setter call was made on the original <table>.
+    const dirSetter = $el.attr.mock.calls.find(
+      call => call[0] === 'dir' && call.length > 1 && call[1] !== undefined
+    )
+
+    expect(dirSetter).toBeUndefined()
+  })
+})
+
+describe('column alignment keeps physical semantics (RTL does not flip align)', () => {
+  let original$
+
+  beforeEach(() => {
+    original$ = global.$
+    global.$ = vi.fn(() => ({ data: vi.fn(), off: vi.fn(), on: vi.fn() }))
+  })
+
+  afterEach(() => {
+    global.$ = original$
+    vi.restoreAllMocks()
+  })
+
+  function createHeaderContext (align) {
+    const column = Utils.extend({}, {
+      field: 'name',
+      title: 'Name',
+      fieldIndex: 0,
+      align,
+      valign: 'top',
+      visible: true,
+      width: undefined,
+      widthUnit: 'px',
+      checkbox: false,
+      radio: false,
+      class: undefined,
+      rowspan: undefined,
+      colspan: undefined,
+      scope: undefined,
+      titleTooltip: undefined,
+      style: undefined,
+      _data: {},
+      formatter: undefined,
+      detailFormatter: undefined,
+      events: undefined,
+      sorter: undefined,
+      sortName: undefined,
+      cellStyle: undefined,
+      searchable: true,
+      sortable: false
+    })
+
+    return {
+      options: {
+        height: undefined,
+        cardView: false,
+        showHeader: true,
+        showFooter: false,
+        columns: [[column]],
+        detailView: false,
+        detailViewAlign: 'left',
+        sortable: false,
+        escape: false,
+        escapeTitle: false,
+        singleSelect: false,
+        checkboxHeader: true,
+        headerStyle: () => ({})
+      },
+      columns: [column],
+      header: {},
+      _headerTrClasses: [''],
+      _headerTrStyles: [''],
+      $el: {
+        is: () => false,
+        attr: () => 'test-table',
+        find: () => ({ each: () => {}, data: () => undefined }),
+        [0]: document.createElement('table')
+      },
+      $header: {
+        html: () => {},
+        show: () => {},
+        hide: () => {},
+        outerHeight: () => 50,
+        find: () => ({ each: () => {}, off: () => ({ on: () => {} }) })
+      },
+      $container: { off: () => ({ on: () => {} }) },
+      $tableHeader: { show: () => {}, hide: () => {} },
+      $selectAll: { off: () => {}, on: () => {} },
+      $tableLoading: { css: () => {} },
+      _timeoutId: {},
+      _setDelayTimeout: () => {},
+      resetView: () => {},
+      resetCaret: () => {},
+      _resizeObserver: null
+    }
+  }
+
+  function runInitHeader (align) {
+    // Column alignment keeps its physical meaning and is intentionally NOT
+    // flipped under RTL. HeaderModule.initHeader never reads the table
+    // direction, so we exercise it without any direction context at all.
+    const ctx = createHeaderContext(align)
+
+    Object.assign(ctx, HeaderModule)
+    ctx.initHeader()
+    return ctx
+  }
+
+  it('outputs text-align: right for an explicitly right-aligned column under RTL', () => {
+    const ctx = runInitHeader('right')
+
+    expect(ctx.header.styles[0]).toContain('text-align: right')
+  })
+
+  it('does not flip left alignment under RTL', () => {
+    const ctx = runInitHeader('left')
+
+    expect(ctx.header.styles[0]).toContain('text-align: left')
+  })
+
+  it('produces the same alignment output regardless of direction', () => {
+    const rtlCtx = createHeaderContext('right')
+    const ltrCtx = createHeaderContext('right')
+
+    Object.assign(rtlCtx, HeaderModule)
+    Object.assign(ltrCtx, HeaderModule)
+    rtlCtx.initHeader()
+    ltrCtx.initHeader()
+
+    expect(rtlCtx.header.styles[0]).toBe(ltrCtx.header.styles[0])
+  })
+})


### PR DESCRIPTION
**🤔Type of Request**
- [ ] **Bug fix**
- [x] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
<!-- Please prefix each issue number with  "Fix #"  (e.g. Fix #200)  -->

N/A

**📝Changelog**

<!-- The type of the change. --->
- [x] **Core**
- [ ] **Extensions**

<!-- Describe changes from the user side. -->

Add a new `rtl` option to render the table in right-to-left direction.

Supported values:
- `false` (default): left-to-right (LTR), byte-for-byte identical to previous versions.
- `true` / `'rtl'`: render the table as RTL.
- `'ltr'`: render the table as LTR (explicit).
- `'auto'`: detect the direction automatically. It reads the `dir` attribute of the table element first, then the `<html>` element, and falls back to LTR if neither is set.

When RTL is active, the root container gets a `dir="rtl"` attribute and a `bootstrap-table-rtl` class, so the toolbar buttons, pagination, search box and sort icons are mirrored, while the checkbox/index columns move to the right side natively via `dir="rtl"`.

Column alignment (`align` / `halign` / `falign`) keeps its physical meaning and is **not** flipped under RTL.

**💡Example(s)?**
<!-- Please use our online Editor (https://live.bootstrap-table.com/) to create example(s) (Before and after your changes).
On our Wiki (https://github.com/wenzhixin/bootstrap-table/wiki/Online-Editor-Explanation) you can read how to use the editor.-->

- Example: [RTL Support](https://examples.bootstrap-table.com/#options/rtl.html)

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
