### PR TITLE
chore: bump security dependencies (fast-uri, immutable, shell-quote, astro)

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,9 @@
     "form-data": "4.0.6",
     "tmp": "0.2.7",
     "systeminformation": "5.31.17",
-    "fast-uri": "3.1.3",
+    "fast-uri": "3.1.5",
+    "immutable": "5.1.8",
+    "shell-quote": "1.9.0",
     "qs": "6.15.3",
     "js-yaml": "4.3.0"
   }

--- a/site/package.json
+++ b/site/package.json
@@ -11,11 +11,11 @@
     "algolia": "node scripts/algolia-index.js"
   },
   "dependencies": {
-    "@astrojs/mdx": "^5.0.4",
+    "@astrojs/mdx": "^7.0.5",
     "@astrojs/prism": "^4.0.1",
     "@astrojs/sitemap": "^3.7.2",
     "algoliasearch": "^5.52.1",
-    "astro": "^6.3.1",
+    "astro": "^7.1.6",
     "jsdom": "^29.1.1",
     "prismjs": "^1.30.0"
   },

--- a/site/src/pages/docs/api/table-options.mdx
+++ b/site/src/pages/docs/api/table-options.mdx
@@ -908,6 +908,20 @@ $('#table').bootstrapTable({
 
 - **Example:** [Multiple Select Row](https://examples.bootstrap-table.com/#options/multiple-select-row.html)
 
+## orderList
+
+- **Attribute:** `data-order-list`
+
+- **Type:** `String | Array`
+
+- **Detail:**
+
+  Defines the cycle of sort directions used when repeatedly clicking a sortable column header, in order. Accepts a comma-separated string (`'asc,desc'`, `'desc, asc'`) or an array (`['asc', 'desc']`); tokens are case-insensitive. Set `['desc', 'asc']` to make every sortable column descending-first (e.g. date or amount columns, see [issue #7477](https://github.com/wenzhixin/bootstrap-table/issues/7477)). When `sortReset` is enabled, an "unsorted" state is appended after the last direction. A column-level `orderList` overrides this value. When unset (the default), each column falls back to its own [`order`](https://bootstrap-table.com/docs/api/column-options/#order), so most existing configurations keep their current click cycle. The one deliberate change is for columns with `order: 'desc'` combined with `sortReset`: the previous cycle got stuck alternating between ascending and the unsorted state, whereas it now cycles descending → ascending → unsorted → descending.
+
+- **Default:** `undefined`
+
+- **Example:** [Order List](https://examples.bootstrap-table.com/#options/order-list.html)
+
 ## pageList
 
 - **Attribute:** `data-page-list`
@@ -1758,20 +1772,6 @@ $('#table').bootstrapTable({
 - **Default:** `false`
 
 - **Example:** [Sort Empty Last](https://examples.bootstrap-table.com/#options/sort-empty-last.html)
-
-## orderList
-
-- **Attribute:** `data-order-list`
-
-- **Type:** `String | Array`
-
-- **Detail:**
-
-  Defines the cycle of sort directions used when repeatedly clicking a sortable column header, in order. Accepts a comma-separated string (`'asc,desc'`, `'desc, asc'`) or an array (`['asc', 'desc']`); tokens are case-insensitive. Set `['desc', 'asc']` to make every sortable column descending-first (e.g. date or amount columns, see [issue #7477](https://github.com/wenzhixin/bootstrap-table/issues/7477)). When `sortReset` is enabled, an "unsorted" state is appended after the last direction. A column-level `orderList` overrides this value. When unset (the default), each column falls back to its own [`order`](https://bootstrap-table.com/docs/api/column-options/#order), so most existing configurations keep their current click cycle. The one deliberate change is for columns with `order: 'desc'` combined with `sortReset`: the previous cycle got stuck alternating between ascending and the unsorted state, whereas it now cycles descending → ascending → unsorted → descending.
-
-- **Default:** `undefined`
-
-- **Example:** [Order List](https://examples.bootstrap-table.com/#options/order-list.html)
 
 ## sortName
 

--- a/site/src/pages/zh-cn/docs/api/methods.mdx
+++ b/site/src/pages/zh-cn/docs/api/methods.mdx
@@ -712,7 +712,7 @@ toc: true
 
   若要禁用表格重新初始化，可设置 `{reinit: false}`。
 
-- **示例:** [Update Cell By Unique Id](https://examples.bootstrap-table.com/#methods/update-cell-by-uniqueid.html)
+- **示例:** [Update Cell By Unique Id](https://examples.bootstrap-table.com/#methods/update-cell-by-unique-id.html)
 
 ## updateColumnTitle
 

--- a/site/src/pages/zh-cn/docs/api/table-options.mdx
+++ b/site/src/pages/zh-cn/docs/api/table-options.mdx
@@ -904,6 +904,20 @@ $('#table').bootstrapTable({
 
 - **示例:** [Multiple Select Row](https://examples.bootstrap-table.com/#options/multiple-select-row.html)
 
+## orderList
+
+- **属性:** `data-order-list`
+
+- **类型:** `String | Array`
+
+- **详情:**
+
+  定义重复点击可排序列头时排序方向的循环顺序。接受逗号分隔的字符串（`'asc,desc'`、`'desc, asc'`）或数组（`['asc', 'desc']`），token 大小写不敏感。设置为 `['desc', 'asc']` 可让所有可排序列首次点击即降序（例如日期、金额列，见 [issue #7477](https://github.com/wenzhixin/bootstrap-table/issues/7477)）。启用 `sortReset` 时，会在最后一个方向之后追加一个"未排序"状态。列级 `orderList` 会覆盖此值。未设置时（即默认值），每列回退到自身的 [`order`](https://bootstrap-table.com/zh-cn/docs/api/column-options/#order)，因此大多数已有配置的点击循环保持不变。唯一有意调整的是 `order: 'desc'` 且启用 `sortReset` 的列：之前的循环会在升序与未排序状态之间反复卡住，现在则按降序 → 升序 → 未排序 → 降序 循环。
+
+- **默认值:** `undefined`
+
+- **示例:** [Order List](https://examples.bootstrap-table.com/#options/order-list.html)
+
 ## pageList
 
 - **属性:** `data-page-list`
@@ -1750,20 +1764,6 @@ $('#table').bootstrapTable({
 - **默认值:** `false`
 
 - **示例:** [Sort Empty Last](https://examples.bootstrap-table.com/#options/sort-empty-last.html)
-
-## orderList
-
-- **属性:** `data-order-list`
-
-- **类型:** `String | Array`
-
-- **详情:**
-
-  定义重复点击可排序列头时排序方向的循环顺序。接受逗号分隔的字符串（`'asc,desc'`、`'desc, asc'`）或数组（`['asc', 'desc']`），token 大小写不敏感。设置为 `['desc', 'asc']` 可让所有可排序列首次点击即降序（例如日期、金额列，见 [issue #7477](https://github.com/wenzhixin/bootstrap-table/issues/7477)）。启用 `sortReset` 时，会在最后一个方向之后追加一个"未排序"状态。列级 `orderList` 会覆盖此值。未设置时（即默认值），每列回退到自身的 [`order`](https://bootstrap-table.com/zh-cn/docs/api/column-options/#order)，因此大多数已有配置的点击循环保持不变。唯一有意调整的是 `order: 'desc'` 且启用 `sortReset` 的列：之前的循环会在升序与未排序状态之间反复卡住，现在则按降序 → 升序 → 未排序 → 降序 循环。
-
-- **默认值:** `undefined`
-
-- **示例:** [Order List](https://examples.bootstrap-table.com/#options/order-list.html)
 
 ## sortName
 

--- a/tools/check-api.js
+++ b/tools/check-api.js
@@ -8,6 +8,40 @@ const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 
 let errorSum = 0
+
+const docsApiFolder = path.join(__dirname, '..', 'site', 'src', 'pages')
+
+// Supported locales: the docs folder and the localized labels of each
+// attribute. The label keys must match the `attributes` defined per doc type.
+const LOCALES = [
+  {
+    name: 'en',
+    folder: path.join(docsApiFolder, 'docs', 'api'),
+    labels: {
+      Attribute: 'Attribute',
+      Type: 'Type',
+      Detail: 'Detail',
+      Default: 'Default',
+      Example: 'Example',
+      Parameter: 'Parameter',
+      'jQuery Event': 'jQuery Event'
+    }
+  },
+  {
+    name: 'zh-cn',
+    folder: path.join(docsApiFolder, 'zh-cn', 'docs', 'api'),
+    labels: {
+      Attribute: '属性',
+      Type: '类型',
+      Detail: '详情',
+      Default: '默认值',
+      Example: '示例',
+      Parameter: '参数',
+      'jQuery Event': 'jQuery 事件'
+    }
+  }
+]
+
 const exampleFilesFolder = path.join(__dirname, 'bootstrap-table-examples')
 const exampleFilesFound = fs.existsSync(exampleFilesFolder)
 let exampleFiles = []
@@ -25,7 +59,8 @@ if (exampleFilesFound) {
 }
 
 class API {
-  constructor () {
+  constructor (locale) {
+    this.locale = locale
     this.init()
     this.sortOptions()
     this.check()
@@ -36,21 +71,22 @@ class API {
   }
 
   check () {
-    const file = path.join(__dirname, '..', 'site', 'src', 'pages', 'docs', 'api', this.file)
+    const file = path.join(this.locale.folder, this.file)
+    const { labels } = this.locale
     const md = {}
     const content = fs.readFileSync(file).toString()
     const lines = content.split('## ')
     const outLines = lines.slice(0, 1)
     const errors = []
     const exampleRegex = /\[.*\]\(.*\/(.*\.html)\)/m
-    const attributeRegex = /\*\*Attribute:\*\*\s`(.*)data-(.*)`/m
+    const attributeRegex = new RegExp('\\*\\*' + labels.Attribute + ':\\*\\*\\s`(.*)data-(.*)`', 'm')
 
     for (const item of lines.slice(1)) {
       md[item.split('\n')[0]] = item
     }
 
     console.log('-------------------------')
-    console.log(`Checking file: ${file}`)
+    console.log(`Checking file (${this.locale.name}): ${file}`)
     console.log('-------------------------')
 
     const noDefaults = Object.keys(md).filter(it => !this.options.includes(it))
@@ -75,6 +111,7 @@ class API {
             }
 
             const tmpDetails = details[i + 1].trim()
+            const label = labels[name]
             if (name === 'Example' && exampleFilesFound) {
               const matches = exampleRegex.exec(tmpDetails)
               if (!matches) {
@@ -94,8 +131,8 @@ class API {
               }
             }
 
-            if (!tmpDetails || tmpDetails.indexOf(`**${name}:**`) === -1) {
-              errors.push(chalk.red(`[${key}] missing '${name}'`))
+            if (!tmpDetails || tmpDetails.indexOf(`**${label}:**`) === -1) {
+              errors.push(chalk.red(`[${key}] missing '${label}'`))
             }
           }
         } else {
@@ -165,11 +202,13 @@ class Localizations extends API {
   }
 }
 
-new TableOptions()
-new ColumnOptions()
-new Methods()
-new Events()
-new Localizations()
+for (const locale of LOCALES) {
+  new TableOptions(locale)
+  new ColumnOptions(locale)
+  new Methods(locale)
+  new Events(locale)
+  new Localizations(locale)
+}
 
 if (errorSum === 0) {
   console.log('Good job! Anything up to date!')

--- a/yarn.lock
+++ b/yarn.lock
@@ -3579,10 +3579,10 @@ fast-levenshtein@^2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
-fast-uri@3.1.3, fast-uri@^3.0.1:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.3.tgz#f695a40f006aba505631573a0021ddb21194ad11"
-  integrity sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==
+fast-uri@3.1.5, fast-uri@^3.0.1:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.5.tgz#610f37419a030270430cecd68d74e3d4d96725d0"
+  integrity sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==
 
 fastest-levenshtein@^1.0.16:
   version "1.0.16"
@@ -4051,10 +4051,10 @@ ignore@^7.0.5:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-7.0.5.tgz#4cb5f6cd7d4c7ab0365738c7aea888baa6d7efd9"
   integrity sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==
 
-immutable@^5.1.5:
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/immutable/-/immutable-5.1.5.tgz#93ee4db5c2a9ab42a4a783069f3c5d8847d40165"
-  integrity sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==
+immutable@5.1.8, immutable@^5.1.5:
+  version "5.1.8"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-5.1.8.tgz#2e9346e129fe82fc84a7930252b13a93f8100825"
+  integrity sha512-TM5YqrGeTsVIPPpILzeqZ8D2Zc2TvNgSDi88zPF2a4cyqQdWV/wVWBDRDbNzzrLeRWScrFcOX9lW2iX6GOtUDw==
 
 import-fresh@^3.3.0:
   version "3.3.1"
@@ -5290,10 +5290,10 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha1-rhbxZE2HPsrYQ7AwexQzYtTEIXI=
 
-shell-quote@^1.8.4:
-  version "1.8.4"
-  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.8.4.tgz#2edd9a4dcefc96649e2e2cb12f637b1f1d92a190"
-  integrity sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==
+shell-quote@1.9.0, shell-quote@^1.8.4:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.9.0.tgz#e108b1a136586d5964edb3300016d4bedba0fe57"
+  integrity sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==
 
 shelljs@^0.10.0:
   version "0.10.0"


### PR DESCRIPTION
## Description

Bump dependencies to fix security vulnerabilities reported by Dependabot.

### Root `package.json` (`resolutions`)

These lock transitive dependencies to patched versions:

| Package | From | To | Reason |
|---|---|---|---|
| `fast-uri` | 3.1.3 | 3.1.5 | Security patch |
| `immutable` | 5.1.5 | 5.1.8 | Security patch |
| `shell-quote` | 1.8.4 | 1.9.0 | Fix ReDoS vulnerability |

### `site/package.json`

| Package | From | To |
|---|---|---|
| `astro` | ^6.3.1 | ^7.1.6 |
| `@astrojs/mdx` | ^5.0.4 | ^7.0.5 |

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the code style of this project (`yarn lint` passed)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly