### PR TITLE
Revert "Add role presentation if the table has no entries"

### DIFF
--- a/src/modules/body.js
+++ b/src/modules/body.js
@@ -395,14 +395,11 @@ export default {
       }
     }
 
-    this.$el.removeAttr('role')
-
     // show no records
     if (!hasTr) {
       this.$body.html(`<tr class="no-records-found">${Utils.sprintf('<td colspan="%s">%s</td>',
         this.getVisibleFields().length + Utils.getDetailViewIndexOffset(this.options),
         this.options.formatNoMatches())}</tr>`)
-      this.$el.attr('role', 'presentation')
     } else if (!this.options.virtualScroll) {
       this.$body.html(trFragments)
     } else {


### PR DESCRIPTION
This reverts commit 97f3a68. (#7431)

`role="presentation"` is meant for tables that are used purely for visual layout, not for showing tabular data, e.g., an old-school table used for layout where the rows/columns carry no semantic meaning. The ARIA spec is explicit that this role removes the table's implicit row/cell/column header semantics from the accessibility tree entirely.

Bootstrap Table's use case here is different: the table doesn't stop being a data table just because the current query returned zero rows. It still has:

- A meaningful `<thead>` with column headers describing what data would appear
- A single-row status message ("No matching records found") that is itself meaningful content, even if it spans all columns.

**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
<!-- Please prefix each issue number with  "Fix #"  (e.g. Fix #200)  -->

**📝Changelog**

<!-- The type of the change. --->
- [x] **Core**
- [ ] **Extensions**

From the user's perspective, the table will always have its native semantics (implicit role="table").  As a result, screen readers will always read it as a table, including the typical ability for the user to list all the tables on the page and navigate through them.  (In JAWS, pressing the "t" key activates this.)

**💡Example(s)?**

None needed

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
