### PR TITLE
feat: extend check-api to validate zh-cn API docs

### DIFF
--- a/site/src/pages/docs/api/table-options.mdx
+++ b/site/src/pages/docs/api/table-options.mdx
@@ -908,6 +908,20 @@ $('#table').bootstrapTable({
 
 - **Example:** [Multiple Select Row](https://examples.bootstrap-table.com/#options/multiple-select-row.html)
 
+## orderList
+
+- **Attribute:** `data-order-list`
+
+- **Type:** `String | Array`
+
+- **Detail:**
+
+  Defines the cycle of sort directions used when repeatedly clicking a sortable column header, in order. Accepts a comma-separated string (`'asc,desc'`, `'desc, asc'`) or an array (`['asc', 'desc']`); tokens are case-insensitive. Set `['desc', 'asc']` to make every sortable column descending-first (e.g. date or amount columns, see [issue #7477](https://github.com/wenzhixin/bootstrap-table/issues/7477)). When `sortReset` is enabled, an "unsorted" state is appended after the last direction. A column-level `orderList` overrides this value. When unset (the default), each column falls back to its own [`order`](https://bootstrap-table.com/docs/api/column-options/#order), so most existing configurations keep their current click cycle. The one deliberate change is for columns with `order: 'desc'` combined with `sortReset`: the previous cycle got stuck alternating between ascending and the unsorted state, whereas it now cycles descending → ascending → unsorted → descending.
+
+- **Default:** `undefined`
+
+- **Example:** [Order List](https://examples.bootstrap-table.com/#options/order-list.html)
+
 ## pageList
 
 - **Attribute:** `data-page-list`
@@ -1758,20 +1772,6 @@ $('#table').bootstrapTable({
 - **Default:** `false`
 
 - **Example:** [Sort Empty Last](https://examples.bootstrap-table.com/#options/sort-empty-last.html)
-
-## orderList
-
-- **Attribute:** `data-order-list`
-
-- **Type:** `String | Array`
-
-- **Detail:**
-
-  Defines the cycle of sort directions used when repeatedly clicking a sortable column header, in order. Accepts a comma-separated string (`'asc,desc'`, `'desc, asc'`) or an array (`['asc', 'desc']`); tokens are case-insensitive. Set `['desc', 'asc']` to make every sortable column descending-first (e.g. date or amount columns, see [issue #7477](https://github.com/wenzhixin/bootstrap-table/issues/7477)). When `sortReset` is enabled, an "unsorted" state is appended after the last direction. A column-level `orderList` overrides this value. When unset (the default), each column falls back to its own [`order`](https://bootstrap-table.com/docs/api/column-options/#order), so most existing configurations keep their current click cycle. The one deliberate change is for columns with `order: 'desc'` combined with `sortReset`: the previous cycle got stuck alternating between ascending and the unsorted state, whereas it now cycles descending → ascending → unsorted → descending.
-
-- **Default:** `undefined`
-
-- **Example:** [Order List](https://examples.bootstrap-table.com/#options/order-list.html)
 
 ## sortName
 

--- a/site/src/pages/zh-cn/docs/api/methods.mdx
+++ b/site/src/pages/zh-cn/docs/api/methods.mdx
@@ -712,7 +712,7 @@ toc: true
 
   若要禁用表格重新初始化，可设置 `{reinit: false}`。
 
-- **示例:** [Update Cell By Unique Id](https://examples.bootstrap-table.com/#methods/update-cell-by-uniqueid.html)
+- **示例:** [Update Cell By Unique Id](https://examples.bootstrap-table.com/#methods/update-cell-by-unique-id.html)
 
 ## updateColumnTitle
 

--- a/site/src/pages/zh-cn/docs/api/table-options.mdx
+++ b/site/src/pages/zh-cn/docs/api/table-options.mdx
@@ -904,6 +904,20 @@ $('#table').bootstrapTable({
 
 - **示例:** [Multiple Select Row](https://examples.bootstrap-table.com/#options/multiple-select-row.html)
 
+## orderList
+
+- **属性:** `data-order-list`
+
+- **类型:** `String | Array`
+
+- **详情:**
+
+  定义重复点击可排序列头时排序方向的循环顺序。接受逗号分隔的字符串（`'asc,desc'`、`'desc, asc'`）或数组（`['asc', 'desc']`），token 大小写不敏感。设置为 `['desc', 'asc']` 可让所有可排序列首次点击即降序（例如日期、金额列，见 [issue #7477](https://github.com/wenzhixin/bootstrap-table/issues/7477)）。启用 `sortReset` 时，会在最后一个方向之后追加一个"未排序"状态。列级 `orderList` 会覆盖此值。未设置时（即默认值），每列回退到自身的 [`order`](https://bootstrap-table.com/zh-cn/docs/api/column-options/#order)，因此大多数已有配置的点击循环保持不变。唯一有意调整的是 `order: 'desc'` 且启用 `sortReset` 的列：之前的循环会在升序与未排序状态之间反复卡住，现在则按降序 → 升序 → 未排序 → 降序 循环。
+
+- **默认值:** `undefined`
+
+- **示例:** [Order List](https://examples.bootstrap-table.com/#options/order-list.html)
+
 ## pageList
 
 - **属性:** `data-page-list`
@@ -1750,20 +1764,6 @@ $('#table').bootstrapTable({
 - **默认值:** `false`
 
 - **示例:** [Sort Empty Last](https://examples.bootstrap-table.com/#options/sort-empty-last.html)
-
-## orderList
-
-- **属性:** `data-order-list`
-
-- **类型:** `String | Array`
-
-- **详情:**
-
-  定义重复点击可排序列头时排序方向的循环顺序。接受逗号分隔的字符串（`'asc,desc'`、`'desc, asc'`）或数组（`['asc', 'desc']`），token 大小写不敏感。设置为 `['desc', 'asc']` 可让所有可排序列首次点击即降序（例如日期、金额列，见 [issue #7477](https://github.com/wenzhixin/bootstrap-table/issues/7477)）。启用 `sortReset` 时，会在最后一个方向之后追加一个"未排序"状态。列级 `orderList` 会覆盖此值。未设置时（即默认值），每列回退到自身的 [`order`](https://bootstrap-table.com/zh-cn/docs/api/column-options/#order)，因此大多数已有配置的点击循环保持不变。唯一有意调整的是 `order: 'desc'` 且启用 `sortReset` 的列：之前的循环会在升序与未排序状态之间反复卡住，现在则按降序 → 升序 → 未排序 → 降序 循环。
-
-- **默认值:** `undefined`
-
-- **示例:** [Order List](https://examples.bootstrap-table.com/#options/order-list.html)
 
 ## sortName
 

--- a/tools/check-api.js
+++ b/tools/check-api.js
@@ -8,6 +8,40 @@ const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 
 let errorSum = 0
+
+const docsApiFolder = path.join(__dirname, '..', 'site', 'src', 'pages')
+
+// Supported locales: the docs folder and the localized labels of each
+// attribute. The label keys must match the `attributes` defined per doc type.
+const LOCALES = [
+  {
+    name: 'en',
+    folder: path.join(docsApiFolder, 'docs', 'api'),
+    labels: {
+      Attribute: 'Attribute',
+      Type: 'Type',
+      Detail: 'Detail',
+      Default: 'Default',
+      Example: 'Example',
+      Parameter: 'Parameter',
+      'jQuery Event': 'jQuery Event'
+    }
+  },
+  {
+    name: 'zh-cn',
+    folder: path.join(docsApiFolder, 'zh-cn', 'docs', 'api'),
+    labels: {
+      Attribute: '属性',
+      Type: '类型',
+      Detail: '详情',
+      Default: '默认值',
+      Example: '示例',
+      Parameter: '参数',
+      'jQuery Event': 'jQuery 事件'
+    }
+  }
+]
+
 const exampleFilesFolder = path.join(__dirname, 'bootstrap-table-examples')
 const exampleFilesFound = fs.existsSync(exampleFilesFolder)
 let exampleFiles = []
@@ -25,7 +59,8 @@ if (exampleFilesFound) {
 }
 
 class API {
-  constructor () {
+  constructor (locale) {
+    this.locale = locale
     this.init()
     this.sortOptions()
     this.check()
@@ -36,21 +71,22 @@ class API {
   }
 
   check () {
-    const file = path.join(__dirname, '..', 'site', 'src', 'pages', 'docs', 'api', this.file)
+    const file = path.join(this.locale.folder, this.file)
+    const { labels } = this.locale
     const md = {}
     const content = fs.readFileSync(file).toString()
     const lines = content.split('## ')
     const outLines = lines.slice(0, 1)
     const errors = []
     const exampleRegex = /\[.*\]\(.*\/(.*\.html)\)/m
-    const attributeRegex = /\*\*Attribute:\*\*\s`(.*)data-(.*)`/m
+    const attributeRegex = new RegExp('\\*\\*' + labels.Attribute + ':\\*\\*\\s`(.*)data-(.*)`', 'm')
 
     for (const item of lines.slice(1)) {
       md[item.split('\n')[0]] = item
     }
 
     console.log('-------------------------')
-    console.log(`Checking file: ${file}`)
+    console.log(`Checking file (${this.locale.name}): ${file}`)
     console.log('-------------------------')
 
     const noDefaults = Object.keys(md).filter(it => !this.options.includes(it))
@@ -74,7 +110,8 @@ class API {
               continue
             }
 
-            const tmpDetails = details[i + 1].trim()
+            const tmpDetails = (details[i + 1] || '').trim()
+            const label = labels[name]
             if (name === 'Example' && exampleFilesFound) {
               const matches = exampleRegex.exec(tmpDetails)
               if (!matches) {
@@ -94,8 +131,8 @@ class API {
               }
             }
 
-            if (!tmpDetails || tmpDetails.indexOf(`**${name}:**`) === -1) {
-              errors.push(chalk.red(`[${key}] missing '${name}'`))
+            if (!tmpDetails || tmpDetails.indexOf(`**${label}:**`) === -1) {
+              errors.push(chalk.red(`[${key}] missing '${label}'`))
             }
           }
         } else {
@@ -165,11 +202,13 @@ class Localizations extends API {
   }
 }
 
-new TableOptions()
-new ColumnOptions()
-new Methods()
-new Events()
-new Localizations()
+for (const locale of LOCALES) {
+  new TableOptions(locale)
+  new ColumnOptions(locale)
+  new Methods(locale)
+  new Events(locale)
+  new Localizations(locale)
+}
 
 if (errorSum === 0) {
   console.log('Good job! Anything up to date!')


### PR DESCRIPTION
**🤔Type of Request**
- [ ] **Bug fix**
- [ ] **New feature**
- [x] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
N/A

**📝Changelog**
- [ ] **Core**
- [ ] **Extensions**

Extends the `check-api` docs validation tool (`yarn docs:check` / pre-commit) to also validate the Chinese (`zh-cn`) API docs under `site/src/pages/zh-cn/docs/api/`, so both locales are kept in sync and pass the same checks.

**What changed**
- `tools/check-api.js`: introduced a `LOCALES` config (docs folder + localized attribute labels). The `API` class now runs once per locale. `this.attributes` still uses the English keys, so `ignore` and the `Example` / `Attribute` special cases are unchanged, while label matching uses the localized text (`属性` / `类型` / `详情` / `默认值` / `示例` / `参数` / `jQuery 事件`).
- Fixed a broken example link caught by the new check in `zh-cn/docs/api/methods.mdx`: `update-cell-by-uniqueid.html` → `update-cell-by-unique-id.html` (matching the actual file in the examples repo; the English version was already correct).
- Re-sorted the `orderList` section to its correct alphabetical position in both `en` and `zh-cn` `table-options.mdx` (existing sorting behavior of the tool).

**💡Example(s)?**
Not applicable — internal docs-check tooling change, no UI impact.

**☑️Self Check before Merge**
- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed